### PR TITLE
fix(optimizer): Materialize multi-referenced non-deterministic projections

### DIFF
--- a/axiom/optimizer/DerivedTable.cpp
+++ b/axiom/optimizer/DerivedTable.cpp
@@ -2608,6 +2608,145 @@ void DerivedTable::tryConvertOuterJoins(bool allowNondeterministic) {
   }
 }
 
+namespace {
+
+// Invokes 'callback' for each top-level scalar expression of 'dt' that may
+// reference a non-deterministic child output column.
+void forEachExprRoot(
+    const DerivedTable& dt,
+    folly::FunctionRef<void(ExprCP)> callback) {
+  // pushWouldSplitDraw only runs on DT with filters, while non-null write
+  // is a thin wrapper with no conjunct, so is not reachable here.
+  VELOX_CHECK_NULL(dt.write);
+  for (auto* expr : dt.exprs) {
+    callback(expr);
+  }
+  for (auto* conjunct : dt.conjuncts) {
+    callback(conjunct);
+  }
+  for (auto* key : dt.orderKeys) {
+    callback(key);
+  }
+  for (auto* expr : dt.having) {
+    callback(expr);
+  }
+  if (dt.aggregation != nullptr) {
+    for (auto* key : dt.aggregation->groupingKeys()) {
+      callback(key);
+    }
+    for (const auto* aggregate : dt.aggregation->aggregates()) {
+      for (auto* arg : aggregate->args()) {
+        callback(arg);
+      }
+      if (aggregate->condition() != nullptr) {
+        callback(aggregate->condition());
+      }
+      for (auto* key : aggregate->orderKeys()) {
+        callback(key);
+      }
+    }
+  }
+  if (dt.windowPlan != nullptr) {
+    for (const auto* function : dt.windowPlan->functions()) {
+      for (auto* arg : function->args()) {
+        callback(arg);
+      }
+      for (auto* key : function->partitionKeys()) {
+        callback(key);
+      }
+      for (auto* key : function->orderKeys()) {
+        callback(key);
+      }
+      if (function->frame().startValue != nullptr) {
+        callback(function->frame().startValue);
+      }
+      if (function->frame().endValue != nullptr) {
+        callback(function->frame().endValue);
+      }
+    }
+  }
+  for (const auto* join : dt.joins) {
+    for (auto* key : join->leftKeys()) {
+      callback(key);
+    }
+    for (auto* key : join->rightKeys()) {
+      callback(key);
+    }
+    for (auto* expr : join->filter()) {
+      callback(expr);
+    }
+  }
+}
+
+// Tracks how the single materialized column 'target' is consumed.
+struct MaterializedColumnUse {
+  ColumnCP target;
+  int32_t numReads{0};
+  bool underLambda{false};
+
+  bool splitsSingleDraw() const {
+    return numReads > 1 || underLambda;
+  }
+};
+
+void accumulateColumnUse(
+    ExprCP expr,
+    MaterializedColumnUse& use,
+    bool insideLambda) {
+  switch (expr->type()) {
+    case PlanType::kColumnExpr: {
+      const auto* column = expr->as<Column>();
+      // A subfield column (Column::topColumn) is still a single read of the
+      // whole materialized value, so it counts against 'target'.
+      if (column == use.target || column->topColumn() == use.target) {
+        ++use.numReads;
+        use.underLambda |= insideLambda;
+      }
+      return;
+    }
+    case PlanType::kLiteralExpr:
+      return;
+    case PlanType::kFieldExpr:
+      accumulateColumnUse(expr->as<Field>()->base(), use, insideLambda);
+      return;
+    case PlanType::kLambdaExpr:
+      accumulateColumnUse(
+          expr->as<Lambda>()->body(), use, /*insideLambda=*/true);
+      return;
+    default:
+      // Calls and special forms, including array/map subscripts (which are
+      // calls).
+      for (auto* child : expr->children()) {
+        accumulateColumnUse(child->as<Expr>(), use, insideLambda);
+      }
+      return;
+  }
+}
+
+// Returns true if pushing a filter that reads 'target' (a non-deterministic
+// child output column) into the child would split its single shared draw,
+// because 'dt' reads it more than once or reads it inside a lambda body.
+bool pushWouldSplitDraw(const DerivedTable& dt, ColumnCP target) {
+  MaterializedColumnUse use{.target = target};
+  forEachExprRoot(dt, [&](ExprCP root) {
+    accumulateColumnUse(root, use, /*insideLambda=*/false);
+  });
+  return use.splitsSingleDraw();
+}
+
+// Returns true if 'col' is an output column of 'dt' whose defining projection
+// expression is non-deterministic.
+bool isNonDeterministicOutputColumn(const DerivedTable& dt, PlanObjectCP col) {
+  for (size_t i = 0; i < dt.columns.size() && i < dt.exprs.size(); ++i) {
+    if (dt.columns[i] == col && dt.exprs[i]->containsNonDeterministic()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+} // namespace
+
 bool DerivedTable::tryPushdownConjunct(ExprCP conjunct, PlanObjectP table) {
   if (table->is(PlanType::kValuesTableNode)) {
     return false; // ValuesTable does not have filter push-down.
@@ -2622,7 +2761,20 @@ bool DerivedTable::tryPushdownConjunct(ExprCP conjunct, PlanObjectP table) {
   }
 
   if (table->is(PlanType::kDerivedTableNode)) {
-    auto innerDt = table->as<DerivedTable>();
+    auto* innerDt = table->as<DerivedTable>();
+    // Do not push a conjunct that reads a non-deterministic output column of
+    // the child when re-inlining it into the child would split the one shared
+    // draw. A single row-scope use is safe and still pushes toward the scan.
+    bool blocked = false;
+    conjunct->columns().forEach([&](PlanObjectCP col) {
+      if (isNonDeterministicOutputColumn(*innerDt, col) &&
+          pushWouldSplitDraw(*this, col->as<Column>())) {
+        blocked = true;
+      }
+    });
+    if (blocked) {
+      return false;
+    }
     if (!innerDt->addFilter(conjunct)) {
       return false;
     }

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1563,9 +1563,7 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
     if (allUsed || usedArgs.contains(i)) {
       args[i] = translateExpr(input);
       cardinality = maxOf(cardinality, args[i]->value().cardinality);
-      if (args[i]->is(PlanType::kCallExpr)) {
-        funcs = funcs | args[i]->as<Call>()->functions();
-      }
+      funcs = funcs | args[i]->functions();
     } else {
       // Make a null of the type for the unused arg to keep the tree valid.
       const auto& inputType = input->type();
@@ -1604,27 +1602,12 @@ std::optional<ExprCP> ToGraph::translateSubfieldFunction(
   return callExpr;
 }
 
-void ToGraph::rejectIfReusedNonDeterministic(std::string_view name, ExprCP expr)
-    const {
-  if (expr == nullptr || !expr->containsNonDeterministic()) {
-    return;
-  }
-  if (!nonDeterministicResolutions_.insert(NameExprKey{toName(name), expr})
-           .second) {
-    VELOX_USER_FAIL(
-        "Non-deterministic expression reused across multiple references is not "
-        "supported yet: {}",
-        name);
-  }
-}
-
 ExprCP ToGraph::translateColumn(std::string_view name) const {
   if (auto it = lambdaSignature_.find(name); it != lambdaSignature_.end()) {
     return it->second;
   }
 
   if (auto it = renames_.find(name); it != renames_.end()) {
-    rejectIfReusedNonDeterministic(name, it->second);
     return it->second;
   }
 
@@ -2300,6 +2283,22 @@ void ToGraph::translateJoin(
       if (rightTable->is(PlanType::kDerivedTableNode)) {
         auto* rightDt =
             const_cast<DerivedTable*>(rightTable->as<DerivedTable>());
+        // Do not push a conjunct that reads a non-deterministic output column
+        // of the right side. addFilter re-inlines via importExpr, so if
+        // importing makes the conjunct non-deterministic, pushing would draw
+        // the value a second time below the materialization. Leaving it here
+        // routes it to the JoinEdge filter, which pre-filters the right side
+        // against the materialized column (one draw) with the same LEFT-join
+        // semantics.
+        //
+        // Conservatively prevent any non-deterministic conjunct from pushing
+        // down because a reference count of non-deterministic columns is not
+        // knowable here: the enclosing projections and filters that may also
+        // read the column are attached only after the join is built.
+        if (rightDt->importExpr(conjunct)->containsNonDeterministic()) {
+          ++it;
+          continue;
+        }
         if (!rightDt->addFilter(conjunct)) {
           ++it;
           continue;
@@ -4635,6 +4634,12 @@ bool hasNondeterministic(const lp::ExprPtr& expr) {
       return true;
     }
   }
+  // A non-deterministic call inside a lambda body (e.g. the rand() in
+  // transform(arr, x -> x + rand())) is not reached via inputs(), so descend
+  // into the body explicitly.
+  if (expr->isLambda()) {
+    return hasNondeterministic(expr->as<lp::LambdaExpr>()->body());
+  }
   return std::ranges::any_of(expr->inputs(), hasNondeterministic);
 }
 
@@ -4943,6 +4948,31 @@ void ToGraph::makeProjectQueryGraph(
   if (excludeOuterJoins && !currentDt_->tables.empty() &&
       std::ranges::any_of(project.expressions(), optimizer::hasSubquery)) {
     wrapInDt(project, /*orderObservedAbove=*/false);
+    return;
+  }
+
+  // A non-deterministic projection must not be inlined into its consumers: a
+  // reused value would be re-drawn per reference, and under join fan-out it
+  // would evaluate at the wrong scope. Force a DT boundary (as for a
+  // non-deterministic filter) so the value is materialized once as the child's
+  // output column.
+  if (std::ranges::any_of(project.expressions(), hasNondeterministic)) {
+    auto* outerDt = std::exchange(currentDt_, newDt());
+    makeQueryGraph(
+        *project.onlyInput(),
+        kAllAllowedInDt,
+        hasWindow ? false : orderObservedAbove,
+        excludeOuterJoins);
+    // Mirror the non-deterministic-free path's window handling: a window must
+    // compute over the full (already limited) input, and a window that reads
+    // another window's output needs its own DT. Skipping this finalize would
+    // hoist a LIMIT above the window or merge dependent windows into one plan.
+    if (hasWindow &&
+        (currentDt_->hasLimit() || windowReferencesWindow(project))) {
+      finalizeDt(*project.onlyInput());
+    }
+    addProjection(project);
+    finalizeDt(project, outerDt);
     return;
   }
 

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -374,14 +374,6 @@ class ToGraph {
   // expression.
   ExprCP translateColumn(std::string_view name) const;
 
-  // Fails the query if 'name' resolves to a non-deterministic inline binding
-  // 'expr' that has already been resolved under the same binding. That is a
-  // single non-deterministic source inlined at more than one reference site,
-  // which would draw the value independently per reference instead of once.
-  // Keyed on (name, expr) so distinct textual draws (different expr) and
-  // rename chains (different name) are not flagged.
-  void rejectIfReusedNonDeterministic(std::string_view name, ExprCP expr) const;
-
   //  Applies translateExpr to a 'source'.
   ExprVector translateExprs(const std::vector<logical_plan::ExprPtr>& source);
 
@@ -940,32 +932,6 @@ class ToGraph {
   // Values may be null when a subfield path is not materialized (see
   // intersectWithSkyline in makeGettersOverSkyline).
   folly::F14FastMap<std::string, ExprCP> renames_;
-
-  // Identifies one resolution of a column name to a specific resolved Expr.
-  // Seeing the same (name, expr) twice means a single non-deterministic source
-  // is inlined at more than one reference site. The name is part of the key
-  // because a rename chain (SELECT y AS z FROM (SELECT x AS y FROM ...))
-  // resolves the same Expr pointer under a different name at each level — that
-  // is propagation, not reuse. Genuine reuse (SELECT u AS a, u AS b) resolves
-  // the same pointer under the same name twice.
-  struct NameExprKey {
-    Name name;
-    ExprCP expr;
-    bool operator==(const NameExprKey& other) const = default;
-  };
-
-  struct NameExprKeyHasher {
-    size_t operator()(const NameExprKey& key) const {
-      return velox::bits::hashMix(
-          folly::hasher<Name>()(key.name), folly::hasher<ExprCP>()(key.expr));
-    }
-  };
-
-  // The (name, binding) pairs resolved via 'renames_' to a non-deterministic
-  // inline binding. A repeat of the same pair means one non-deterministic
-  // source is inlined at multiple reference sites.
-  mutable folly::F14FastSet<NameExprKey, NameExprKeyHasher>
-      nonDeterministicResolutions_;
 
   // Symbols from the 'outer' query. Used when processing correlated subqueries.
   const folly::F14FastMap<std::string, ExprCP>* correlations_{nullptr};

--- a/axiom/optimizer/tests/NonDeterministicFlagTest.cpp
+++ b/axiom/optimizer/tests/NonDeterministicFlagTest.cpp
@@ -41,9 +41,14 @@ class NonDeterministicFlagTest : public test::QueryTestBase {
     bool result = true;
     auto plan = parseSelect(sql, kTestConnectorId);
     verifyOptimization(*plan, [&](Optimization& opt) {
-      const auto& dt = *opt.rootDt();
-      ASSERT_EQ(dt.exprs.size(), 1);
-      result = !dt.exprs[0]->containsNonDeterministic();
+      const auto* dt = opt.rootDt();
+      // A non-deterministic projection may be materialized into a child DT.
+      if (dt->exprs[0]->is(PlanType::kColumnExpr) && dt->tables.size() == 1 &&
+          dt->tables[0]->is(PlanType::kDerivedTableNode)) {
+        dt = dt->tables[0]->as<DerivedTable>();
+      }
+      ASSERT_EQ(dt->exprs.size(), 1);
+      result = !dt->exprs[0]->containsNonDeterministic();
     });
     return result;
   }
@@ -79,6 +84,20 @@ TEST_F(NonDeterministicFlagTest, lambda) {
 
   // Deterministic lambda body reports determinism.
   EXPECT_TRUE(isDeterministic("transform(array[a], e -> e + b)"));
+
+  // Accessing a subfield of the result routes through the subfield path. The
+  // lambda's rand() must still taint the call.
+  EXPECT_FALSE(isDeterministic(
+      "transform(array[a], e -> e + cast(rand() * 10 AS bigint))[1]"));
+
+  // A rand() in the INNER lambda of nested higher-order calls propagates out
+  // through both lambdas.
+  EXPECT_FALSE(isDeterministic(
+      "transform(array[a], x -> transform(array[x], y -> y + cast(rand() * 10 AS bigint)))"));
+
+  // Nested lambdas with a deterministic inner body report determinism.
+  EXPECT_TRUE(isDeterministic(
+      "transform(array[a], x -> transform(array[x], y -> y + b))"));
 }
 
 } // namespace

--- a/axiom/optimizer/tests/NonDeterministicTest.cpp
+++ b/axiom/optimizer/tests/NonDeterministicTest.cpp
@@ -1,0 +1,1020 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class NonDeterministicTest : public test::QueryTestBase {
+ protected:
+  // A fixed-size source with the shared schema. The row count must stay above
+  // the limits used by the limit/top-N tests so those boundaries are not
+  // optimized away.
+  RowVectorPtr makeSource() {
+    constexpr int32_t kNumRows = 64;
+    return makeRowVector(
+        {"k", "v", "s"},
+        {makeFlatVector<int64_t>(std::vector<int64_t>(kNumRows)),
+         makeFlatVector<int64_t>(std::vector<int64_t>(kNumRows)),
+         makeFlatVector<std::string>(std::vector<std::string>(kNumRows))});
+  }
+
+  // Registers a table with the shared schema used by every scan-based test.
+  void addTable(const std::string& name) {
+    testConnector_->addTable(
+        name, ROW({"k", "v", "s"}, {BIGINT(), BIGINT(), VARCHAR()}));
+  }
+};
+
+// A non-deterministic projection referenced more than once is computed once and
+// reused: all references see the same value.
+TEST_F(NonDeterministicTest, reusedProjectionComputedOnce) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map({"concat(cast(uuid() as varchar), '-suffix') as y"})
+          .map({"y as a", "y as b", "upper(y) as c"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchValues()
+          .project({"concat(cast(uuid() as varchar), '-suffix') as y"})
+          .project({"y as a", "y as b", "upper(y) as c"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value compared against itself within a single expression
+// is one draw: (r = r) is always true.
+TEST_F(NonDeterministicTest, ndSelfComparisonInProjection) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"rand() as r"})
+                         .map({"(r = r) as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchValues().project({"rand() as r"}).project({"r = r as b"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Multiple references to a non-deterministic value inside a single filter
+// predicate are one draw: r <> r is never true, so no rows pass.
+TEST_F(NonDeterministicTest, ndSelfComparisonInFilter) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"rand() as r"})
+                         .filter("r <> r")
+                         .map({"1 as one"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"rand() as r"})
+                     .filter("r <> r")
+                     .project({"1 as one"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Subfield form of the single-expression self-comparison: seq[1] = seq[1] reads
+// the same element of one materialized array, so it is always true.
+TEST_F(NonDeterministicTest, subfieldSelfComparisonInProjection) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"shuffle(sequence(1, k + 5)) as seq"})
+                         .map({"(seq[1] = seq[1]) as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"shuffle(sequence(1, k + 5)) as seq"})
+                     .project({"seq[1] = seq[1] as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Two distinct occurrences of a non-deterministic function are independent and
+// must each be evaluated.
+TEST_F(NonDeterministicTest, distinctOccurrencesStayDistinct) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"uuid() as a", "uuid() as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues().project({"uuid() as a", "uuid() as b"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A deterministic projection referenced more than once is still inlined, not
+// materialized into a separate projection.
+TEST_F(NonDeterministicTest, deterministicProjectionNotMaterialized) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"k + 1 as x"})
+                         .map({"x as p", "x * 2 as q"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchValues().project({"k + 1 as p", "(k + 1) * 2 as q"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value accessed through a subfield more than once is
+// computed once and reused.
+TEST_F(NonDeterministicTest, reusedSubfieldComputedOnce) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"shuffle(sequence(1, 100)) as seq"})
+                         .map({"seq[1] as a1", "seq[1] as a2"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(shuffle("any"()) as g)"})
+                     .project({"g[1] as a1", "g[1] as a2"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A field defined directly as a subfield over a non-deterministic function,
+// then subfielded again and reused. The outer subfield must be computed once
+// over the shared base.
+TEST_F(NonDeterministicTest, nestedSubfieldOverFunction) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map({"shuffle(array[array[1,2,3], array[4,5,6]])[1] as field1"})
+          .map({"field1[1] as a", "field1[1] as b"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(shuffle("any"())[1] as field1)"})
+                     .project({"field1[1] as a", "field1[1] as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value reused inside a UNION ALL leg is computed once per
+// leg.
+TEST_F(NonDeterministicTest, reusedAcrossUnionLeg) {
+  lp::PlanBuilder::Context ctx;
+  auto leftLeg = lp::PlanBuilder(ctx)
+                     .values({makeSource()})
+                     .map({"uuid() as u"})
+                     .map({"u as a", "u as b"});
+  auto rightLeg = lp::PlanBuilder(ctx)
+                      .values({makeSource()})
+                      .map({"uuid() as u"})
+                      .map({"u as a", "u as b"});
+
+  auto logicalPlan = leftLeg.unionAll(rightLeg).build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto leg = [this]() {
+    return matchValues()
+        .project({"uuid() as u"})
+        .project({"u as a", "u as b"})
+        .build();
+  };
+  auto matcher = matchValues()
+                     .project({"uuid() as u"})
+                     .project({"u as a", "u as b"})
+                     .localPartition(leg())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value referenced more than once inside a single filter
+// predicate is computed once.
+TEST_F(NonDeterministicTest, reusedInFilterComputedOnce) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"cast(uuid() as varchar) as u", "k"})
+                         .filter("u >= '0' and u <= 'zzzzz'")
+                         .map({"k"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"cast(uuid() as varchar) as u", "k"})
+                     .filter("u >= '0' and u <= 'zzzzz'")
+                     .project({"k"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value referenced by both a filter and a downstream
+// projection is computed once and shared across both.
+TEST_F(NonDeterministicTest, reusedAcrossFilterAndProjection) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"cast(uuid() as varchar) as u"})
+                         .filter("u <= 'zzzzz'")
+                         .map({"u as a", "u as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"cast(uuid() as varchar) as u"})
+                     .filter("u <= 'zzzzz'")
+                     .project({"u as a", "u as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A deterministic filter on a base column pushes below the non-deterministic
+// materialization; the reused source is still computed once.
+TEST_F(NonDeterministicTest, deterministicFilterPushedUnderNDMaterialization) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"k + 5 as k"})
+                         .map({"shuffle(sequence(1, k)) as seq", "k"})
+                         .filter("k > 0")
+                         .map({"seq[1] as a", "seq[1] as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .filter("k + 5 > 0")
+                     .project({"shuffle(sequence(1, k + 5)) as seq"})
+                     .project({"seq[1] as a", "seq[1] as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic array reused inside a UNION ALL leg via subfield is
+// computed once per leg.
+TEST_F(NonDeterministicTest, reusedSubfieldInUnionLeg) {
+  lp::PlanBuilder::Context ctx;
+  auto leftLeg = lp::PlanBuilder(ctx)
+                     .values({makeSource()})
+                     .map({"shuffle(sequence(1, k + 10)) as seq"})
+                     .map({"seq[1] as a", "seq[1] as b"});
+  auto rightLeg = lp::PlanBuilder(ctx)
+                      .values({makeSource()})
+                      .map({"shuffle(sequence(1, k + 10)) as seq"})
+                      .map({"seq[1] as a", "seq[1] as b"});
+  auto logicalPlan = leftLeg.unionAll(rightLeg).build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto leg = [this]() {
+    return matchValues()
+        .project({R"(shuffle("any"()) as g)"})
+        .project({"g[1] as a", "g[1] as b"})
+        .build();
+  };
+  auto matcher = matchValues()
+                     .project({R"(shuffle("any"()) as g)"})
+                     .project({"g[1] as a", "g[1] as b"})
+                     .localPartition(leg())
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value computed in the same projection as an aggregate
+// output sits at post-aggregation scope.
+TEST_F(NonDeterministicTest, reusedNonDeterministicWithAggregateOutput) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"k % 3 as g", "k"})
+                         .aggregate({"g"}, {"max(k) as mx"})
+                         .map({"uuid() as u", "mx"})
+                         .map({"u as a", "u as b", "mx"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"k % 3 as g", "k"})
+                     .singleAggregation({"g"}, {"max(k) as mx"})
+                     .project({"uuid() as u", "mx"})
+                     .project({"u as a", "u as b", "mx"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A pre-aggregation non-deterministic source reused across several aggregate
+// arguments is computed once.
+TEST_F(NonDeterministicTest, reusedNonDeterministicInAggregateArgs) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map({"rand() as r"})
+          .aggregate({}, {"sum(r) as seq", "count(r) as c", "max(r) as mx"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"rand() as r"})
+                     .singleAggregation(
+                         {}, {"sum(r) as seq", "count(r) as c", "max(r) as mx"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A pre-window non-deterministic source reused across two window functions is
+// computed once.
+TEST_F(NonDeterministicTest, reusedNonDeterministicInWindowArgs) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k"})
+                         .map({"rand() as r", "k"})
+                         .map(
+                             {"max(r) over (partition by k order by k) as mx",
+                              "min(r) over (partition by k order by k) as mn"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .project({"rand() as r", "k"})
+                     .window(
+                         {"max(r) OVER (PARTITION BY k) as mx",
+                          "min(r) OVER (PARTITION BY k) as mn"})
+                     .project({"mx", "mn"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value used as a grouping key and reused in
+// post-aggregation projection is materialized once.
+TEST_F(NonDeterministicTest, reusedNonDeterministicAsGroupingKey) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"uuid() as u"})
+                         .aggregate({"u"}, {"count(1) as c"})
+                         .map({"u as a", "u as b", "c"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"uuid() as u"})
+                     .singleAggregation({"u"}, {"count(1) as c"})
+                     .project({"u as a", "u as b", "c"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A reused non-deterministic value used as an equi-join key and in post-join
+// projection must be materialized once on the join table.
+TEST_F(NonDeterministicTest, reusedNonDeterministicAsJoinKey) {
+  addTable("t_left");
+  addTable("t_right");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t_left", {"k"})
+                         .map({"cast(uuid() as varchar) as u"})
+                         .join(
+                             lp::PlanBuilder(ctx).tableScan("t_right", {"s"}),
+                             "u = s",
+                             lp::JoinType::kInner)
+                         .map({"u as a", "u as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto buildSide = matchScan("t_right").build();
+  auto matcher = matchScan("t_left")
+                     .project({"cast(uuid() as varchar) as u"})
+                     .hashJoinInner(buildSide, {.keys = {{"u = s"}}})
+                     .project({"u as a", "u as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value read only by an equi-join key and a post-join
+// filter must stay materialized.
+TEST_F(NonDeterministicTest, reusedInJoinKeyAndFilter) {
+  addTable("t_left");
+  addTable("t_right");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t_left", {"k"})
+                         .map({"cast(uuid() as varchar) as u"})
+                         .join(
+                             lp::PlanBuilder(ctx).tableScan("t_right", {"s"}),
+                             "u = s",
+                             lp::JoinType::kInner)
+                         .filter("u > '0'")
+                         .map({"s"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto buildSide = matchScan("t_right").build();
+  auto matcher = matchScan("t_left")
+                     .project({"cast(uuid() as varchar) as u"})
+                     .filter("u > '0'")
+                     .hashJoinInner(buildSide, {.keys = {{"u = s"}}})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value on the null-supplying side of a LEFT JOIN must stay
+// materialized.
+TEST_F(NonDeterministicTest, reusedInLeftJoinFilter) {
+  addTable("t_left");
+  addTable("t_right");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t_left", {"k"})
+                         .join(
+                             lp::PlanBuilder(ctx)
+                                 .tableScan("t_right", {"v"})
+                                 .map({"cast(uuid() as varchar) as u", "v"}),
+                             "k = v and u > '0'",
+                             lp::JoinType::kLeft)
+                         .map({"k as lk", "u as uu"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto buildSide = matchScan("t_right")
+                       .project({"cast(uuid() as varchar) as u", "v"})
+                       .build();
+  auto matcher = matchScan("t_left")
+                     .hashJoin(
+                         buildSide,
+                         core::JoinType::kLeft,
+                         {.keys = {{"k = v"}}, .filter = "u > '0'"})
+                     .project({"k as lk", "u as uu"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A reused non-deterministic value in a filter, on a query that also carries a
+// window partitioned/ordered by base columns: the value is materialized once
+// below the filter, and the window still partitions by the base column.
+TEST_F(NonDeterministicTest, reusedInFilterWithBaseColumnPassThrough) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan =
+      lp::PlanBuilder(ctx)
+          .tableScan("t", {"k"})
+          .map({"cast(uuid() as varchar) as u", "k"})
+          .filter("u >= '0' and u <= 'zzzzz'")
+          .map(
+              {"row_number() over (partition by k order by k) as rn",
+               "u as uu"})
+          .build();
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .project({"cast(uuid() as varchar) as u", "k"})
+                     .filter("u >= '0' and u <= 'zzzzz'")
+                     .rowNumber({"k"})
+                     .project({R"("any"())", "u as uu"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value computed in the same projection as a window
+// function output. The value is materialized once in the projection above the
+// window (not pulled below it).
+TEST_F(NonDeterministicTest, reusedNonDeterministicWithWindowOutput) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan =
+      lp::PlanBuilder(ctx)
+          .tableScan("t", {"k"})
+          .map(
+              {"row_number() over (partition by k order by k) as m",
+               "uuid() as u"})
+          .map({"u as a", "u as b", "m"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // RowNumber (the window) sits directly over the scan; the uuid is computed
+  // once in the projection above it, then the outer projection reuses that one
+  // column as both a and b.
+  auto matcher = matchScan("t")
+                     .rowNumber({"k"})
+                     .project({R"("any"())", "uuid()"})
+                     .aliases({"m", "u"})
+                     .project({"u as a", "u as b", "m"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value read by a window function argument and a filter
+// must stay materialized.
+TEST_F(NonDeterministicTest, reusedInWindowArgAndFilter) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k", "v"})
+                         .map({"cast(uuid() as varchar) as u", "k", "v"})
+                         .filter("u > '0'")
+                         .map({"max(u) over (partition by k order by v) as m"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .project({"cast(uuid() as varchar) as u", "k", "v"})
+                     .filter("u > '0'")
+                     .window({"max(u) OVER (PARTITION BY k ORDER BY v) as m"})
+                     .project({"m"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A filter on a reused non-deterministic value over a table scan is not pushed
+// down.
+TEST_F(NonDeterministicTest, reusedAcrossPushedDownFilterTableScan) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k"})
+                         .map({"shuffle(sequence(1, k + 10)) as seq"})
+                         .map({"seq[1] as x", "seq[1] as y"})
+                         .filter("x > -1")
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .project({"shuffle(sequence(1, k + 10)) as g"})
+                     .filter("g[1] > -1")
+                     .project({"g[1] as x", "g[1] as y"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic filter whose value is NOT reused is pushed to table scan.
+TEST_F(NonDeterministicTest, nonReusedFilterStillPushesToScan) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k"})
+                         .map({"rand() as r", "k"})
+                         .filter("r > -1.0")
+                         .map({"k"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t").filter("rand() > -1.0").build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic value read through a SINGLE subfield is demand 1, so the
+// filter is pushed to the scan rather than kept materialized.
+TEST_F(NonDeterministicTest, singleUseSubfieldFilterPushesToScan) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k"})
+                         .map({"shuffle(sequence(1, k + 10)) as seq", "k"})
+                         .filter("seq[1] > -1")
+                         .map({"k"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchScan("t").filter("shuffle(sequence(1, k + 10))[1] > -1").build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A per-row non-deterministic value referenced from inside a lambda body must
+// stay materialized.
+TEST_F(NonDeterministicTest, lambdaCapturedNonDeterministicStaysMaterialized) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map({"k", "rand() as r"})
+          .filter(
+              "cardinality(array_distinct(transform(sequence(1, k + 2), x -> r))) = 1")
+          .map({"k"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchValues()
+          .project({"k", "rand() as r"})
+          .filter(
+              "cardinality(array_distinct(transform(sequence(1, k + 2), x -> r))) = 1")
+          .project({"k"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A reused non-deterministic filter over a pure UNION ALL (the other
+// allowNondeterministic branch). The filter is not pushed into the legs.
+TEST_F(NonDeterministicTest, reusedFilterOverUnionAll) {
+  addTable("t_left");
+  addTable("t_right");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+
+  auto left = lp::PlanBuilder(ctx).tableScan("t_left", {"k"});
+  auto right = lp::PlanBuilder(ctx).tableScan("t_right", {"k"});
+  auto logicalPlan = left.unionAll(right)
+                         .map({"shuffle(sequence(1, k + 10)) as arr"})
+                         .map({"arr[1] as p", "arr[1] as q"})
+                         .filter("p > -1")
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // Union of the two scans, then the generator materialized once (g) above the
+  // union, referenced by the filter and both outputs.
+  auto rightLeg = matchScan("t_right").project({"k_0 as k"}).build();
+  auto matcher = matchScan("t_left")
+                     .localPartition(rightLeg)
+                     .project({"shuffle(sequence(1, k + 10)) as g"})
+                     .filter("g[1] > -1")
+                     .project({"g[1] as p", "g[1] as q"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A field defined as a subfield over another field over a function, reused: the
+// whole chain is materialized once and shared.
+TEST_F(NonDeterministicTest, chainedFieldOfFieldOverFunction) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map({"shuffle(array[array[1,2,3], array[4,5,6]]) as f0"})
+          .map({"f0[1] as field1"})
+          .map({"field1[2] as field2"})
+          .map({"field2 as a", "field2 as b"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(shuffle("any"()) as g)"})
+                     .project({"g[1][2] as a", "g[1][2] as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A function-defined field subfielded with multiple steps, reused: the full
+// subscript chain is computed once and shared.
+TEST_F(NonDeterministicTest, multiStepNestedSubfield) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map(
+              {"shuffle(array[array[array[1,2],array[3,4]], array[array[5,6],array[7,8]]]) as f0"})
+          .map({"f0[1][1] as field1"})
+          .map({"field1[1] as a", "field1[1] as b"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(shuffle("any"()) as g)"})
+                     .project({"g[1][1][1] as a", "g[1][1][1] as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A reused non-deterministic value referenced from an ORDER BY and the
+// projection is computed once below the OrderBy.
+TEST_F(NonDeterministicTest, reusedInOrderBy) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k"})
+                         .map({"shuffle(sequence(1, k + 10))[1] as u"})
+                         .orderBy({"u"})
+                         .map({"u as a", "u as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .project({"shuffle(sequence(1, k + 10))[1] as u"})
+                     .orderBy({"u ASC NULLS LAST"})
+                     .project({"u as a", "u as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A reused non-deterministic value with an ORDER BY on base column with no
+// LIMIT. The query must pass through the order by key column.
+TEST_F(NonDeterministicTest, reusedNonDeterministicWithOrderByNoLimit) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .tableScan("t", {"k"})
+                         .map({"uuid() as u", "k"})
+                         .orderBy({"k"})
+                         .map({"u as a", "u as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchScan("t")
+                     .project({"uuid() as u", "k"})
+                     .orderBy({"k ASC NULLS LAST"})
+                     .project({"u as a", "u as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic projection over a subquery that carries a LIMIT. The
+// LIMIT is a cardinality barrier at the child's layer.
+TEST_F(NonDeterministicTest, ndOverLimitKeepsBoundary) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .limit(3)
+                         .map({"uuid() as u"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues().limit().project({"uuid() as u"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic projection over a subquery that carries ORDER BY ...
+// LIMIT (top-N). The non-deterministic materialization must be above the top-N.
+TEST_F(NonDeterministicTest, ndOverOrderByLimitKeepsBoundary) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .orderBy({"k"})
+                         .limit(3)
+                         .map({"uuid() as u", "k"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // The order-by + limit collapses to a TopN barrier below the
+  // non-deterministic projection.
+  auto matcher = matchValues().topN(3).project({"uuid() as u", "k"}).build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// An inner non-deterministic value (u) reused both standalone (a) and nested
+// inside another reused expression (v). The
+// inner generator must be materialized one layer deeper so v references the
+// single u column rather than recomputing it.
+TEST_F(NonDeterministicTest, nestedCrossPathReuse) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"cast(uuid() as varchar) as u"})
+                         .map({"u as uu", "concat(u, 'x') as v"})
+                         .map({"uu as a", "v as b", "v as c"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchValues()
+          .project({"cast(uuid() as varchar) as u"})
+          .project({"u as a", "concat(u, 'x') as b", "concat(u, 'x') as c"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A non-deterministic source read via a subfield (m) feeds the argument of a
+// second non-deterministic source (arr); both are reused. The two must be
+// stacked -- the inner shuffle deepest, arr above it referencing m -- so each
+// shuffle is evaluated once.
+TEST_F(NonDeterministicTest, sourceInSource) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"shuffle(sequence(1, 10))[1] as m"})
+                         .map({"m as mm", "shuffle(sequence(1, m + 1)) as arr"})
+                         .map({"mm as a", "arr[1] as b", "arr[1] as c"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(shuffle("any"())[1] as m)"})
+                     .project({"m", "shuffle(sequence(1, m + 1)) as arr"})
+                     .project({"m as a", "arr[1] as b", "arr[1] as c"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Non-determinism inside a lambda body, reused. The projection is materialized
+// once and shared.
+TEST_F(NonDeterministicTest, reusedLambdaWithNonDeterministic) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"transform(sequence(1, 3), x -> rand()) as a"})
+                         .map({"a as p", "a as q"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(transform("any"(), x -> rand()) as a)"})
+                     .project({"a as p", "a as q"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A single-use of non-deterministic lambda needs no shared materialization.
+TEST_F(NonDeterministicTest, singleUseNonDeterministicLambda) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .map({"transform(sequence(1, 3), x -> rand()) as a"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({R"(transform("any"(), x -> rand()) as a)"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Two parallel non-deterministic projections. Each is materialized once
+// independently.
+TEST_F(NonDeterministicTest, lambdaTrappedAndPerRowSource) {
+  auto logicalPlan =
+      lp::PlanBuilder()
+          .values({makeSource()})
+          .map({"uuid() as u", "transform(sequence(1, 3), x -> rand()) as a"})
+          .map({"u as u1", "u as u2", "a as a1", "a as a2"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher =
+      matchValues()
+          .project({"uuid() as u", R"(transform("any"(), x -> rand()) as a)"})
+          .project({"u as u1", "u as u2", "a as a1", "a as a2"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A UNION ALL where a filter on a constant-valued column eliminates one leg.
+// The surviving leg has a reused non-deterministic value materialized once at a
+// kept boundary.
+TEST_F(NonDeterministicTest, unionCollapsePreservesSingleDraw) {
+  lp::PlanBuilder::Context ctx;
+  auto leftLeg = lp::PlanBuilder(ctx)
+                     .values({makeSource()})
+                     .map({"cast(uuid() as varchar) as u", "1 as tag"})
+                     .map({"u as a", "u as b", "tag"});
+  auto rightLeg = lp::PlanBuilder(ctx)
+                      .values({makeSource()})
+                      .map({"'x' as a", "'x' as b", "2 as tag"});
+
+  auto logicalPlan =
+      leftLeg.unionAll(rightLeg).filter("tag = 1").map({"a", "b"}).build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .project({"cast(uuid() as varchar) as u"})
+                     .project({"u as a", "u as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A reused non-deterministic value in a subquery that is joined with another
+// table. The scalar layer must materialize the non-deterministic value BELOW
+// the join.
+TEST_F(NonDeterministicTest, reusedInJoinedSubquery) {
+  lp::PlanBuilder::Context ctx;
+  auto logicalPlan = lp::PlanBuilder(ctx)
+                         .values({makeSource()})
+                         .map({"k", "uuid() as r"})
+                         .crossJoin(lp::PlanBuilder(ctx).values({makeSource()}))
+                         .map({"r as a", "r as b"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  // The non-deterministic projection must be materialized below the join,
+  // scoped to the left table, not above the join.
+  auto rightSide = matchValues().build();
+  auto matcher = matchValues()
+                     .project({"uuid() as r"})
+                     .nestedLoopJoin(rightSide)
+                     .project({"r as a", "r as b"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// Two reused non-deterministic sources from different sides of a join are each
+// materialized once, both below the join.
+TEST_F(NonDeterministicTest, reusedSourcesFromBothJoinSides) {
+  lp::PlanBuilder::Context ctx;
+  auto logicalPlan =
+      lp::PlanBuilder(ctx)
+          .values({makeSource()})
+          .map({"uuid() as left_r"})
+          .crossJoin(
+              lp::PlanBuilder(ctx)
+                  .values({makeSource()})
+                  .map({"uuid() as right_r"}))
+          .map({"left_r as a", "left_r as b", "right_r as c", "right_r as d"})
+          .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto rightSide = matchValues().project({"uuid() as right_r"}).build();
+  auto matcher =
+      matchValues()
+          .project({"uuid() as left_r"})
+          .nestedLoopJoin(rightSide)
+          .project(
+              {"left_r as a", "left_r as b", "right_r as c", "right_r as d"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// The window's argument is an inline non-deterministic expression. The LIMIT
+// sits below the window and must stay below: hoisting it above the window
+// would make count() aggregate over all rows instead of the 3 kept rows.
+TEST_F(NonDeterministicTest, ndInlineWindowArgOverLimit) {
+  auto logicalPlan = lp::PlanBuilder()
+                         .values({makeSource()})
+                         .limit(3)
+                         .map({"count(rand()) over (partition by k) as c"})
+                         .build();
+
+  auto plan = toSingleNodePlan(logicalPlan);
+
+  auto matcher = matchValues()
+                     .limit()
+                     .project({"k", "rand()"})
+                     .window()
+                     .project({"c"})
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+// A window whose argument references another window's output, in a projection
+// that is also non-deterministic. The two windows must be in separate Window
+// nodes.
+TEST_F(NonDeterministicTest, ndWindowOnWindow) {
+  addTable("t");
+  lp::PlanBuilder::Context ctx{kTestConnectorId, kDefaultSchema};
+  auto logicalPlan =
+      lp::PlanBuilder(ctx)
+          .tableScan("t", {"k", "v"})
+          .map({"row_number() over (partition by k order by v) as w", "k"})
+          .map({"sum(w) over (partition by k order by k) as s", "rand() as r"})
+          .build();
+
+  core::PlanNodePtr plan;
+  ASSERT_NO_THROW({ plan = toSingleNodePlan(logicalPlan); });
+
+  auto matcher =
+      matchScan("t")
+          .window({"row_number() OVER (PARTITION BY k ORDER BY v) as w"})
+          .project({"w", "k"})
+          .window({"sum(w) OVER (PARTITION BY k) as s"})
+          .project({"s", "rand()"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/sql/nondeterministic.sql
+++ b/axiom/optimizer/tests/sql/nondeterministic.sql
@@ -1,81 +1,202 @@
 -- setup_file: common_setup.sql
 
--- Reject: both references resolve to one shared inline expression that would be
--- re-drawn.
--- error: Non-deterministic expression reused
-SELECT u AS x, u AS y
-FROM (SELECT cast(uuid() AS varchar) AS u FROM t)
+-- A non-deterministic projection referenced more than once is computed once.
+-- count 15
+SELECT a FROM (SELECT y AS p, y AS q, a FROM (SELECT concat(cast(uuid() AS varchar), '-x') AS y, a FROM t)) WHERE p = q
 ----
--- Reject: a reused complex-typed non-deterministic source read through
--- subfields.
--- error: Non-deterministic expression reused
-SELECT s[1] AS x, s[1] AS y
-FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+-- A non-deterministic value compared against itself is one draw, always equal.
+-- count 15
+SELECT eq FROM (SELECT (r = r) AS eq FROM (SELECT rand() AS r FROM t)) WHERE eq
 ----
--- Reject: a non-deterministic source read by both a filter and a projection is
--- reused.
--- error: Non-deterministic expression reused
-SELECT r FROM (SELECT rand() AS r FROM t) WHERE r > 0.5
+-- r <> r on one draw is never true, so no rows pass.
+-- count 0
+SELECT a FROM (SELECT rand() AS r, a FROM t) WHERE r <> r
 ----
--- Reject: a reused complex source read once as a whole value and once via a
--- subfield.
--- error: Non-deterministic expression reused
-SELECT s AS x, s[1] AS y
-FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+-- A subfield compared against itself reads one materialized element.
+-- count 15
+SELECT eq FROM (SELECT (s[1] = s[1]) AS eq FROM (SELECT shuffle(sequence(1, a + 5)) AS s FROM t)) WHERE eq
 ----
--- Reject: a reused lambda result.
--- error: Non-deterministic expression reused
-SELECT v AS x, v AS y
-FROM (SELECT transform(sequence(1, 3), e -> e + cast(rand() * 1000000 AS bigint)) AS v FROM t)
-----
--- Reject: reuse of a name bound to a struct field read out of a
--- non-deterministic source.
--- error: Non-deterministic expression reused
-SELECT s AS x, s AS y
-FROM (SELECT shuffle(array[cast(row(a, a) AS row(f1 bigint, f2 bigint))])[1].f1 AS s FROM t)
-----
--- Reject: nested non-deterministic subscript over a non-deterministic call.
--- error: Non-deterministic expression reused
-SELECT s[1] AS x, s[1] AS y
-FROM (SELECT shuffle(array[sequence(1, 5)])[1] AS s FROM t)
-----
--- Known conservative over-rejection: reading more than one subfield of a struct
--- that carries a non-deterministic field.
--- error: Non-deterministic expression reused
-SELECT n.x AS p, n.y AS q
-FROM (SELECT cast(row(a, rand()) AS row(x bigint, y double)) AS n FROM t)
-----
--- Known conservative over-rejection: a single use of an aliased
--- non-deterministic subscript index.
--- error: Non-deterministic expression reused
-SELECT s[i] AS u
-FROM (SELECT array[10, 20, 30, 40, 50] AS s, cast(rand() * 3 AS integer) + 1 AS i FROM t)
-----
--- Accept: two independent non-deterministic draws.
+-- Two independent non-deterministic draws.
 -- count 15
 SELECT uuid() AS x, uuid() AS y FROM t
 ----
--- Accept: a non-deterministic source used only once in a filter.
--- count 15
-SELECT a FROM t WHERE rand() < 2.0
+-- A reused deterministic projection is inlined.
+SELECT a + 1 AS p, (a + 1) * 2 AS q FROM t
 ----
--- Accept: a non-deterministic source referenced once without rename.
+-- A non-deterministic source read via subfield more than once is computed once.
 -- count 15
-SELECT r FROM (SELECT rand() AS r FROM t)
+SELECT a FROM (SELECT s[1] AS x, s[1] AS y, a FROM (SELECT shuffle(sequence(1, 100)) AS s, a FROM t)) WHERE x = y
 ----
--- Accept: a non-deterministic source referenced once, through a single rename.
+-- A subfield of a subfield over a draw is shared.
 -- count 15
-SELECT r AS x FROM (SELECT rand() AS r FROM t)
+SELECT a FROM (SELECT f[1] AS x, f[1] AS y, a FROM (SELECT shuffle(array[array[1, 2, 3], array[4, 5, 6]])[1] AS f, a FROM t)) WHERE x = y
 ----
--- Accept: a non-deterministic source renamed across nested projections but used
+-- A draw reused within a UNION ALL leg is one draw per leg.
+-- count 30
+SELECT a FROM (SELECT u AS x, u AS y, a FROM (SELECT cast(uuid() AS varchar) AS u, a FROM t) UNION ALL SELECT u AS x, u AS y, a FROM (SELECT cast(uuid() AS varchar) AS u, a FROM t)) WHERE x = y
+----
+-- A draw referenced more than once in one filter is one draw.
+-- count 15
+SELECT a FROM (SELECT cast(uuid() AS varchar) AS u, a FROM t) WHERE u >= '0' AND u <= 'zzzzz'
+----
+-- A draw shared by a filter and a projection is one draw.
+-- count 15
+SELECT x FROM (SELECT u AS x, u AS y FROM (SELECT cast(uuid() AS varchar) AS u FROM t) WHERE u <= 'zzzzz') WHERE x = y
+----
+-- A base-column filter pushes below the draw; the reused subfield stays one
+-- draw.
+-- count 15
+SELECT k FROM (SELECT s[1] AS x, s[1] AS y, k FROM (SELECT shuffle(sequence(1, k)) AS s, k FROM (SELECT a + 5 AS k FROM t)) WHERE k > 0) WHERE x = y
+----
+-- A subfield of a draw reused within a UNION ALL leg is one draw per leg.
+-- count 30
+SELECT a FROM (SELECT s[1] AS x, s[1] AS y, a FROM (SELECT shuffle(sequence(1, a + 10)) AS s, a FROM t) UNION ALL SELECT s[1] AS x, s[1] AS y, a FROM (SELECT shuffle(sequence(1, a + 10)) AS s, a FROM t)) WHERE x = y
+----
+-- A draw computed above an aggregate and reused is one draw per group.
+-- count 3
+SELECT mx FROM (SELECT u AS x, u AS y, mx FROM (SELECT cast(uuid() AS varchar) AS u, mx FROM (SELECT max(b) AS mx FROM t GROUP BY a % 3))) WHERE x = y
+----
+-- A pre-aggregation draw reused across several aggregate arguments is computed
 -- once.
--- count 15
-SELECT y AS z FROM (SELECT x AS y FROM (SELECT rand() AS x FROM t))
+-- count 1
+SELECT sum(r) AS s, count(r) AS cnt, max(r) AS mx FROM (SELECT rand() AS r FROM t)
 ----
--- Accept: a complex source read by a single subfield.
+-- A pre-window draw reused across two window functions is computed once.
 -- count 15
-SELECT s[1] AS x FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+SELECT max(r) OVER (PARTITION BY a) AS mx, min(r) OVER (PARTITION BY a) AS mn FROM (SELECT rand() AS r, a FROM t)
 ----
--- Accept: a deterministic complex value reused via subfield.
+-- A draw used as a grouping key and reused post-aggregation is one draw.
 -- count 15
-SELECT s[1] AS x, s[1] AS y FROM (SELECT sequence(1, 5) AS s FROM t)
+SELECT cnt FROM (SELECT u AS x, u AS y, cnt FROM (SELECT u, count(1) AS cnt FROM (SELECT cast(uuid() AS varchar) AS u FROM t) GROUP BY u)) WHERE x = y
+----
+-- A draw used as an equi-join key is materialized once per side.
+-- count 0
+SELECT l.u AS x, l.u AS y FROM (SELECT cast(uuid() AS varchar) AS u FROM t) l JOIN (SELECT cast(uuid() AS varchar) AS s FROM t) r ON l.u = r.s
+----
+-- A draw read by an equi-join key and a post-join filter stays materialized.
+-- count 0
+SELECT l.u AS x FROM (SELECT cast(uuid() AS varchar) AS u FROM t) l JOIN (SELECT cast(uuid() AS varchar) AS s FROM t) r ON l.u = r.s WHERE l.u > '0'
+----
+-- A draw on the null-supplying side of a LEFT JOIN stays materialized.
+-- count 15
+SELECT l.a AS lk, r.u AS uu FROM t l LEFT JOIN (SELECT cast(uuid() AS varchar) AS u, b AS v FROM t) r ON l.a = r.v AND r.u > '0'
+----
+-- A reused draw in a filter alongside a window on a base column is one draw.
+-- count 15
+SELECT row_number() OVER (PARTITION BY a) AS rn, u AS uu FROM (SELECT cast(uuid() AS varchar) AS u, a FROM t) WHERE u >= '0' AND u <= 'zzzzz'
+----
+-- A draw computed alongside a window output and reused is one draw.
+-- count 15
+SELECT m FROM (SELECT u AS x, u AS y, m FROM (SELECT row_number() OVER (PARTITION BY a ORDER BY a) AS m, cast(uuid() AS varchar) AS u FROM t)) WHERE x = y
+----
+-- A draw read by a window argument and a filter stays materialized.
+-- count 15
+SELECT max(u) OVER (PARTITION BY a ORDER BY b) AS m FROM (SELECT cast(uuid() AS varchar) AS u, a, b FROM t) WHERE u >= '0' AND u <= 'zzzzz'
+----
+-- A filter on a reused draw over a scan is not pushed down.
+-- count 15
+SELECT x FROM (SELECT s[1] AS x, s[1] AS y FROM (SELECT shuffle(sequence(1, a + 10)) AS s FROM t)) WHERE x = y AND x > -1
+----
+-- A draw used only in a filter is pushed to the scan.
+-- count 15
+SELECT a FROM (SELECT rand() AS r, a FROM t) WHERE r > -1.0
+----
+-- A draw read through a single subfield is pushed to the scan.
+-- count 15
+SELECT a FROM (SELECT shuffle(sequence(1, a + 10)) AS s, a FROM t) WHERE s[1] > -1
+----
+-- A per-row draw captured in a lambda body is one draw.
+-- count 15
+SELECT a FROM (SELECT rand() AS r, a FROM t) WHERE cardinality(array_distinct(transform(sequence(1, a + 2), x -> r))) = 1
+----
+-- A draw materialized once above a UNION ALL, reused by a filter and two
+-- outputs.
+-- count 30
+SELECT p FROM (SELECT arr[1] AS p, arr[1] AS q FROM (SELECT shuffle(sequence(1, a + 10)) AS arr FROM (SELECT a FROM t UNION ALL SELECT a FROM t))) WHERE p = q AND p > -1
+----
+-- A field of a field over a draw, reused, is one draw.
+-- count 15
+SELECT a FROM (SELECT field2 AS x, field2 AS y, a FROM (SELECT field1[2] AS field2, a FROM (SELECT f0[1] AS field1, a FROM (SELECT shuffle(array[array[1, 2, 3], array[4, 5, 6]]) AS f0, a FROM t)))) WHERE x = y
+----
+-- A multi-step subscript chain over a draw, reused, is one draw.
+-- count 15
+SELECT a FROM (SELECT field1[1] AS x, field1[1] AS y, a FROM (SELECT f0[1][1] AS field1, a FROM (SELECT shuffle(array[array[array[1, 2], array[3, 4]], array[array[5, 6], array[7, 8]]]) AS f0, a FROM t))) WHERE x = y
+----
+-- A draw referenced by ORDER BY and the projection is one draw.
+-- count 15
+SELECT x FROM (SELECT u AS x, u AS y FROM (SELECT shuffle(sequence(1, a + 10))[1] AS u FROM t)) WHERE x = y ORDER BY x
+----
+-- A reused draw with ORDER BY on a base column, no limit.
+-- count 15
+SELECT x FROM (SELECT u AS x, u AS y, a FROM (SELECT cast(uuid() AS varchar) AS u, a FROM t)) WHERE x = y ORDER BY a
+----
+-- A draw over a subquery LIMIT; the LIMIT is a cardinality barrier below the
+-- draw.
+-- count 3
+SELECT cast(uuid() AS varchar) AS u FROM (SELECT a FROM t LIMIT 3)
+----
+-- A draw over ORDER BY ... LIMIT; the draw sits above the top-N.
+-- count 3
+SELECT cast(uuid() AS varchar) AS u, a FROM (SELECT a FROM t ORDER BY a LIMIT 3)
+----
+-- A draw reused standalone and nested inside another reused expression.
+-- count 15
+SELECT uu FROM (SELECT u AS uu, concat(u, 'x') AS v1, concat(u, 'x') AS v2 FROM (SELECT cast(uuid() AS varchar) AS u FROM t)) WHERE v1 = v2
+----
+-- A draw read via subfield feeds the argument of a second draw; both reused.
+-- count 15
+SELECT mm FROM (SELECT m AS mm, arr[1] AS b1, arr[1] AS b2 FROM (SELECT m, shuffle(sequence(1, m + 1)) AS arr FROM (SELECT shuffle(sequence(1, 10))[1] AS m FROM t))) WHERE b1 = b2
+----
+-- A non-deterministic lambda result reused is materialized once.
+-- count 15
+SELECT a FROM (SELECT arr AS p, arr AS q, a FROM (SELECT transform(sequence(1, 3), x -> rand()) AS arr, a FROM t)) WHERE p = q
+----
+-- A single-use non-deterministic lambda needs no shared materialization.
+-- count 15
+SELECT transform(sequence(1, 3), x -> rand()) AS a FROM t
+----
+-- Two parallel draws (a uuid and a lambda array), each materialized once.
+-- count 15
+SELECT a1 FROM (SELECT u AS u1, u AS u2, arr AS a1 FROM (SELECT cast(uuid() AS varchar) AS u, transform(sequence(1, 3), x -> rand()) AS arr FROM t)) WHERE u1 = u2
+----
+-- A filter on a constant tag drops one UNION ALL leg; the survivor's reused
+-- draw is one draw.
+-- count 15
+SELECT x FROM (SELECT u AS x, u AS y, 1 AS tag FROM (SELECT cast(uuid() AS varchar) AS u FROM t) UNION ALL SELECT 'z' AS x, 'z' AS y, 2 AS tag FROM t) WHERE tag = 1 AND x = y
+----
+-- A reused draw in a subquery joined with another table is materialized below
+-- the join.
+-- count 45
+SELECT x FROM (SELECT r AS x, r AS y FROM (SELECT cast(uuid() AS varchar) AS r FROM t)) CROSS JOIN (SELECT b FROM t WHERE b <= 30) WHERE x = y
+----
+-- Reused draws from both sides of a join, each materialized once below the join.
+-- count 45
+SELECT l.lr AS a, l.lr AS b, r.rr AS c, r.rr AS d FROM (SELECT cast(uuid() AS varchar) AS lr FROM t) l CROSS JOIN (SELECT cast(uuid() AS varchar) AS rr FROM t WHERE b <= 30) r
+----
+-- An inline draw as a window argument over a LIMIT; the LIMIT stays below the
+-- window.
+-- count 3
+SELECT count(rand()) OVER (PARTITION BY a) AS c FROM (SELECT a FROM t LIMIT 3)
+----
+-- A window whose argument references another window's output, in a
+-- non-deterministic projection.
+-- count 15
+SELECT sum(w) OVER (PARTITION BY a) AS s, rand() AS r FROM (SELECT row_number() OVER (PARTITION BY a ORDER BY b) AS w, a FROM t)
+----
+-- A draw read both as a whole value and via a subfield is one draw; the
+-- subfield of the whole matches the separate subfield read.
+-- count 15
+SELECT a FROM (SELECT s AS x, s[1] AS y, a FROM (SELECT shuffle(sequence(1, 5)) AS s, a FROM t)) WHERE x[1] = y
+----
+-- A struct field read out of a non-deterministic source, reused, is one draw.
+-- count 15
+SELECT a FROM (SELECT f AS x, f AS y, a FROM (SELECT shuffle(array[cast(row(a, a) AS row(f1 bigint, f2 bigint))])[1].f1 AS f, a FROM t)) WHERE x = y
+----
+-- Reading two subfields of a struct that carries a non-deterministic field; the
+-- deterministic field still equals its base column.
+-- count 15
+SELECT q FROM (SELECT n.x AS p, n.y AS q, a FROM (SELECT cast(row(a, rand()) AS row(x bigint, y double)) AS n, a FROM t)) WHERE p = a
+----
+-- A non-deterministic value used as an array subscript index (single use).
+-- count 15
+SELECT s[i] AS u FROM (SELECT array[10, 20, 30, 40, 50] AS s, cast(rand() * 3 AS integer) + 1 AS i FROM t)


### PR DESCRIPTION
Summary:
Inlining a non-deterministic projected expression (e.g., rand(), uuid(), shuffle(), …) into its consumers causes incorrect results when the expression is referenced more than once: each reference re-draws the value independently, and under join fan-out the draw evaluates at the wrong scope.

https://github.com/facebookincubator/axiom/pull/1497 mitigated this by rejecting such queries with an error instead of silently returning wrong results, until a proper fix was ready.

This diff fixes the issue and removes the mitigation, by materializing a non-deterministic expression into a column. When a projection contains a non-deterministic expression, makeProjectQueryGraph forces a derived-table boundary so the value is computed once as the child's output column, and every reference reads that single column.

Pushdown of a non-deterministic filter into a child derived table is allowed only when it would not split that single draw — i.e. when the materialized column is read at most once and not read inside a lambda body; otherwise the filter is kept above the materialization.

Differential Revision: D111292652


