### PR TITLE
test: Run bucketed and write tests under v1 and v2 (#1562)

### DIFF
--- a/axiom/cli/AxiomSql.cpp
+++ b/axiom/cli/AxiomSql.cpp
@@ -34,6 +34,11 @@ DEFINE_string(
     "",
     "Default catalog (connector). If empty, uses tpch or hive if --data_path is set.");
 DEFINE_string(schema, "", "Default schema.");
+DEFINE_bool(
+    v2,
+    false,
+    "Use the v2 optimizer. EXPLAIN (type graph|optimized|io) and "
+    "SHOW STATS FOR (<query>) are not supported under v2 yet.");
 
 int main(int argc, char** argv) {
   folly::Init init(&argc, &argv, false);
@@ -45,7 +50,7 @@ int main(int argc, char** argv) {
   // Progress-polling scheduler for the console's live progress bar.
   folly::FunctionScheduler progressScheduler;
   axiom::sql::SqlQueryRunner runner{
-      axiom::sql::SystemUser::resolve(), &progressScheduler};
+      axiom::sql::SystemUser::resolve(), &progressScheduler, FLAGS_v2};
   runner.initialize([&]() {
     VELOX_USER_CHECK(
         FLAGS_data_path.empty() || FLAGS_etc_dir.empty(),

--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(
   axiom_runner_local_runner
   axiom_optimizer_multifragment_plan
   axiom_optimizer
+  axiom_optimizer_v2
   axiom_graphviz_printers
   axiom_hive_connector_metadata
   axiom_tpch_connector_metadata

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -34,6 +34,7 @@ The examples below use `axiom_sql` for brevity. With Buck, replace
 | `--split_target_bytes` | `16MB` | Hive specific: approximate bytes per split. |
 | `--num_workers` | `4` | Number of in-process workers. |
 | `--num_drivers` | `4` | Number of drivers per worker (parallelism). |
+| `--v2` | `false` | Route queries through the v2 optimizer. `EXPLAIN (type graph\|optimized\|io)` and `SHOW STATS FOR (<query>)` are not supported under v2 yet. |
 | `--max_rows` | `100` | Maximum number of printed result rows. |
 | `--show_live_progress` | `false` | Draw the [live progress](#live-progress) grid for `--query` and piped-stdin runs (when stderr is a terminal). The interactive REPL always shows it; this only opts the non-interactive paths in. |
 | `--debug` | `false` | Enable debug mode (logging to stderr; adds per-split and CPU-time detail lines to the live progress display). |

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -44,6 +44,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/RelationOpPrinter.h"
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/optimizer/v2/Optimize.h"
 #include "axiom/runner/ProgressReporter.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
@@ -720,6 +721,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     }
 
     if (explain->type() == presto::ExplainStatement::Type::kIo) {
+      VELOX_USER_CHECK(
+          !useOptimizerV2_, "EXPLAIN TYPE IO is not supported with --v2");
       std::optional<CatalogSchemaTableName> outputTable;
       if (statement->isCreateTableAsSelect()) {
         const auto* ctas =
@@ -961,6 +964,8 @@ std::string SqlQueryRunner::runExplain(
       return logical_plan::PlanPrinter::toText(*logicalPlan);
 
     case presto::ExplainStatement::Type::kGraph: {
+      VELOX_USER_CHECK(
+          !useOptimizerV2_, "EXPLAIN TYPE GRAPH is not supported with --v2");
       std::string text;
       auto queryCtx = newQuery(options);
       {
@@ -992,6 +997,9 @@ std::string SqlQueryRunner::runExplain(
     }
 
     case presto::ExplainStatement::Type::kOptimized: {
+      VELOX_USER_CHECK(
+          !useOptimizerV2_,
+          "EXPLAIN TYPE OPTIMIZED is not supported with --v2");
       std::string text;
       auto queryCtx = newQuery(options);
       {
@@ -1216,6 +1224,18 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
       sessionConfig_->effectiveValues(kRunnerPrefix),
       std::move(connectorProperties));
 
+  if (useOptimizerV2_) {
+    VELOX_USER_CHECK(
+        checkDerivedTable == nullptr && checkBestPlan == nullptr,
+        "DerivedTable / RelationOp inspection hooks are not supported by the v2 optimizer");
+    // The v2 optimizer runs as a single phase, so the per-phase timing
+    // breakdown keys (toGraph / bestPlan / toVelox) are not populated; only
+    // the overall `kOptimizeWallNanos` / `kOptimizeCpuNanos` are recorded,
+    // from the caller-side `PhaseTimer`.
+    return optimizer::v2::optimize(
+        *logicalPlan, *schemaResolver, *optimizerSession, evaluator, opts);
+  }
+
   uint64_t toGraphNanos{0};
   uint64_t toGraphCpuNanos{0};
   auto toGraphCpuStart = velox::process::threadCpuNanos();
@@ -1430,6 +1450,8 @@ std::optional<int64_t> roundCardinality(std::optional<float> cardinality) {
 std::vector<velox::RowVectorPtr> SqlQueryRunner::runShowStatsForQuery(
     const presto::SqlStatement& sqlStatement,
     const RunOptions& options) {
+  VELOX_USER_CHECK(
+      !useOptimizerV2_, "SHOW STATS FOR (<query>) is not supported with --v2");
   const auto* showStats = sqlStatement.as<presto::ShowStatsForQueryStatement>();
   const auto& innerStatement = showStats->statement();
   VELOX_CHECK(innerStatement->isSelect());

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -164,10 +164,17 @@ class SqlQueryRunner {
   /// `progressScheduler` (not owned, must outlive this runner) drives progress
   /// polling for queries that set RunOptions::onProgress. If null, such a query
   /// fails loudly rather than running without the progress it asked for.
+  /// @param useOptimizerV2 When true, all queries route through the v2
+  /// optimizer. EXPLAIN (type graph|optimized|io) and SHOW STATS FOR (<query>)
+  /// fail with a user error under v2, because they inspect optimizer internals
+  /// the v2 pipeline does not expose.
   explicit SqlQueryRunner(
       std::string user,
-      folly::FunctionScheduler* progressScheduler = nullptr)
-      : user_{std::move(user)}, progressScheduler_{progressScheduler} {
+      folly::FunctionScheduler* progressScheduler = nullptr,
+      bool useOptimizerV2 = false)
+      : user_{std::move(user)},
+        useOptimizerV2_{useOptimizerV2},
+        progressScheduler_{progressScheduler} {
     VELOX_USER_CHECK(!user_.empty(), "SqlQueryRunner user must be non-empty");
   }
 
@@ -485,6 +492,7 @@ class SqlQueryRunner {
   std::string defaultSchema_;
   const std::string user_;
   std::atomic<int32_t> queryCounter_{0};
+  const bool useOptimizerV2_{false};
 
   // Progress-polling scheduler (see constructor). Started idempotently before
   // each progress-reporting query.

--- a/axiom/connectors/file/tests/CMakeLists.txt
+++ b/axiom/connectors/file/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_test(NAME axiom_file_connector_test COMMAND axiom_file_connector_test)
 target_link_libraries(
   axiom_file_connector_test
   axiom_cli
+  axiom_optimizer_v2
   velox_dwio_parquet_writer
   velox_vector_test_lib
   velox_exec_test_lib

--- a/axiom/optimizer/CMakeLists.txt
+++ b/axiom/optimizer/CMakeLists.txt
@@ -67,3 +67,5 @@ target_link_libraries(
   axiom_runner_local_runner
   velox_connector
 )
+
+add_subdirectory(v2)

--- a/axiom/optimizer/EstimateMath.h
+++ b/axiom/optimizer/EstimateMath.h
@@ -45,6 +45,16 @@ inline std::optional<float> add(
   return std::nullopt;
 }
 
+/// Subtraction.
+inline std::optional<float> subtract(
+    std::optional<float> a,
+    std::optional<float> b) {
+  if (a.has_value() && b.has_value()) {
+    return *a - *b;
+  }
+  return std::nullopt;
+}
+
 /// Division. nullopt if either operand is unknown or the divisor is 0.
 inline std::optional<float> divide(
     std::optional<float> a,

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -83,6 +83,15 @@ bool FunctionRegistry::registerCount(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerBoolOr(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (boolOr_.has_value() && boolOr_.value() != name) {
+    return false;
+  }
+  boolOr_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerStatsAggregates(StatsAggregates aggregates) {
   VELOX_USER_CHECK(!aggregates.min.empty());
   VELOX_USER_CHECK(!aggregates.max.empty());
@@ -391,6 +400,7 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerSubscript(fullName("subscript"));
   registry->registerArbitrary(fullName("arbitrary"));
   registry->registerCount(fullName("count"));
+  registry->registerBoolOr(fullName("bool_or"));
   registry->registerLessThan(fullName("lt"));
   registry->registerLessThanOrEqual(fullName("lte"));
   registry->registerGreaterThan(fullName("gt"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -319,6 +319,19 @@ class FunctionRegistry {
     return count_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'bool_or'
+  /// aggregate function, i.e. returns true if any input is true, false
+  /// if all inputs are false, and NULL only if there are no rows or
+  /// all inputs are NULL.
+  /// @return true if successfully registered, false if a different
+  /// 'bool_or' function is already registered.
+  bool registerBoolOr(std::string_view name);
+
+  /// Returns the name of the 'bool_or' aggregate function.
+  const std::optional<std::string>& boolOr() const {
+    return boolOr_;
+  }
+
   /// Registers aggregate function names used for computing column statistics
   /// during table writes. 'count' is omitted since it has its own slot.
   /// @return true if successfully registered, false if stats aggregates are
@@ -526,6 +539,7 @@ class FunctionRegistry {
   // Aggregate functions.
   std::optional<std::string> arbitrary_;
   std::optional<std::string> count_;
+  std::optional<std::string> boolOr_;
   // Aggregate function names for computing column statistics during writes.
   std::optional<StatsAggregates> statsAggregates_;
 

--- a/axiom/optimizer/OptimizerOptions.cpp
+++ b/axiom/optimizer/OptimizerOptions.cpp
@@ -103,6 +103,14 @@ std::vector<ConfigProperty> buildProperties(
           "worker's memory. \"0B\" disables broadcast.",
       },
       {
+          std::string(OptimizerOptions::kDphypEnumerationBudget),
+          ConfigPropertyType::kInteger,
+          std::to_string(OptimizerOptions::kDphypEnumerationBudgetDefault),
+          "Max connected-subgraph/complement pairs the DPhyp join enumerator "
+          "evaluates before falling back to greedy ordering. Bounds planning "
+          "time on dense join graphs. 0 means unlimited.",
+      },
+      {
           std::string(OptimizerOptions::kTraceFlags),
           ConfigPropertyType::kInteger,
           std::to_string(OptimizerOptions::kTraceFlagsDefault),
@@ -194,6 +202,7 @@ OptimizerOptions OptimizerOptions::from(
   setInt(kParallelProjectWidth, options.parallelProjectWidth);
   setInt(kGreedyJoinThreshold, options.greedyJoinThreshold);
   setCapacity(kBroadcastSizeLimit, options.broadcastSizeLimit);
+  setInt(kDphypEnumerationBudget, options.dphypEnumerationBudget);
 
   auto setUint = [&](std::string_view key, uint32_t& field) {
     auto it = properties.find(key);

--- a/axiom/optimizer/OptimizerOptions.h
+++ b/axiom/optimizer/OptimizerOptions.h
@@ -51,6 +51,8 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
       "greedy_join_threshold";
   static constexpr std::string_view kBroadcastSizeLimit =
       "broadcast_size_limit";
+  static constexpr std::string_view kDphypEnumerationBudget =
+      "dphyp_enumeration_budget";
   static constexpr std::string_view kTraceFlags = "trace_flags";
 
   // Default values — single source of truth for field initializers
@@ -61,6 +63,7 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   // units; the bytes form initializes the parsed field.
   static constexpr std::string_view kBroadcastSizeLimitDefault = "100MB";
   static constexpr int64_t kBroadcastSizeLimitDefaultBytes = 100LL << 20;
+  static constexpr int32_t kDphypEnumerationBudgetDefault = 100'000;
   static constexpr bool kPushdownSubfieldsDefault = false;
   static constexpr bool kAllMapsAsStructDefault = false;
   static constexpr bool kSampleJoinsDefault = false;
@@ -127,6 +130,13 @@ struct OptimizerOptions : public velox::config::ConfigProvider {
   /// worker's memory. Configured as a capacity string ("100MB", "1GB"); "0B"
   /// disables broadcast entirely.
   int64_t broadcastSizeLimit{kBroadcastSizeLimitDefaultBytes};
+
+  /// Maximum number of connected-subgraph/complement pairs the DPhyp join
+  /// enumerator evaluates before falling back to greedy (GOO) ordering. Bounds
+  /// worst-case planning time on dense join graphs (e.g. same-key N-way joins,
+  /// which equality-transitivity closure turns into cliques). 0 means
+  /// unlimited.
+  int32_t dphypEnumerationBudget{kDphypEnumerationBudgetDefault};
 
   /// Disable cost-based decision re: whether to split an aggregation into
   /// partial + final or not.

--- a/axiom/optimizer/PlanObject.cpp
+++ b/axiom/optimizer/PlanObject.cpp
@@ -34,6 +34,7 @@ const auto& planTypeNames() {
       {PlanType::kDerivedTableNode, "DerivedTableNode"},
       {PlanType::kAggregationNode, "AggregationNode"},
       {PlanType::kWindowPlanNode, "WindowPlanNode"},
+      {PlanType::kV2Node, "V2Node"},
   };
   return kNames;
 }
@@ -51,6 +52,10 @@ size_t PlanObject::hash() const {
 
 void PlanObjectSet::unionColumns(ExprCP expr) {
   unionSet(expr->columns());
+}
+
+bool PlanObjectSet::containsColumns(ExprCP expr) const {
+  return expr->columns().isSubset(*this);
 }
 
 void PlanObjectSet::unionColumns(const ExprVector& exprs) {

--- a/axiom/optimizer/PlanObject.h
+++ b/axiom/optimizer/PlanObject.h
@@ -41,6 +41,8 @@ enum class PlanType : uint32_t {
   kAggregationNode,
   kWindowPlanNode,
   kWriteNode,
+  // Node from the v2 tree IR. See axiom/optimizer/v2/Node.h.
+  kV2Node,
 };
 
 AXIOM_DECLARE_ENUM_NAME(PlanType);
@@ -172,6 +174,7 @@ class PlanObjectSet : public BitSet {
         velox::bits::isBitSet(bits_.data(), object->id());
   }
 
+  /// True if id of any object in 'objects' is in 'this'.
   template <typename V>
   bool containsAny(const V& objects) const {
     for (const auto& object : objects) {
@@ -180,6 +183,31 @@ class PlanObjectSet : public BitSet {
       }
     }
     return false;
+  }
+
+  /// True if id of every object in 'objects' is in 'this'.
+  template <typename V>
+  bool containsAll(const V& objects) const {
+    for (const auto& object : objects) {
+      if (!contains(object)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// True if every column 'expr' depends on is in 'this' — i.e. 'expr' can be
+  /// evaluated from these columns.
+  bool containsColumns(ExprCP expr) const;
+
+  /// True if every expression in 'exprs' can be evaluated from these columns.
+  bool containsColumns(const ExprVector& exprs) const {
+    for (ExprCP expr : exprs) {
+      if (!containsColumns(expr)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /// Inserts id of 'object'.

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -49,6 +49,8 @@ const char* SpecialFormCallNames::kSwitch = "__switch";
 const char* SpecialFormCallNames::kIn = "__in";
 // static
 const char* SpecialFormCallNames::kNullIf = "__nullif";
+// static
+const char* SpecialFormCallNames::kDereference = "__dereference";
 
 // static
 ColumnCP Column::createForSymbol(Name symbol, const Value& value) {

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -51,6 +51,23 @@ const char* SpecialFormCallNames::kIn = "__in";
 const char* SpecialFormCallNames::kNullIf = "__nullif";
 
 // static
+ColumnCP Column::createForSymbol(Name symbol, const Value& value) {
+  VELOX_DCHECK(
+      queryCtx()->isV2(),
+      "Column::createForSymbol synthesizes a relation-less column, a v2-only idiom");
+  return make<Column>(
+      queryCtx()->newName(symbol),
+      /*relation=*/nullptr,
+      value,
+      /*alias=*/symbol);
+}
+
+// static
+ColumnCP Column::createBoolean(std::string_view prefix) {
+  return create(prefix, Value(toType(velox::BOOLEAN()), /*cardinality=*/2));
+}
+
+// static
 ColumnCP Column::create(std::string_view prefix, const Value& value) {
   VELOX_DCHECK(
       queryCtx()->isV2(),

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -50,6 +50,14 @@ const char* SpecialFormCallNames::kIn = "__in";
 // static
 const char* SpecialFormCallNames::kNullIf = "__nullif";
 
+// static
+ColumnCP Column::create(std::string_view prefix, const Value& value) {
+  VELOX_DCHECK(
+      queryCtx()->isV2(),
+      "Column::create synthesizes a relation-less column, a v2-only idiom");
+  return make<Column>(queryCtx()->newName(prefix), /*relation=*/nullptr, value);
+}
+
 void Column::equals(ColumnCP other) const {
   if (!equivalence_ && !other->equivalence_) {
     auto* equiv = make<Equivalence>();
@@ -66,6 +74,10 @@ void Column::equals(ColumnCP other) const {
   }
   if (!equivalence_) {
     other->equals(this);
+    return;
+  }
+  // Already in one class: merging would iterate and grow the same vector.
+  if (equivalence_ == other->equivalence_) {
     return;
   }
   for (auto& column : other->equivalence_->columns) {
@@ -90,6 +102,10 @@ Name cname(PlanObjectCP relation) {
 }
 
 std::string Column::toString() const {
+  if (queryCtx()->isV2()) {
+    return name_;
+  }
+
   const auto* opt = queryCtx()->optimization();
   if (!opt->cnamesInExpr() || relation_ == nullptr) {
     return name_;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -169,6 +169,19 @@ class Column : public Expr {
   /// names pass an `alias` to the full constructor instead.
   static ColumnCP create(std::string_view prefix, const Value& value);
 
+  /// Creates a `Column` named by the logical-plan `symbol` it carries. The
+  /// internal `name` is uniquified for the optimizer's flat namespace, while
+  /// `outputName()` returns `symbol` (the alias), so the emitted plan uses the
+  /// logical-plan name. Use whenever a translated logical-plan node produces a
+  /// named column; synthetic columns use `create`.
+  static ColumnCP createForSymbol(Name symbol, const Value& value);
+
+  /// Synthesizes a `BOOLEAN` column with cardinality 2 (the two valid
+  /// boolean values). Convenience for the recurring pattern of
+  /// creating eligibility / marker columns in rewrites; equivalent to
+  /// `create(prefix, Value(toType(velox::BOOLEAN()), 2))`.
+  static ColumnCP createBoolean(std::string_view prefix);
+
   Name name() const {
     return name_;
   }

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -161,6 +161,14 @@ class Column : public Expr {
       ColumnCP topColumn = nullptr,
       PathCP path = nullptr);
 
+  /// Synthesizes a `Column`. The column's `name` is `prefix` with a
+  /// uniqueness suffix appended by `QueryGraphContext::newName`. The
+  /// resulting name appears in plan output (EXPLAIN, `NodePrinter`),
+  /// so pick a descriptive prefix (`"__rownum"`, `"mark"`, etc.).
+  /// `alias` is not set; sites that produce user-visible LP output
+  /// names pass an `alias` to the full constructor instead.
+  static ColumnCP create(std::string_view prefix, const Value& value);
+
   Name name() const {
     return name_;
   }
@@ -1338,6 +1346,8 @@ struct Frame {
   /// Offset expression for the end bound, or nullptr for UNBOUNDED or
   /// CURRENT ROW.
   ExprCP endValue;
+
+  bool operator==(const Frame& other) const = default;
 };
 
 /// Window function call. Stores partition keys, order keys, frame, and

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -452,6 +452,7 @@ struct SpecialFormCallNames {
   static const char* kSwitch;
   static const char* kIn;
   static const char* kNullIf;
+  static const char* kDereference;
 
   static const char* toCallName(const logical_plan::SpecialForm& form) {
     switch (form) {
@@ -475,6 +476,8 @@ struct SpecialFormCallNames {
         return SpecialFormCallNames::kIn;
       case logical_plan::SpecialForm::kNullIf:
         return SpecialFormCallNames::kNullIf;
+      case logical_plan::SpecialForm::kDereference:
+        return SpecialFormCallNames::kDereference;
       default:
         VELOX_FAIL(
             "No function call name for special form: {}",
@@ -513,6 +516,9 @@ struct SpecialFormCallNames {
     }
     if (name == kNullIf) {
       return logical_plan::SpecialForm::kNullIf;
+    }
+    if (name == kDereference) {
+      return logical_plan::SpecialForm::kDereference;
     }
 
     return std::nullopt;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1376,6 +1376,28 @@ struct Frame {
   ExprCP endValue;
 
   bool operator==(const Frame& other) const = default;
+
+  /// ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING — every
+  /// row sees the whole partition (e.g. a partition-wide aggregate).
+  static Frame wholePartition() {
+    return Frame{
+        logical_plan::WindowExpr::WindowType::kRows,
+        logical_plan::WindowExpr::BoundType::kUnboundedPreceding,
+        /*startValue=*/nullptr,
+        logical_plan::WindowExpr::BoundType::kUnboundedFollowing,
+        /*endValue=*/nullptr};
+  }
+
+  /// ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW — the default
+  /// running frame (e.g. for row_number).
+  static Frame toCurrentRow() {
+    return Frame{
+        logical_plan::WindowExpr::WindowType::kRows,
+        logical_plan::WindowExpr::BoundType::kUnboundedPreceding,
+        /*startValue=*/nullptr,
+        logical_plan::WindowExpr::BoundType::kCurrentRow,
+        /*endValue=*/nullptr};
+  }
 };
 
 /// Window function call. Stores partition keys, order keys, frame, and

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -393,6 +393,21 @@ class Call : public Expr {
     bool operator()(const Call* call, const KeyView& key) const;
   };
 
+  /// Returns 'base' OR'd with the `FunctionSet` of each argument. Used
+  /// when constructing a new `Call` to propagate flags
+  /// (kNonDeterministic, kAggregate, kWindow, etc.) that downstream
+  /// passes consult via `Expr::containsFunction(...)`. Pair with
+  /// `functionBits(name, specialForm)` to seed `base` with the
+  /// function's own bits.
+  static FunctionSet unionArgFunctions(
+      FunctionSet base,
+      const ExprVector& arguments) {
+    for (const auto* argument : arguments) {
+      base = base | argument->functions();
+    }
+    return base;
+  }
+
  private:
   // Name of function.
   Name const name_;

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <fmt/format.h>
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
 #include "axiom/common/Enums.h"
@@ -459,6 +460,18 @@ class QueryGraphContext {
     return allVariants_.back().get();
   }
 
+  /// Returns a globally unique interned name `{prefix}{N}` within this query
+  /// context. Example: `newName("a_")` returns `"a_47"`.
+  Name newName(std::string_view prefix) {
+    return toName(fmt::format("{}{}", prefix, ++nameCounter_));
+  }
+
+  /// True when the v2 optimizer is driving this query. v2 runs without an
+  /// `Optimization` (a v1 construct), so a null `optimization()` marks v2.
+  bool isV2() const {
+    return optimization_ == nullptr;
+  }
+
  private:
   void populateFunctionNames();
 
@@ -488,6 +501,8 @@ class QueryGraphContext {
   FunctionNames functionNames_;
 
   std::vector<std::unique_ptr<velox::Variant>> allVariants_;
+
+  uint32_t nameCounter_{0};
 };
 
 /// Returns a mutable reference to the calling thread's QueryGraphContext.
@@ -555,5 +570,8 @@ using ExprVector = QGVector<ExprCP>;
 class Column;
 using ColumnCP = const Column*;
 using ColumnVector = QGVector<ColumnCP>;
+
+class Literal;
+using LiteralCP = const Literal*;
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1361,6 +1361,7 @@ ExprCP ToGraph::translateExpr(const lp::ExprPtr& expr) {
 
     // Drop redundant cast.
     //    CAST(x as t) / TRY_CAST(x as t) ==> x if typeof(x) == t.
+    // TRY_CAST too: a same-type cast never errors.
     if (specialForm &&
         (specialForm->form() == lp::SpecialForm::kCast ||
          specialForm->form() == lp::SpecialForm::kTryCast)) {

--- a/axiom/optimizer/ToGraph.h
+++ b/axiom/optimizer/ToGraph.h
@@ -99,7 +99,7 @@ class ToGraph {
           connector::TablePtr> pushdownRoots);
 
   Name newCName(std::string_view prefix) {
-    return toName(fmt::format("{}{}", prefix, ++nameCounter_));
+    return queryCtx()->newName(prefix);
   }
 
   /// Creates a new column with a unique name using the given prefix.

--- a/axiom/optimizer/docs/Testing.md
+++ b/axiom/optimizer/docs/Testing.md
@@ -234,7 +234,7 @@ How to read:
 
 ### SqlTest: Verifying Correctness
 
-SqlTest runs SQL queries through the full Axiom pipeline (parse → optimize → execute) and compares results against DuckDB.
+SqlTest runs SQL queries through the full Axiom pipeline (parse → optimize → execute) and compares results against DuckDB. Each query runs under both the v1 and v2 optimizers, so one `.sql` file exercises both.
 
 Tests are written as plain `.sql` files. Queries are separated by `----`. Comment lines (`-- ...`) before the SQL can contain annotations that control how the query is verified. Unrecognized comments are ignored. Comments after the SQL starts are treated as part of the SQL body.
 
@@ -245,12 +245,16 @@ Tests are written as plain `.sql` files. Queries are separated by `----`. Commen
 | *(none)* | Default: run query in Axiom and DuckDB, compare results ignoring row order and output column names. |
 | `-- ordered` | Compare results preserving row order. Use for queries with ORDER BY. |
 | `-- count N` | Only check that the result has exactly N rows (no data comparison). Useful for verifying empty results (`-- count 0`) or queries with non-deterministic output (e.g., `random()`, `uuid()`, `LIMIT` without `ORDER BY`). |
-| `-- error: message` | Expect the query to fail with an error containing `message`. |
+| `-- error: message` | Expect the query to fail under both optimizers with an error containing `message`. Shorthand for `error_v1` + `error_v2`; cannot be combined with either. |
+| `-- error_v1: message` | Expect the query to fail under the v1 optimizer with an error containing `message`. v2 is verified normally unless it also carries `error_v2`. |
+| `-- error_v2: message` | Expect the query to fail under the v2 optimizer with an error containing `message`. v1 is verified normally unless it also carries `error_v1`. |
 | `-- duckdb: sql` | Use a different SQL for the DuckDB comparison (when Presto and DuckDB syntax differs). |
 | `-- columns` | Additionally verify that column names match between Axiom and DuckDB. |
 | `-- disabled` | Skip this query entirely. For use during local development only — do not commit disabled queries. |
 
 Annotations can be combined. For example, `-- ordered` and `-- columns` can be used together.
+
+Use `error_v1`/`error_v2` when the two optimizers legitimately diverge — typically a v1 limitation that v2 fixes (or vice versa). The optimizer without an error annotation runs and is verified normally, so the same query can assert a v1 error and check the v2 result.
 
 **Example:**
 
@@ -327,10 +331,13 @@ INSERT INTO u VALUES (1), (2), (3)
 SELECT * FROM t JOIN u ON t.a = u.a
 ```
 
-Each query in a `.sql` file becomes a separate gtest (e.g., `SqlTest.basic_l22` for the query at line 22 of `basic.sql`). Run them with:
+Each query becomes a separate gtest per optimizer, in the suites `V1/SqlTest_<file>` and `V2/SqlTest_<file>` (e.g., `V1/SqlTest_basic.l22` and `V2/SqlTest_basic.l22` for the query at line 22 of `basic.sql`); each also runs under cost-based and syntactic join ordering. Run them with:
 ```bash
 buck test fbcode//axiom/optimizer/tests:sql
-buck test fbcode//axiom/optimizer/tests:sql -- basic_l28
+# only the v2 optimizer:
+buck test fbcode//axiom/optimizer/tests:sql -- V2/
+# one file:
+buck test fbcode//axiom/optimizer/tests:sql -- basic
 ```
 
 To add a new correctness test, append a query to the appropriate `.sql` file in `axiom/optimizer/tests/sql/`. No C++ changes needed. A few of the files:

--- a/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/BucketedExecutionPlanTest.cpp
@@ -26,8 +26,14 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class BucketedExecutionTest : public test::QueryTestBase {
+class BucketedExecutionTest : public test::QueryTestBase,
+                              public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+    useV2_ = GetParam();
+  }
+
   lp::PlanBuilder::Context makeContext() const {
     return lp::PlanBuilder::Context{kTestConnectorId, kDefaultSchema};
   }
@@ -103,7 +109,7 @@ class BucketedExecutionTest : public test::QueryTestBase {
   }
 };
 
-TEST_F(BucketedExecutionTest, join) {
+TEST_P(BucketedExecutionTest, join) {
   addBucketedTable("j_orders", {"customer_id"}, 128);
   addBucketedTable(
       "j_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
@@ -156,7 +162,7 @@ TEST_F(BucketedExecutionTest, join) {
       /*expectedHashExchanges=*/1);
 }
 
-TEST_F(BucketedExecutionTest, semijoin) {
+TEST_P(BucketedExecutionTest, semijoin) {
   addBucketedTable("sj_orders", {"customer_id"}, 128);
   addBucketedTable(
       "sj_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
@@ -166,16 +172,26 @@ TEST_F(BucketedExecutionTest, semijoin) {
         "SELECT * FROM sj_orders WHERE customer_id IN "
         "(SELECT id FROM sj_customers)",
         kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchScan("sj_orders")
-            .hashJoin(
-                matchScan("sj_customers").build(),
-                core::JoinType::kLeftSemiFilter)
-            .bucketed()
-            .fragmentWidth(4)
-            .gather()
-            .build());
+    // V2 lowers WHERE-`IN` to a null-aware kLeftSemiProject (not
+    // kLeftSemiFilter) and rejects bucketing for null-aware existence joins, so
+    // it shuffles both sides instead of keeping the probe bucketed (sound, but
+    // a missed co-location). The V2 check is gated off until WHERE-`IN` folds
+    // to a non-null-aware semi-filter.
+    // TODO: assert V2 co-location once WHERE-`IN` folds to a non-null-aware
+    // semi-filter (v2 lowers it to a null-aware kLeftSemiProject DPhyp won't
+    // co-bucket).
+    if (!useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("sj_orders")
+              .hashJoin(
+                  matchScan("sj_customers").build(),
+                  core::JoinType::kLeftSemiFilter)
+              .bucketed()
+              .fragmentWidth(4)
+              .gather()
+              .build());
+    }
   }
 
   {
@@ -183,21 +199,30 @@ TEST_F(BucketedExecutionTest, semijoin) {
         "SELECT * FROM sj_orders WHERE customer_id NOT IN "
         "(SELECT id FROM sj_customers)",
         kTestConnectorId));
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchScan("sj_orders")
-            .hashJoin(
-                matchScan("sj_customers").build(),
-                core::JoinType::kAnti,
-                {.nullAware = true})
-            .bucketed()
-            .fragmentWidth(4)
-            .gather()
-            .build());
+    // V2 rejects bucketing for the null-aware anti join (a bucketed existence
+    // side would confine a null key to one bucket) and shuffles both sides with
+    // null/any replication instead of co-bucketing. The V2 check is gated off;
+    // DPhyp skips co-bucketing for null-aware edges.
+    // TODO: assert V2 co-location once null-aware existence joins co-bucket
+    // with replication (DPhyp currently skips co-bucketing for null-aware
+    // edges).
+    if (!useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchScan("sj_orders")
+              .hashJoin(
+                  matchScan("sj_customers").build(),
+                  core::JoinType::kAnti,
+                  {.nullAware = true})
+              .bucketed()
+              .fragmentWidth(4)
+              .gather()
+              .build());
+    }
   }
 }
 
-TEST_F(BucketedExecutionTest, aggregation) {
+TEST_P(BucketedExecutionTest, aggregation) {
   testConnector_->addTable(
       "a_orders",
       ROW({"customer_id", "order_date", "amount"},
@@ -290,7 +315,7 @@ TEST_F(BucketedExecutionTest, aggregation) {
   }
 }
 
-TEST_F(BucketedExecutionTest, select) {
+TEST_P(BucketedExecutionTest, select) {
   {
     addBucketedTable("s_one", {"customer_id"}, 1);
     auto plan = planDistributed(
@@ -378,7 +403,7 @@ TEST_F(BucketedExecutionTest, select) {
   }
 }
 
-TEST_F(BucketedExecutionTest, unionall) {
+TEST_P(BucketedExecutionTest, unionall) {
   // gcd(128, 4) = 4.
   addBucketedTable("u_a", {"customer_id"}, 128);
   addBucketedTable(
@@ -438,7 +463,7 @@ TEST_F(BucketedExecutionTest, unionall) {
   }
 }
 
-TEST_F(BucketedExecutionTest, alwaysPlanPartialAggregation) {
+TEST_P(BucketedExecutionTest, alwaysPlanPartialAggregation) {
   addBucketedTable("g_orders", {"customer_id"}, 128);
 
   auto plan = lp::PlanBuilder(makeContext())
@@ -460,7 +485,7 @@ TEST_F(BucketedExecutionTest, alwaysPlanPartialAggregation) {
           .build());
 }
 
-TEST_F(BucketedExecutionTest, mixedJoinOneBucketed) {
+TEST_P(BucketedExecutionTest, mixedJoinOneBucketed) {
   addBucketedTable("m_orders", {"customer_id"}, 8);
   addUnbucketedTable("m_extras");
 
@@ -488,7 +513,7 @@ TEST_F(BucketedExecutionTest, mixedJoinOneBucketed) {
   EXPECT_TRUE(foundMixed);
 }
 
-TEST_F(BucketedExecutionTest, mixedJoinTwoBucketedOneNot) {
+TEST_P(BucketedExecutionTest, mixedJoinTwoBucketedOneNot) {
   addBucketedTable("m2_orders", {"customer_id"}, 8);
   addBucketedTable(
       "m2_customers", {"id"}, 8, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
@@ -519,7 +544,7 @@ TEST_F(BucketedExecutionTest, mixedJoinTwoBucketedOneNot) {
   EXPECT_TRUE(foundMixed);
 }
 
-TEST_F(BucketedExecutionTest, mixedJoinOneBucketedTwoNot) {
+TEST_P(BucketedExecutionTest, mixedJoinOneBucketedTwoNot) {
   addBucketedTable("m3_orders", {"customer_id"}, 8);
   addUnbucketedTable("m3_extras1");
   addUnbucketedTable("m3_extras2");
@@ -549,7 +574,7 @@ TEST_F(BucketedExecutionTest, mixedJoinOneBucketedTwoNot) {
   EXPECT_TRUE(foundMixed);
 }
 
-TEST_F(BucketedExecutionTest, windowOnBucketKey) {
+TEST_P(BucketedExecutionTest, windowOnBucketKey) {
   addBucketedTable("w_orders", {"customer_id"}, 16);
   auto plan = planDistributed(parseSelect(
       "SELECT customer_id, amount, "
@@ -568,7 +593,7 @@ TEST_F(BucketedExecutionTest, windowOnBucketKey) {
   EXPECT_TRUE(foundBucketed);
 }
 
-TEST_F(BucketedExecutionTest, threeWayCoBucketed) {
+TEST_P(BucketedExecutionTest, threeWayCoBucketed) {
   addBucketedTable("tw_a", {"customer_id"}, 16);
   addBucketedTable("tw_b", {"customer_id"}, 8);
   addBucketedTable("tw_c", {"customer_id"}, 4);
@@ -600,7 +625,7 @@ TEST_F(BucketedExecutionTest, threeWayCoBucketed) {
 
 // A chain of inner joins on a shared bucket key fuses into one bucketed
 // fragment: all three scans local, no remote hash exchange.
-TEST_F(BucketedExecutionTest, innerJoinChainFuses) {
+TEST_P(BucketedExecutionTest, innerJoinChainFuses) {
   addBucketedTable("t", {"k"}, 16, ROW({"k"}, BIGINT()));
   addBucketedTable("u", {"k"}, 16, ROW({"k"}, BIGINT()));
   addBucketedTable("v", {"k"}, 16, ROW({"k"}, BIGINT()));
@@ -612,9 +637,12 @@ TEST_F(BucketedExecutionTest, innerJoinChainFuses) {
       "(SELECT v.k FROM u, v WHERE u.k = v.k) sub "
       "WHERE t.k = sub.k";
 
+  // In syntactic order both optimizers co-bucket all three scans into one
+  // fragment as t ⋈ (u ⋈ v).
   optimizerOptions_.syntacticJoinOrder = true;
+  auto syntacticPlan = planDistributed(parseSelect(sql, kTestConnectorId)).plan;
   AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
+      syntacticPlan,
       matchScan("t")
           .hashJoin(
               matchScan("u")
@@ -627,23 +655,42 @@ TEST_F(BucketedExecutionTest, innerJoinChainFuses) {
           .gather()
           .build());
 
+  // Under cost-based ordering each optimizer picks a different (equally valid)
+  // order — v1 u ⋈ v ⋈ t, v2 (t ⋈ u) ⋈ v — but both co-bucket all three into
+  // one fragment.
   optimizerOptions_.syntacticJoinOrder = false;
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
-      matchScan("u")
-          .hashJoin(matchScan("v").build(), core::JoinType::kInner)
-          .hashJoin(matchScan("t").build(), core::JoinType::kInner)
-          .bucketed()
-          .bucketedScans(3)
-          .fragmentWidth(4)
-          .gather()
-          .build());
+  auto reorderedPlan = planDistributed(parseSelect(sql, kTestConnectorId)).plan;
+  if (!useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        reorderedPlan,
+        matchScan("u")
+            .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("t").build(), core::JoinType::kInner)
+            .bucketed()
+            .bucketedScans(3)
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  } else {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        reorderedPlan,
+        matchScan("t")
+            .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+            .bucketed()
+            .bucketedScans(3)
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
 }
 
-// Same shape with a LEFT join: the outer join forms no equivalence, so t cannot
-// bucket-align with the chain and joins across a remote exchange. Regression
-// guard for if outer joins ever start forming equivalences.
-TEST_F(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
+// Same shape with a LEFT join. In V1 the outer join forms no equivalence, so t
+// cannot bucket-align with the chain and joins across a remote exchange
+// (regression guard for if outer joins ever start forming equivalences). V2
+// demotes the LEFT to INNER and fuses, so v1 asserts the shuffled shape and v2
+// the co-location property.
+TEST_P(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
   addBucketedTable("t", {"k"}, 16, ROW({"k"}, BIGINT()));
   addBucketedTable("u", {"k"}, 16, ROW({"k"}, BIGINT()));
   addBucketedTable("v", {"k"}, 16, ROW({"k"}, BIGINT()));
@@ -653,30 +700,68 @@ TEST_F(BucketedExecutionTest, leftJoinChainDoesNotFuse) {
       "(SELECT v.k FROM u LEFT JOIN v ON u.k = v.k) sub "
       "WHERE t.k = sub.k";
 
+  // V1 keeps the LEFT JOIN (its outer null-padding forms no equivalence), so t
+  // can't bucket-align and joins across a remote exchange. V2 demotes the LEFT
+  // to INNER (the outer t.k = v.k rejects null v.k) and co-buckets all three,
+  // in syntactic order t ⋈ (u ⋈ v).
   optimizerOptions_.syntacticJoinOrder = true;
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
-      matchScan("t")
-          .hashJoin(
-              matchScan("u")
-                  .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
-                  .shuffle()
-                  .build(),
-              core::JoinType::kInner)
-          .gather()
-          .build());
+  auto syntacticPlan = planDistributed(parseSelect(sql, kTestConnectorId)).plan;
+  if (!useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        syntacticPlan,
+        matchScan("t")
+            .hashJoin(
+                matchScan("u")
+                    .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+                    .shuffle()
+                    .build(),
+                core::JoinType::kInner)
+            .gather()
+            .build());
+  } else {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        syntacticPlan,
+        matchScan("t")
+            .hashJoin(
+                matchScan("u")
+                    .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+                    .build(),
+                core::JoinType::kInner)
+            .bucketed()
+            .bucketedScans(3)
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
 
+  // Under cost-based ordering v1 still keeps the LEFT (broadcasting t); v2
+  // demotes and co-buckets all three as (t ⋈ u) ⋈ v.
   optimizerOptions_.syntacticJoinOrder = false;
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      planDistributed(parseSelect(sql, kTestConnectorId)).plan,
-      matchScan("u")
-          .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
-          .hashJoin(matchScan("t").broadcast().build(), core::JoinType::kInner)
-          .gather()
-          .build());
+  auto reorderedPlan = planDistributed(parseSelect(sql, kTestConnectorId)).plan;
+  if (!useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        reorderedPlan,
+        matchScan("u")
+            .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
+            .hashJoin(
+                matchScan("t").broadcast().build(), core::JoinType::kInner)
+            .gather()
+            .build());
+  } else {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        reorderedPlan,
+        matchScan("t")
+            .hashJoin(matchScan("u").build(), core::JoinType::kInner)
+            .hashJoin(matchScan("v").build(), core::JoinType::kInner)
+            .bucketed()
+            .bucketedScans(3)
+            .fragmentWidth(4)
+            .gather()
+            .build());
+  }
 }
 
-TEST_F(BucketedExecutionTest, bucketedAggThenBucketedJoin) {
+TEST_P(BucketedExecutionTest, bucketedAggThenBucketedJoin) {
   addBucketedTable("ab_orders", {"customer_id"}, 16);
   addBucketedTable(
       "ab_customers", {"id"}, 16, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
@@ -706,7 +791,7 @@ TEST_F(BucketedExecutionTest, bucketedAggThenBucketedJoin) {
   EXPECT_TRUE(found);
 }
 
-TEST_F(BucketedExecutionTest, bucketedAggThenBroadcastJoin) {
+TEST_P(BucketedExecutionTest, bucketedAggThenBroadcastJoin) {
   addBucketedTable("bc_orders", {"customer_id"}, 16);
   addUnbucketedTable(
       "bc_dim",
@@ -729,7 +814,7 @@ TEST_F(BucketedExecutionTest, bucketedAggThenBroadcastJoin) {
   EXPECT_TRUE(foundBucketedScan);
 }
 
-TEST_F(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
+TEST_P(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
   addBucketedTable("bj_orders", {"customer_id"}, 16);
   addUnbucketedTable(
       "bj_dim",
@@ -751,7 +836,7 @@ TEST_F(BucketedExecutionTest, broadcastJoinThenBucketedAgg) {
   EXPECT_TRUE(foundBucketedScan);
 }
 
-TEST_F(BucketedExecutionTest, greedyBucketed) {
+TEST_P(BucketedExecutionTest, greedyBucketed) {
   addBucketedTable("g_orders", {"customer_id"}, 128);
   addBucketedTable(
       "g_customers", {"id"}, 128, ROW({"id", "name"}, {BIGINT(), VARCHAR()}));
@@ -765,7 +850,7 @@ TEST_F(BucketedExecutionTest, greedyBucketed) {
   expectBucketedFragmentWithWidth(*plan.plan, 4);
 }
 
-TEST_F(BucketedExecutionTest, greedyBucketedWithDimensions) {
+TEST_P(BucketedExecutionTest, greedyBucketedWithDimensions) {
   constexpr int kNumDims = 20;
 
   std::vector<std::string> factColumns{"customer_id"};
@@ -797,6 +882,8 @@ TEST_F(BucketedExecutionTest, greedyBucketedWithDimensions) {
   auto plan = planDistributed(parseSelect(sql, kTestConnectorId));
   expectBucketedFragmentWithWidth(*plan.plan, 4);
 }
+
+AXIOM_INSTANTIATE_V1_V2(BucketedExecutionTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -192,6 +192,7 @@ target_link_libraries(
   axiom_optimizer_tests_sql_test_base
   axiom_common
   axiom_optimizer
+  axiom_optimizer_v2
   axiom_runner_local_runner
   axiom_sql_presto_parser
   axiom_test_connector
@@ -206,8 +207,14 @@ target_link_libraries(
 add_executable(axiom_optimizer_sql_test SqlTest.cpp)
 
 add_test(
-  NAME axiom_optimizer_sql_test
-  COMMAND axiom_optimizer_sql_test
+  NAME axiom_optimizer_sql_test_v1
+  COMMAND axiom_optimizer_sql_test --gtest_filter=V1/*
+  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+add_test(
+  NAME axiom_optimizer_sql_test_v2
+  COMMAND axiom_optimizer_sql_test --gtest_filter=V2/*
   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 

--- a/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
+++ b/axiom/optimizer/tests/HiveBucketedExecutionPlanTest.cpp
@@ -25,8 +25,14 @@ namespace {
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class HiveBucketedExecutionTest : public test::HiveQueriesTestBase {
+class HiveBucketedExecutionTest : public test::HiveQueriesTestBase,
+                                  public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    test::HiveQueriesTestBase::SetUp();
+    useV2_ = GetParam();
+  }
+
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
     createTpchTables({velox::tpch::Table::TBL_CUSTOMER});
@@ -98,7 +104,7 @@ class HiveBucketedExecutionTest : public test::HiveQueriesTestBase {
   std::vector<std::string> tablesToDrop_;
 };
 
-TEST_F(HiveBucketedExecutionTest, join) {
+TEST_P(HiveBucketedExecutionTest, join) {
   createBucketedTable(
       "t", 16, {"c_nationkey"}, "SELECT c_custkey, c_nationkey FROM customer");
   createBucketedTable(
@@ -123,24 +129,28 @@ TEST_F(HiveBucketedExecutionTest, join) {
     assertSameAsSingleNode(logicalPlan, plan);
   }
 
-  // RIGHT join: the build side is repartitioned into the bucketed fragment.
+  // RIGHT join: v1 repartitions the build side into the bucketed fragment; v2
+  // co-buckets both sides instead (both are bucketed on the join key). Results
+  // are checked below.
   {
     auto logicalPlan = parseSelect(
         "SELECT * FROM t RIGHT JOIN u ON t.c_nationkey = u.c_nationkey");
     auto plan = planDistributed(logicalPlan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchHiveScan("t")
-            .hashJoinRight(matchHiveScan("u")
-                               .aliases({"u_nationkey"})
-                               .shuffle({"u_nationkey"})
-                               .build())
-            .project()
-            .bucketed()
-            .fragmentWidth(4)
-            .gather()
-            .project()
-            .build());
+    if (!useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchHiveScan("t")
+              .hashJoinRight(matchHiveScan("u")
+                                 .aliases({"u_nationkey"})
+                                 .shuffle({"u_nationkey"})
+                                 .build())
+              .project()
+              .bucketed()
+              .fragmentWidth(4)
+              .gather()
+              .project()
+              .build());
+    }
     assertSameAsSingleNode(logicalPlan, plan);
   }
 
@@ -200,7 +210,7 @@ TEST_F(HiveBucketedExecutionTest, join) {
   assertSameAsSingleNode(logicalPlan, plan);
 }
 
-TEST_F(HiveBucketedExecutionTest, semijoin) {
+TEST_P(HiveBucketedExecutionTest, semijoin) {
   createBucketedTable(
       "t", 16, {"c_nationkey"}, "SELECT c_custkey, c_nationkey FROM customer");
   createBucketedTable(
@@ -214,36 +224,45 @@ TEST_F(HiveBucketedExecutionTest, semijoin) {
         "SELECT c_custkey, c_nationkey FROM t "
         "WHERE c_nationkey IN (SELECT c_nationkey FROM u)");
     auto plan = planDistributed(logicalPlan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchHiveScan("t")
-            .hashJoinLeftSemiFilter(matchHiveScan("u").build())
-            .bucketed()
-            .fragmentWidth(4)
-            .gather()
-            .build());
+    // v2 plans IN as a null-aware kLeftSemiProject and shuffles+replicates
+    // rather than co-bucketing; its shape is asserted in
+    // BucketedExecutionPlanTest, and its results are checked below.
+    if (!useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchHiveScan("t")
+              .hashJoinLeftSemiFilter(matchHiveScan("u").build())
+              .bucketed()
+              .fragmentWidth(4)
+              .gather()
+              .build());
+    }
     assertSameAsSingleNode(logicalPlan, plan);
   }
 
-  // NOT IN lowers to a null-aware anti join, co-bucketed in one fragment.
   {
     auto logicalPlan = parseSelect(
         "SELECT c_custkey, c_nationkey FROM t "
         "WHERE c_nationkey NOT IN (SELECT c_nationkey FROM u)");
     auto plan = planDistributed(logicalPlan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchHiveScan("t")
-            .hashJoinAnti(matchHiveScan("u").build())
-            .bucketed()
-            .fragmentWidth(4)
-            .gather()
-            .build());
+    // v1 co-buckets the null-aware anti join in one fragment; v2 shuffles+
+    // replicates the existence side instead (a bucketed side confines a NULL
+    // key to one bucket). Results are checked below.
+    if (!useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchHiveScan("t")
+              .hashJoinAnti(matchHiveScan("u").build())
+              .bucketed()
+              .fragmentWidth(4)
+              .gather()
+              .build());
+    }
     assertSameAsSingleNode(logicalPlan, plan);
   }
 }
 
-TEST_F(HiveBucketedExecutionTest, aggregation) {
+TEST_P(HiveBucketedExecutionTest, aggregation) {
   createBucketedTable("t", 16, {"c_nationkey"}, "SELECT * FROM customer");
 
   {
@@ -313,19 +332,24 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
         "SELECT c_nationkey, count(DISTINCT c_mktsegment) FROM t "
         "GROUP BY c_nationkey");
     auto plan = planDistributed(logicalPlan);
-    AXIOM_ASSERT_DISTRIBUTED_PLAN(
-        plan.plan,
-        matchHiveScan("t")
-            .partialAggregation()
-            .localPartition({"c_nationkey", "c_mktsegment"})
-            .finalAggregation()
-            .partialAggregation()
-            .localPartition({"c_nationkey"})
-            .finalAggregation()
-            .bucketed()
-            .fragmentWidth(4)
-            .gather()
-            .build());
+    // v2 computes the distinct in a single co-located aggregation (the input is
+    // already bucketed on the grouping key), not the stacked partial/final
+    // form. Results are checked below.
+    if (!useV2_) {
+      AXIOM_ASSERT_DISTRIBUTED_PLAN(
+          plan.plan,
+          matchHiveScan("t")
+              .partialAggregation()
+              .localPartition({"c_nationkey", "c_mktsegment"})
+              .finalAggregation()
+              .partialAggregation()
+              .localPartition({"c_nationkey"})
+              .finalAggregation()
+              .bucketed()
+              .fragmentWidth(4)
+              .gather()
+              .build());
+    }
     assertSameAsSingleNode(logicalPlan, plan);
   }
 
@@ -369,7 +393,7 @@ TEST_F(HiveBucketedExecutionTest, aggregation) {
   }
 }
 
-TEST_F(HiveBucketedExecutionTest, singleBucket) {
+TEST_P(HiveBucketedExecutionTest, singleBucket) {
   createBucketedTable("t", 1, {"c_nationkey"}, "SELECT * FROM customer");
 
   auto logicalPlan =
@@ -388,7 +412,7 @@ TEST_F(HiveBucketedExecutionTest, singleBucket) {
   assertSameAsSingleNode(logicalPlan, plan);
 }
 
-TEST_F(HiveBucketedExecutionTest, joinDifferentBucketCounts) {
+TEST_P(HiveBucketedExecutionTest, joinDifferentBucketCounts) {
   // 8 divides 16, so the 16-bucket and 8-bucket sides share a compatible
   // bucketing and co-fragment without a shuffle.
   createBucketedTable(
@@ -417,7 +441,7 @@ TEST_F(HiveBucketedExecutionTest, joinDifferentBucketCounts) {
   assertSameAsSingleNode(logicalPlan, plan);
 }
 
-TEST_F(HiveBucketedExecutionTest, compositeBucketKeys) {
+TEST_P(HiveBucketedExecutionTest, compositeBucketKeys) {
   createBucketedTable(
       "t", 16, {"c_nationkey", "c_mktsegment"}, "SELECT * FROM customer");
 
@@ -462,7 +486,7 @@ TEST_F(HiveBucketedExecutionTest, compositeBucketKeys) {
   }
 }
 
-TEST_F(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
+TEST_P(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
   // 8 buckets, 5 workers: fragment width clamps to 5.
   createBucketedTable(
       "t", 8, {"c_nationkey"}, "SELECT c_custkey, c_nationkey FROM customer");
@@ -508,7 +532,7 @@ TEST_F(HiveBucketedExecutionTest, widthClampsToNumWorkers) {
   }
 }
 
-TEST_F(HiveBucketedExecutionTest, copartitionedJoinIndivisibleWorkers) {
+TEST_P(HiveBucketedExecutionTest, copartitionedJoinIndivisibleWorkers) {
   // 3 workers divide neither bucket count (16, 8); the co-bucketed join must
   // still return all matching rows.
   createBucketedTable(
@@ -534,7 +558,7 @@ TEST_F(HiveBucketedExecutionTest, copartitionedJoinIndivisibleWorkers) {
   assertSameAsSingleNode(logicalPlan, plan);
 }
 
-TEST_F(HiveBucketedExecutionTest, unionall) {
+TEST_P(HiveBucketedExecutionTest, unionall) {
   // The two inputs bucket on different keys, so they cannot co-partition; the
   // union reshuffles on the grouping key before aggregating.
   createBucketedTable(
@@ -549,19 +573,27 @@ TEST_F(HiveBucketedExecutionTest, unionall) {
       "  SELECT c_custkey AS c_nationkey FROM u"
       ") GROUP BY 1");
   auto plan = planDistributed(logicalPlan);
-  AXIOM_ASSERT_DISTRIBUTED_PLAN(
-      plan.plan,
-      matchHiveScan("t")
-          .localPartition(matchHiveScan("u").project().build())
-          .bucketed()
-          .fragmentWidth(4)
-          .shuffle({"c_nationkey"})
-          .localPartition({"c_nationkey"})
-          .singleAggregation({"c_nationkey"}, {"count(*)"})
-          .gather()
-          .build());
+  // Each leg contributes its own bucket column as the union key (t:
+  // c_nationkey, u: c_custkey), which hash identically, so v2 co-buckets the
+  // legs and aggregates without the remote reshuffle v1 adds. Results are
+  // checked below.
+  if (!useV2_) {
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(
+        plan.plan,
+        matchHiveScan("t")
+            .localPartition(matchHiveScan("u").project().build())
+            .bucketed()
+            .fragmentWidth(4)
+            .shuffle({"c_nationkey"})
+            .localPartition({"c_nationkey"})
+            .singleAggregation({"c_nationkey"}, {"count(*)"})
+            .gather()
+            .build());
+  }
   assertSameAsSingleNode(logicalPlan, plan);
 }
+
+AXIOM_INSTANTIATE_V1_V2(HiveBucketedExecutionTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -25,6 +25,7 @@
 #include "axiom/optimizer/Plan.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/optimizer/tests/TestDataPath.h"
+#include "axiom/optimizer/v2/Optimize.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "velox/dwio/common/tests/utils/DataFiles.h"
 #include "velox/exec/tests/utils/LocalExchangeSource.h"
@@ -315,28 +316,39 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
     }
   };
 
-  optimizer::Optimization opt(
-      makeOptimizerSession(
-          queryCtx->queryId(), optimizerOptions.value_or(optimizerOptions_)),
-      makeRunnerSession(queryCtx->queryId()),
-      *plan,
-      schemaResolver,
-      *history_,
-      queryCtx,
-      evaluator,
-      options);
-  if (planPath != nullptr) {
-    *planPath << "Query Graph:\n\n" << opt.rootDt()->toString() << "\n\n";
+  auto session = makeOptimizerSession(
+      queryCtx->queryId(), optimizerOptions.value_or(optimizerOptions_));
+
+  optimizer::PlanAndStats planAndStats;
+  if (useV2_) {
+    planAndStats =
+        v2::optimize(*plan, schemaResolver, *session, evaluator, options);
+  } else {
+    optimizer::Optimization opt(
+        session,
+        makeRunnerSession(queryCtx->queryId()),
+        *plan,
+        schemaResolver,
+        *history_,
+        queryCtx,
+        evaluator,
+        options);
+    // The query-graph and optimized-plan sections are v1-only; v2 exposes
+    // neither here.
+    if (planPath != nullptr) {
+      *planPath << "Query Graph:\n\n" << opt.rootDt()->toString() << "\n\n";
+    }
+
+    auto best = opt.bestPlan();
+    if (planPath != nullptr) {
+      *planPath << "Optimized plan (oneline):\n\n"
+                << best->op->toOneline() << "\n\n";
+      *planPath << "Optimized plan:\n\n" << best->op->toString() << "\n\n";
+    }
+
+    planAndStats = opt.toVeloxPlan(best->op);
   }
 
-  auto best = opt.bestPlan();
-  if (planPath != nullptr) {
-    *planPath << "Optimized plan (oneline):\n\n"
-              << best->op->toOneline() << "\n\n";
-    *planPath << "Optimized plan:\n\n" << best->op->toString() << "\n\n";
-  }
-
-  auto planAndStats = opt.toVeloxPlan(best->op);
   if (planPath != nullptr) {
     *planPath << "Executable Velox plan:\n\n" << planAndStats.plan->toString();
     *planPath << "___END___\n";

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -20,6 +20,7 @@
 #include <gflags/gflags.h>
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/OptimizerSession.h"
 #include "axiom/optimizer/RelationOp.h"
 #include "axiom/optimizer/VeloxHistory.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
@@ -262,6 +263,11 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
 
   OptimizerOptions optimizerOptions_;
 
+  // When true, `optimize()` routes through the v2 optimizer pipeline instead of
+  // v1. Lets one fixture run the same tests through either optimizer (e.g. set
+  // from a TEST_P parameter). Default false = v1.
+  bool useV2_{false};
+
   std::shared_ptr<connector::TestConnector> testConnector_;
 
  private:
@@ -356,3 +362,18 @@ inline auto in(
     ASSERT_TRUE((matcher)->match(*_axiom_plan_))     \
         << _axiom_plan_->toString(true);             \
   }
+
+// Instantiates a value-parameterized (`TEST_P`) suite for both optimizers,
+// producing `V1/<suite>.<case>/_` and `V2/<suite>.<case>/_`. The fixture must
+// derive from `WithParamInterface<bool>` and set `useV2_ = GetParam()` in
+// `SetUp`; `false` selects v1, `true` v2. The trailing `_` is gtest's mandatory
+// value-parameter segment.
+#define AXIOM_INSTANTIATE_V1_V2(test_suite)                       \
+  INSTANTIATE_TEST_SUITE_P(                                       \
+      V1, test_suite, ::testing::Values(false), [](const auto&) { \
+        return std::string("_");                                  \
+      });                                                         \
+  INSTANTIATE_TEST_SUITE_P(                                       \
+      V2, test_suite, ::testing::Values(true), [](const auto&) {  \
+        return std::string("_");                                  \
+      })

--- a/axiom/optimizer/tests/SqlFile.cpp
+++ b/axiom/optimizer/tests/SqlFile.cpp
@@ -29,7 +29,6 @@ const auto& typeNames() {
       {QueryEntry::Type::kResults, "results"},
       {QueryEntry::Type::kOrdered, "ordered"},
       {QueryEntry::Type::kCount, "count"},
-      {QueryEntry::Type::kError, "error"},
   };
   return kNames;
 }
@@ -121,11 +120,15 @@ std::vector<QueryEntry> parseQueries(
     }
 
     if (!sqlLines.empty() && !disabled) {
+      // `-- columns` checks output column names, so it needs a result set from
+      // at least one optimizer: reject it only for a count query or one that
+      // fails in both v1 and v2.
       VELOX_CHECK(
           !current.checkColumnNames ||
-              (current.type == QueryEntry::Type::kResults ||
-               current.type == QueryEntry::Type::kOrdered),
-          "'-- columns' can only be used with 'results' or 'ordered' queries at line {}",
+              ((current.type == QueryEntry::Type::kResults ||
+                current.type == QueryEntry::Type::kOrdered) &&
+               !current.expectError()),
+          "'-- columns' can only be used with 'results' or 'ordered' queries that succeed in at least one optimizer at line {}",
           sqlStartLine);
 
       current.sql = std::move(sqlLines);
@@ -168,8 +171,33 @@ std::vector<QueryEntry> parseQueries(
         current.type = QueryEntry::Type::kCount;
         current.expectedCount = std::stoull(annotation.substr(6));
       } else if (annotation.substr(0, 7) == "error: ") {
-        current.type = QueryEntry::Type::kError;
+        VELOX_USER_CHECK(
+            current.expectedErrorV1.empty() && current.expectedErrorV2.empty(),
+            "-- error: cannot be combined with -- error_v1:/-- error_v2: (line {})",
+            lineNumber);
         current.expectedError = annotation.substr(7);
+        current.expectedErrorV1 = current.expectedError;
+        current.expectedErrorV2 = current.expectedError;
+      } else if (annotation.substr(0, 10) == "error_v1: ") {
+        VELOX_USER_CHECK(
+            current.expectedError.empty(),
+            "-- error_v1: cannot be combined with -- error: (line {})",
+            lineNumber);
+        VELOX_USER_CHECK(
+            current.expectedErrorV1.empty(),
+            "duplicate -- error_v1: (line {})",
+            lineNumber);
+        current.expectedErrorV1 = annotation.substr(10);
+      } else if (annotation.substr(0, 10) == "error_v2: ") {
+        VELOX_USER_CHECK(
+            current.expectedError.empty(),
+            "-- error_v2: cannot be combined with -- error: (line {})",
+            lineNumber);
+        VELOX_USER_CHECK(
+            current.expectedErrorV2.empty(),
+            "duplicate -- error_v2: (line {})",
+            lineNumber);
+        current.expectedErrorV2 = annotation.substr(10);
       } else if (annotation.substr(0, 8) == "duckdb: ") {
         current.duckDbSql = annotation.substr(8);
       } else if (annotation == "columns") {

--- a/axiom/optimizer/tests/SqlFile.h
+++ b/axiom/optimizer/tests/SqlFile.h
@@ -29,7 +29,7 @@ namespace facebook::axiom::optimizer::test {
 /// Represents a single SQL query parsed from a test file, along with its
 /// assertion type and any annotation parameters.
 struct QueryEntry {
-  enum class Type { kResults, kOrdered, kCount, kError };
+  enum class Type { kResults, kOrdered, kCount };
 
   AXIOM_DECLARE_EMBEDDED_ENUM_NAME(Type)
 
@@ -37,9 +37,24 @@ struct QueryEntry {
   Type type{Type::kResults};
   std::optional<std::string> duckDbSql;
   uint64_t expectedCount{0};
+  /// Set by `-- error: msg`: both optimizers expect this error. Mutually
+  /// exclusive with `-- error_v1:`/`-- error_v2:`; also mirrored into
+  /// `expectedErrorV1` and `expectedErrorV2`.
   std::string expectedError;
+  /// Per-optimizer expected error, set by `-- error_v1:` / `-- error_v2:` (or
+  /// by `-- error:`). An empty field means that optimizer is expected to
+  /// succeed, and its results are compared against DuckDB.
+  std::string expectedErrorV1;
+  std::string expectedErrorV2;
   bool checkColumnNames{false};
   int32_t lineNumber{0};
+
+  /// True if the query expects an error in both optimizers, so no run produces
+  /// a result set. A query that fails in only one optimizer still yields
+  /// results in the other.
+  bool expectError() const {
+    return !expectedErrorV1.empty() && !expectedErrorV2.empty();
+  }
 };
 
 /// Represents the contents of a parsed .sql test file: setup statements
@@ -77,7 +92,10 @@ struct SqlFile {
   /// before each query may carry annotations:
   ///   -- ordered         -> assertOrderedResults
   ///   -- count N         -> assertResultCount(sql, N)
-  ///   -- error: message  -> assertFailure(sql, "message")
+  ///   -- error: message     -> both optimizers expect this error
+  ///   -- error_v1: message  -> v1 expects this error (v2 unaffected)
+  ///   -- error_v2: message  -> v2 expects this error (v1 unaffected)
+  /// `-- error:` cannot be combined with `-- error_v1:`/`-- error_v2:`.
   ///   -- duckdb: sql     -> use alternate SQL for DuckDB comparison
   ///   -- columns         -> verify column names match DuckDB
   ///   -- disabled        -> skip this query

--- a/axiom/optimizer/tests/SqlFileTest.cpp
+++ b/axiom/optimizer/tests/SqlFileTest.cpp
@@ -92,8 +92,46 @@ TEST_F(SqlFileTest, error) {
       "-- error: Column not found\n"
       "SELECT missing FROM t");
   ASSERT_THAT(entries, testing::SizeIs(1));
-  EXPECT_EQ(entries[0].type, QueryEntry::Type::kError);
   EXPECT_EQ(entries[0].expectedError, "Column not found");
+  // `-- error:` sets both per-optimizer fields.
+  EXPECT_EQ(entries[0].expectedErrorV1, "Column not found");
+  EXPECT_EQ(entries[0].expectedErrorV2, "Column not found");
+}
+
+TEST_F(SqlFileTest, errorPerSuite) {
+  auto entries = parseQueries(
+      "-- error_v1: v1 message\n"
+      "-- error_v2: v2 message\n"
+      "SELECT bad FROM t");
+  ASSERT_THAT(entries, testing::SizeIs(1));
+  EXPECT_EQ(entries[0].type, QueryEntry::Type::kResults);
+  EXPECT_EQ(entries[0].expectedError, "");
+  EXPECT_EQ(entries[0].expectedErrorV1, "v1 message");
+  EXPECT_EQ(entries[0].expectedErrorV2, "v2 message");
+}
+
+TEST_F(SqlFileTest, errorV1Only) {
+  auto entries = parseQueries(
+      "-- error_v1: v1 message\n"
+      "SELECT bad FROM t");
+  ASSERT_THAT(entries, testing::SizeIs(1));
+  EXPECT_EQ(entries[0].expectedErrorV1, "v1 message");
+  EXPECT_EQ(entries[0].expectedErrorV2, "");
+}
+
+TEST_F(SqlFileTest, errorAndPerSuiteAreExclusive) {
+  VELOX_ASSERT_THROW(
+      parseQueries(
+          "-- error: both\n"
+          "-- error_v1: v1 message\n"
+          "SELECT bad FROM t"),
+      "cannot be combined");
+  VELOX_ASSERT_THROW(
+      parseQueries(
+          "-- error_v2: v2 message\n"
+          "-- error: both\n"
+          "SELECT bad FROM t"),
+      "cannot be combined");
 }
 
 TEST_F(SqlFileTest, duckdb) {

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -31,13 +31,10 @@ namespace {
 
 using namespace facebook::velox;
 
-// Process-wide setup/teardown for the SqlTest binary. SqlTest<Name>'s
-// per-suite SetUpTestCase shadows the inherited SqlTestBase::SetUpTestCase,
-// so the gtest-driven once-per-process initialization that a non-templated
-// SqlTestBase consumer would otherwise get is moved here. gtest's
-// Environment lifecycle fires once per RUN_ALL_TESTS invocation and only
-// when tests actually run, which makes it the right home for non-idempotent
-// global state (function registries, SharedArbitrator factory, etc.).
+// Runs process-global, non-idempotent initialization (function registries,
+// SharedArbitrator factory, etc.) exactly once per RUN_ALL_TESTS. The
+// per-suite SetUpTestCase below shadows SqlTestBase::SetUpTestCase, so this
+// global init cannot live there.
 class SqlTestEnvironment : public testing::Environment {
  public:
   void SetUp() override {
@@ -62,22 +59,23 @@ struct FileName {
   char value[N]{};
 };
 
-// Per-.sql-file gtest fixture, parameterized by the file's base name. Each
-// distinct base name instantiates a distinct fixture class, giving every
-// .sql file its own SetUpTestCase/TearDownTestCase scope and its own
-// suite-scoped state: a standalone MemoryManager (separate from the
-// per-test singleton that OperatorTestBase resets), a TestConnector,
-// reference tables installed once, and a DuckDbQueryRunner.
+// Per-.sql-file, per-optimizer gtest fixture. Each (file, optimizer) pair is a
+// distinct instantiation with its own SetUpTestCase/TearDownTestCase scope and
+// its own suite-scoped state: a standalone MemoryManager (separate from the
+// per-test singleton that OperatorTestBase resets), a TestConnector, reference
+// tables installed once, and a DuckDbQueryRunner. 'UseV2' selects the optimizer
+// the queries run through; results are compared against DuckDB either way.
 //
-// The standalone MemoryManager is the key that lets fixture state survive
-// the per-test resetMemory() call: pools created from it are not bound to
-// the singleton, so testingSetInstance does not invalidate them.
-template <FileName Name>
+// The standalone MemoryManager is the key that lets fixture state survive the
+// per-test resetMemory() call: pools created from it are not bound to the
+// singleton, so testingSetInstance does not invalidate them.
+template <FileName Name, bool UseV2>
 class SqlTest : public SqlTestBase {
  public:
   SqlTest(QueryEntry entry, bool syntacticJoinOrder)
       : entry_(std::move(entry)) {
     this->syntacticJoinOrder_ = syntacticJoinOrder;
+    this->useV2_ = UseV2;
   }
 
   // Uses SetUpTestCase / TearDownTestCase rather than the modern
@@ -111,12 +109,17 @@ class SqlTest : public SqlTestBase {
           *suiteConnector_,
           *suiteDuckDbRunner_,
           [](const logical_plan::LogicalPlanNodePtr& plan) {
-            return makeLocalRunner(
+            const auto buildRunner =
+                UseV2 ? makeLocalRunnerV2 : makeLocalRunner;
+            return buildRunner(
                 plan,
                 suiteExecutor_.get(),
                 /*asyncDataCache=*/nullptr,
                 suiteRootPool_,
-                suiteOptimizerPool_);
+                suiteOptimizerPool_,
+                /*numWorkers=*/4,
+                /*numDrivers=*/4,
+                /*syntacticJoinOrder=*/false);
           });
     }
   }
@@ -132,10 +135,7 @@ class SqlTest : public SqlTestBase {
     suiteManager_.reset();
   }
 
-  // Setup statements parsed once at registration time and consumed by
-  // SetUpTestCase. registerQueryFile() populates this when it parses the
-  // file to register individual tests. Public so the free-function
-  // registerQueryFile() can assign it.
+  // Setup statements consumed by SetUpTestCase, populated at registration time.
   static std::vector<std::string> setupStatements;
 
  protected:
@@ -149,8 +149,7 @@ class SqlTest : public SqlTestBase {
 
   void SetUp() override {
     SqlTestBase::SetUp();
-    // The base class skipped per-test connector creation because of the
-    // override above; point connector_ at the suite-scoped one.
+    // connector_ is suite-scoped, set once per suite rather than per test.
     connector_ = suiteConnector_;
   }
 
@@ -161,7 +160,13 @@ class SqlTest : public SqlTestBase {
   }
 
   void TestBody() override {
+    const std::string& expectedError =
+        UseV2 ? entry_.expectedErrorV2 : entry_.expectedErrorV1;
     try {
+      if (!expectedError.empty()) {
+        assertFailure(entry_.sql, expectedError);
+        return;
+      }
       switch (entry_.type) {
         case QueryEntry::Type::kResults:
           assertResults(entry_.sql, entry_.checkColumnNames, entry_.duckDbSql);
@@ -172,9 +177,6 @@ class SqlTest : public SqlTestBase {
           break;
         case QueryEntry::Type::kCount:
           assertResultCount(entry_.sql, entry_.expectedCount);
-          break;
-        case QueryEntry::Type::kError:
-          assertFailure(entry_.sql, entry_.expectedError);
           break;
       }
     } catch (const std::exception& e) {
@@ -193,31 +195,61 @@ class SqlTest : public SqlTestBase {
   QueryEntry entry_;
 };
 
-template <FileName Name>
-std::unique_ptr<memory::MemoryManager> SqlTest<Name>::suiteManager_;
+template <FileName Name, bool UseV2>
+std::unique_ptr<memory::MemoryManager> SqlTest<Name, UseV2>::suiteManager_;
 
-template <FileName Name>
-std::shared_ptr<folly::CPUThreadPoolExecutor> SqlTest<Name>::suiteExecutor_;
+template <FileName Name, bool UseV2>
+std::shared_ptr<folly::CPUThreadPoolExecutor>
+    SqlTest<Name, UseV2>::suiteExecutor_;
 
-template <FileName Name>
-std::shared_ptr<memory::MemoryPool> SqlTest<Name>::suiteRootPool_;
+template <FileName Name, bool UseV2>
+std::shared_ptr<memory::MemoryPool> SqlTest<Name, UseV2>::suiteRootPool_;
 
-template <FileName Name>
-std::shared_ptr<memory::MemoryPool> SqlTest<Name>::suiteOptimizerPool_;
+template <FileName Name, bool UseV2>
+std::shared_ptr<memory::MemoryPool> SqlTest<Name, UseV2>::suiteOptimizerPool_;
 
-template <FileName Name>
-std::shared_ptr<connector::TestConnector> SqlTest<Name>::suiteConnector_;
+template <FileName Name, bool UseV2>
+std::shared_ptr<connector::TestConnector> SqlTest<Name, UseV2>::suiteConnector_;
 
-template <FileName Name>
+template <FileName Name, bool UseV2>
 std::unique_ptr<exec::test::DuckDbQueryRunner>
-    SqlTest<Name>::suiteDuckDbRunner_;
+    SqlTest<Name, UseV2>::suiteDuckDbRunner_;
 
-template <FileName Name>
-std::vector<std::string> SqlTest<Name>::setupStatements;
+template <FileName Name, bool UseV2>
+std::vector<std::string> SqlTest<Name, UseV2>::setupStatements;
 
-// Registers all queries from a .sql file as individual gtest tests under a
-// per-file fixture class 'SqlTest<Name>'. Each test instance picks its
-// QueryEntry comes from the closure captured at RegisterTest time.
+// Registers every query in 'file' as an individual gtest test under the suite
+// 'V1/SqlTest_<name>' or 'V2/SqlTest_<name>' (per UseV2). Each query runs under
+// both cost-based (default) and syntactic join ordering.
+template <FileName Name, bool UseV2>
+void registerVariant(const SqlFile& file, const std::string& path) {
+  SqlTest<Name, UseV2>::setupStatements = file.setupStatements;
+
+  const auto suiteName =
+      fmt::format("{}/SqlTest_{}", UseV2 ? "V2" : "V1", Name.value);
+
+  for (const auto& entry : file.entries) {
+    for (const bool syntacticJoinOrder : {false, true}) {
+      auto testName = syntacticJoinOrder
+          ? fmt::format("l{}_syntactic", entry.lineNumber)
+          : fmt::format("l{}", entry.lineNumber);
+      testing::RegisterTest(
+          suiteName.c_str(),
+          testName.c_str(),
+          /*type_param=*/nullptr,
+          /*value_param=*/nullptr,
+          path.c_str(),
+          entry.lineNumber,
+          [capturedEntry = entry,
+           syntacticJoinOrder]() -> SqlTest<Name, UseV2>* {
+            return new SqlTest<Name, UseV2>(capturedEntry, syntacticJoinOrder);
+          });
+    }
+  }
+}
+
+// Parses a .sql file and registers its queries under both the v1 and v2
+// suites.
 template <FileName Name>
 void registerQueryFile() {
   const std::string baseName = Name.value;
@@ -229,31 +261,8 @@ void registerQueryFile() {
   auto baseDir = std::filesystem::path(path).parent_path().string();
   auto file = SqlFile::parse(content, baseDir);
 
-  // Stash the setup statements where SetUpTestCase can find them.
-  SqlTest<Name>::setupStatements = std::move(file.setupStatements);
-
-  auto suiteName = fmt::format("SqlTest_{}", baseName);
-
-  // Run every query both with cost-based join ordering (the default) and with
-  // syntactic join ordering, so the optimizer is exercised under both
-  // strategies and must produce the same correct results.
-  for (const auto& entry : file.entries) {
-    for (const bool syntacticJoinOrder : {false, true}) {
-      auto testName = syntacticJoinOrder
-          ? fmt::format("{}_l{}_syntactic", baseName, entry.lineNumber)
-          : fmt::format("{}_l{}", baseName, entry.lineNumber);
-      testing::RegisterTest(
-          suiteName.c_str(),
-          testName.c_str(),
-          /*type_param=*/nullptr,
-          /*value_param=*/nullptr,
-          path.c_str(),
-          entry.lineNumber,
-          [capturedEntry = entry, syntacticJoinOrder]() -> SqlTest<Name>* {
-            return new SqlTest<Name>(capturedEntry, syntacticJoinOrder);
-          });
-    }
-  }
+  registerVariant<Name, false>(file, path);
+  registerVariant<Name, true>(file, path);
 }
 
 } // namespace
@@ -267,22 +276,22 @@ int main(int argc, char** argv) {
 
   testing::AddGlobalTestEnvironment(new SqlTestEnvironment);
 
-  registerQueryFile<"basic">();
-  registerQueryFile<"cte">();
-  registerQueryFile<"join">();
-  registerQueryFile<"subquery">();
-  registerQueryFile<"window">();
-  registerQueryFile<"set">();
-  registerQueryFile<"limit">();
   registerQueryFile<"aggregation">();
-  registerQueryFile<"subfield">();
-  registerQueryFile<"nullif">();
+  registerQueryFile<"basic">();
   registerQueryFile<"coercion">();
+  registerQueryFile<"cte">();
   registerQueryFile<"distinctAggregation">();
+  registerQueryFile<"groupingsets">();
+  registerQueryFile<"join">();
+  registerQueryFile<"limit">();
+  registerQueryFile<"nondeterministic">();
+  registerQueryFile<"nullif">();
+  registerQueryFile<"set">();
+  registerQueryFile<"subfield">();
+  registerQueryFile<"subquery">();
   registerQueryFile<"unionAll">();
   registerQueryFile<"unionAllFlatten">();
-  registerQueryFile<"groupingsets">();
-  registerQueryFile<"nondeterministic">();
+  registerQueryFile<"window">();
 
   return RUN_ALL_TESTS();
 }

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -21,6 +21,7 @@
 #include "axiom/optimizer/FunctionRegistry.h"
 #include "axiom/optimizer/Optimization.h"
 #include "axiom/optimizer/VeloxHistory.h"
+#include "axiom/optimizer/v2/Optimize.h"
 #include "axiom/runner/LocalRunner.h"
 #include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/SqlStatement.h"
@@ -90,7 +91,13 @@ void SqlTestBase::createTable(
   duckDbRunner().createTable(name, data);
 }
 
-std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
+namespace {
+// Shared setup for makeLocalRunner / makeLocalRunnerV2: builds the query and
+// optimizer contexts, sessions, and plan options, invokes 'plan' to optimize
+// through the chosen optimizer, and wraps the result in a LocalRunner. 'plan'
+// receives the prepared context and returns the executable plan.
+template <typename PlanFn>
+std::shared_ptr<runner::LocalRunner> makeLocalRunnerImpl(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     folly::Executor* executor,
     cache::AsyncDataCache* asyncDataCache,
@@ -98,7 +105,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
     const std::shared_ptr<memory::MemoryPool>& optimizerPool,
     int32_t numWorkers,
     int32_t numDrivers,
-    bool syntacticJoinOrder) {
+    bool syntacticJoinOrder,
+    PlanFn plan) {
   static std::atomic<int32_t> queryCounter{0};
   auto queryId = fmt::format("sql_test_{}", ++queryCounter);
   auto queryCtx = core::QueryCtx::create(
@@ -121,7 +129,6 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
 
   connector::SchemaResolver schemaResolver{
       connector::ConnectorMetadataRegistry::global()};
-  VeloxHistory history;
 
   MultiFragmentPlan::Options options;
   options.numWorkers = numWorkers;
@@ -135,18 +142,14 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
   auto runnerSession = std::make_shared<runner::RunnerSession>(
       queryId, "test", runner::Properties{}, connector::ConnectorProperties{});
 
-  Optimization optimization(
-      optimizerSession,
-      runnerSession,
+  auto planAndStats = plan(
       *logicalPlan,
       schemaResolver,
-      history,
-      queryCtx,
       evaluator,
-      options);
-
-  auto best = optimization.bestPlan();
-  auto planAndStats = optimization.toVeloxPlan(best->op);
+      options,
+      optimizerSession,
+      runnerSession,
+      queryCtx);
 
   static QueryRuntimeStats noopStats;
   return std::make_shared<runner::LocalRunner>(
@@ -158,6 +161,77 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
       optimizerPool,
       /*baseSpillDirectory=*/"",
       noopStats);
+}
+} // namespace
+
+std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunner(
+    const logical_plan::LogicalPlanNodePtr& logicalPlan,
+    folly::Executor* executor,
+    cache::AsyncDataCache* asyncDataCache,
+    const std::shared_ptr<memory::MemoryPool>& rootPool,
+    const std::shared_ptr<memory::MemoryPool>& optimizerPool,
+    int32_t numWorkers,
+    int32_t numDrivers,
+    bool syntacticJoinOrder) {
+  return makeLocalRunnerImpl(
+      logicalPlan,
+      executor,
+      asyncDataCache,
+      rootPool,
+      optimizerPool,
+      numWorkers,
+      numDrivers,
+      syntacticJoinOrder,
+      [](const logical_plan::LogicalPlanNode& logicalPlan,
+         const connector::SchemaResolver& schemaResolver,
+         velox::core::ExpressionEvaluator& evaluator,
+         const MultiFragmentPlan::Options& options,
+         const std::shared_ptr<OptimizerSession>& optimizerSession,
+         const std::shared_ptr<runner::RunnerSession>& runnerSession,
+         const std::shared_ptr<core::QueryCtx>& queryCtx) {
+        VeloxHistory history;
+        Optimization optimization(
+            optimizerSession,
+            runnerSession,
+            logicalPlan,
+            schemaResolver,
+            history,
+            queryCtx,
+            evaluator,
+            options);
+        auto best = optimization.bestPlan();
+        return optimization.toVeloxPlan(best->op);
+      });
+}
+
+std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunnerV2(
+    const logical_plan::LogicalPlanNodePtr& logicalPlan,
+    folly::Executor* executor,
+    cache::AsyncDataCache* asyncDataCache,
+    const std::shared_ptr<memory::MemoryPool>& rootPool,
+    const std::shared_ptr<memory::MemoryPool>& optimizerPool,
+    int32_t numWorkers,
+    int32_t numDrivers,
+    bool syntacticJoinOrder) {
+  return makeLocalRunnerImpl(
+      logicalPlan,
+      executor,
+      asyncDataCache,
+      rootPool,
+      optimizerPool,
+      numWorkers,
+      numDrivers,
+      syntacticJoinOrder,
+      [](const logical_plan::LogicalPlanNode& logicalPlan,
+         const connector::SchemaResolver& schemaResolver,
+         velox::core::ExpressionEvaluator& evaluator,
+         const MultiFragmentPlan::Options& options,
+         const std::shared_ptr<OptimizerSession>& optimizerSession,
+         const std::shared_ptr<runner::RunnerSession>& /*runnerSession*/,
+         const std::shared_ptr<core::QueryCtx>& /*queryCtx*/) {
+        return v2::optimize(
+            logicalPlan, schemaResolver, *optimizerSession, evaluator, options);
+      });
 }
 
 void SqlTestBase::runSetupStatement(
@@ -176,7 +250,7 @@ void SqlTestBase::runSetupStatement(
           /*user=*/"test",
           ::axiom::sql::presto::ParserOptions{},
           connector::ConnectorProperties{}));
-  auto stmt = parser.parse(sql, /*enableTracing=*/true);
+  auto stmt = parser.parse(sql);
 
   if (stmt->isCreateTable()) {
     const auto& create =
@@ -204,16 +278,6 @@ void SqlTestBase::runSetupStatement(
   runner->drain([](RowVectorPtr) {});
 }
 
-void SqlTestBase::runSetupStatement(const std::string& sql) {
-  runSetupStatement(
-      sql,
-      *connector_,
-      duckDbRunner(),
-      [this](const logical_plan::LogicalPlanNodePtr& plan) {
-        return makeRunner(plan);
-      });
-}
-
 std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
     std::string_view sql) {
   // Parse SQL to logical plan.
@@ -236,7 +300,8 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
 
 std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
     const logical_plan::LogicalPlanNodePtr& logicalPlan) {
-  return makeLocalRunner(
+  const auto buildRunner = useV2_ ? makeLocalRunnerV2 : makeLocalRunner;
+  return buildRunner(
       logicalPlan,
       executor_.get(),
       cache::AsyncDataCache::getInstance(),

--- a/axiom/optimizer/tests/SqlTestBase.h
+++ b/axiom/optimizer/tests/SqlTestBase.h
@@ -81,10 +81,7 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   ///     RowVector (one TestConnector split) and runs the same statement
   ///     in DuckDB.
   /// Each INSERT to the same table produces a separate split, mirroring
-  /// the multi-RowVector createTable shape.
-  void runSetupStatement(const std::string& sql);
-
-  /// Static variant of runSetupStatement. The caller supplies the
+  /// the multi-RowVector createTable shape. The caller supplies the
   /// connector, the DuckDB runner, and a factory that builds a LocalRunner
   /// for an INSERT / CTAS plan. Suite-scoped fixtures use this in
   /// SetUpTestSuite to install reference tables once into a standalone
@@ -101,6 +98,18 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   /// MemoryManager / executor / AsyncDataCache into a runnerFactory for
   /// runSetupStatement.
   static std::shared_ptr<runner::LocalRunner> makeLocalRunner(
+      const logical_plan::LogicalPlanNodePtr& logicalPlan,
+      folly::Executor* executor,
+      velox::cache::AsyncDataCache* asyncDataCache,
+      const std::shared_ptr<velox::memory::MemoryPool>& rootPool,
+      const std::shared_ptr<velox::memory::MemoryPool>& optimizerPool,
+      int32_t numWorkers = 4,
+      int32_t numDrivers = 4,
+      bool syntacticJoinOrder = false);
+
+  /// Like makeLocalRunner, but optimizes 'logicalPlan' through the v2
+  /// optimizer pipeline (axiom/optimizer/v2) instead of v1.
+  static std::shared_ptr<runner::LocalRunner> makeLocalRunnerV2(
       const logical_plan::LogicalPlanNodePtr& logicalPlan,
       folly::Executor* executor,
       velox::cache::AsyncDataCache* asyncDataCache,
@@ -143,6 +152,10 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   // placing tables in the order they appear in the query.
   bool syntacticJoinOrder_{false};
 
+  // When true, makeRunner routes queries through the v2 optimizer
+  // (axiom/optimizer/v2) instead of v1.
+  bool useV2_{false};
+
   // Override to false in subclasses that manage the TestConnector lifecycle
   // at suite scope (i.e., create and register the connector once per
   // fixture class in SetUpTestSuite, not once per test in SetUp).
@@ -172,14 +185,17 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   // returns a LocalRunner to iterate over.
   std::shared_ptr<runner::LocalRunner> makeRunner(std::string_view sql);
 
-  // Builds a LocalRunner directly from a logical plan. Used by
-  // runSetupStatement to execute INSERT / CREATE TABLE AS SELECT plans
-  // without re-parsing.
+  // Builds a LocalRunner that runs 'logicalPlan' end-to-end (optimize +
+  // execute), routing through the v2 optimizer when useV2_ is set and v1
+  // otherwise.
   std::shared_ptr<runner::LocalRunner> makeRunner(
       const logical_plan::LogicalPlanNodePtr& logicalPlan);
 
+  // Memory pool for optimizer allocations.
   std::shared_ptr<velox::memory::MemoryPool> optimizerPool_;
+  // Executor for query execution.
   std::shared_ptr<folly::CPUThreadPoolExecutor> executor_;
+
   QueryRuntimeStats runtimeStats_;
 };
 

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -44,10 +44,16 @@ void verifyPlanSerde(
   }
 }
 
-class WriteTest : public test::HiveQueriesTestBase {
+class WriteTest : public test::HiveQueriesTestBase,
+                  public ::testing::WithParamInterface<bool> {
  protected:
   const std::string kDefaultSchema{
       connector::hive::LocalHiveConnectorMetadata::kDefaultSchema};
+
+  void SetUp() override {
+    test::HiveQueriesTestBase::SetUp();
+    useV2_ = GetParam();
+  }
 
   static void SetUpTestCase() {
     test::HiveQueriesTestBase::SetUpTestCase();
@@ -339,7 +345,7 @@ class WriteTest : public test::HiveQueriesTestBase {
   velox::Variant evaluateConstantExpr(const lp::Expr& expr);
 };
 
-TEST_F(WriteTest, basic) {
+TEST_P(WriteTest, basic) {
   SCOPE_EXIT {
     dropTableIfExists("test");
     dropTableIfExists("test2");
@@ -432,7 +438,7 @@ TEST_F(WriteTest, basic) {
   }
 }
 
-TEST_F(WriteTest, insertSql) {
+TEST_P(WriteTest, insertSql) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -475,7 +481,7 @@ TEST_F(WriteTest, insertSql) {
       }));
 }
 
-TEST_F(WriteTest, ctasSql) {
+TEST_P(WriteTest, ctasSql) {
   {
     SCOPE_EXIT {
       dropTableIfExists("test");
@@ -529,7 +535,7 @@ TEST_F(WriteTest, ctasSql) {
 // Verifies that CTAS and INSERT on unpartitioned tables populate per-column
 // stats (count, min, max, numDistinct) and that INSERT merges with existing
 // stats.
-TEST_F(WriteTest, columnStatsUnpartitioned) {
+TEST_P(WriteTest, columnStatsUnpartitioned) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -592,7 +598,7 @@ TEST_F(WriteTest, columnStatsUnpartitioned) {
 }
 
 // Verifies that all-null columns produce zero count and no min/max/ndv.
-TEST_F(WriteTest, columnStatsAllNulls) {
+TEST_P(WriteTest, columnStatsAllNulls) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -623,7 +629,7 @@ TEST_F(WriteTest, columnStatsAllNulls) {
 
 // Verifies that CTAS on partitioned tables stores per-partition stats but
 // does not produce table-level stats.
-TEST_F(WriteTest, columnStatsPartitioned) {
+TEST_P(WriteTest, columnStatsPartitioned) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -653,7 +659,7 @@ TEST_F(WriteTest, columnStatsPartitioned) {
   }
 }
 
-TEST_F(WriteTest, ctasPartitionedSql) {
+TEST_P(WriteTest, ctasPartitionedSql) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -720,7 +726,7 @@ void verifyCollocatedWrite(const MultiFragmentPlan& plan) {
 // Verifies that CTAS with a Values input (single-fragment, single-threaded
 // pipeline) does not produce LocalGather + TableWriteMerge nodes even when
 // numWorkers > 1 and numDrivers > 1.
-TEST_F(WriteTest, ctasValuesNoMerge) {
+TEST_P(WriteTest, ctasValuesNoMerge) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -737,7 +743,7 @@ TEST_F(WriteTest, ctasValuesNoMerge) {
       {.numWorkers = 4, .numDrivers = 4});
 }
 
-TEST_F(WriteTest, ctasBucketedSql) {
+TEST_P(WriteTest, ctasBucketedSql) {
   SCOPE_EXIT {
     for (const auto& name : {"test", "more", "same", "fewer"}) {
       dropTableIfExists(name);
@@ -780,7 +786,7 @@ TEST_F(WriteTest, ctasBucketedSql) {
   verifyPartitionedLayout(getLayout("fewer"), "key", 2);
 }
 
-TEST_F(WriteTest, ctasBucketedSingleNode) {
+TEST_P(WriteTest, ctasBucketedSingleNode) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -808,7 +814,7 @@ TEST_F(WriteTest, ctasBucketedSingleNode) {
   verifyPartitionedLayout(getLayout("test"), "key", 128);
 }
 
-TEST_F(WriteTest, ctasBucketedSingleThreaded) {
+TEST_P(WriteTest, ctasBucketedSingleThreaded) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -833,7 +839,7 @@ TEST_F(WriteTest, ctasBucketedSingleThreaded) {
   verifyPartitionedLayout(getLayout("test"), "key", 64);
 }
 
-TEST_F(WriteTest, ctasBucketedAndSorted) {
+TEST_P(WriteTest, ctasBucketedAndSorted) {
   SCOPE_EXIT {
     dropTableIfExists("test");
   };
@@ -846,6 +852,8 @@ TEST_F(WriteTest, ctasBucketedAndSorted) {
 
   verifyPartitionedLayout(getLayout("test"), "n_nationkey", 16, "n_name");
 }
+
+AXIOM_INSTANTIATE_V1_V2(WriteTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -166,3 +166,7 @@ JOIN (VALUES (1)) AS a (k) ON s.k = a.k
 JOIN (VALUES (1)) AS c (k) ON s.k = c.k
 JOIN (VALUES (1)) AS d (k) ON s.k = d.k
 JOIN (VALUES (1, 2)) AS b (k, v) ON s.k = b.k
+----
+-- Cross join where one relation has no equi-predicate and is connected
+-- only by an inequality: the theta predicate must still be applied.
+SELECT t1.a, t2.a FROM t t1, t t2, t t3 WHERE t1.a = t3.a AND t1.b < t2.b

--- a/axiom/optimizer/tests/sql/nondeterministic.sql
+++ b/axiom/optimizer/tests/sql/nondeterministic.sql
@@ -1,81 +1,105 @@
 -- setup_file: common_setup.sql
 
--- Reject: both references resolve to one shared inline expression that would be
--- re-drawn.
--- error: Non-deterministic expression reused
-SELECT u AS x, u AS y
-FROM (SELECT cast(uuid() AS varchar) AS u FROM t)
+-- A reused non-deterministic binding yields equal values at both references.
+-- error_v1: Non-deterministic expression reused
+SELECT x = y
+FROM (SELECT u AS x, u AS y FROM (SELECT cast(uuid() AS varchar) AS u FROM t))
 ----
--- Reject: a reused complex-typed non-deterministic source read through
--- subfields.
--- error: Non-deterministic expression reused
-SELECT s[1] AS x, s[1] AS y
-FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+-- A reused complex-typed non-deterministic source read through subfields; the
+-- two references never diverge.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT x
+FROM (SELECT s[1] AS x, s[1] AS y FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t))
+WHERE x <> y
 ----
--- Reject: a non-deterministic source read by both a filter and a projection is
--- reused.
--- error: Non-deterministic expression reused
-SELECT r FROM (SELECT rand() AS r FROM t) WHERE r > 0.5
+-- A non-deterministic source reused across a filter and a projection observes
+-- the same single draw: a value that passed the r > 0.5 filter is never <= 0.5
+-- in the projection.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT o
+FROM (SELECT r AS o FROM (SELECT random() AS r FROM t) WHERE r > 0.5)
+WHERE o <= 0.5
 ----
--- Reject: a reused complex source read once as a whole value and once via a
--- subfield.
--- error: Non-deterministic expression reused
-SELECT s AS x, s[1] AS y
-FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+-- A reused complex source read once as a whole value and once via a subfield.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT x
+FROM (SELECT s AS x, s[1] AS y FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t))
+WHERE x[1] <> y
 ----
--- Reject: a reused lambda result.
--- error: Non-deterministic expression reused
-SELECT v AS x, v AS y
-FROM (SELECT transform(sequence(1, 3), e -> e + cast(rand() * 1000000 AS bigint)) AS v FROM t)
+-- A reused lambda result.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT x
+FROM (
+  SELECT v AS x, v AS y
+  FROM (SELECT transform(sequence(1, 3), e -> e + cast(random() * 1000000 AS bigint)) AS v FROM t))
+WHERE x <> y
 ----
--- Reject: reuse of a name bound to a struct field read out of a
--- non-deterministic source.
--- error: Non-deterministic expression reused
-SELECT s AS x, s AS y
-FROM (SELECT shuffle(array[cast(row(a, a) AS row(f1 bigint, f2 bigint))])[1].f1 AS s FROM t)
+-- Reuse of a name bound to a struct field read out of a non-deterministic
+-- source.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT x
+FROM (
+  SELECT s AS x, s AS y
+  FROM (SELECT shuffle(array[cast(row(a, a) AS row(f1 bigint, f2 bigint))])[1].f1 AS s FROM t))
+WHERE x <> y
 ----
--- Reject: nested non-deterministic subscript over a non-deterministic call.
--- error: Non-deterministic expression reused
-SELECT s[1] AS x, s[1] AS y
-FROM (SELECT shuffle(array[sequence(1, 5)])[1] AS s FROM t)
+-- Nested non-deterministic subscript over a non-deterministic call.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT x
+FROM (SELECT s[1] AS x, s[1] AS y FROM (SELECT shuffle(array[sequence(1, 5)])[1] AS s FROM t))
+WHERE x <> y
 ----
--- Known conservative over-rejection: reading more than one subfield of a struct
--- that carries a non-deterministic field.
--- error: Non-deterministic expression reused
-SELECT n.x AS p, n.y AS q
-FROM (SELECT cast(row(a, rand()) AS row(x bigint, y double)) AS n FROM t)
+-- Reading two subfields of a struct with a non-deterministic field returns the
+-- deterministic subfield and an in-range draw.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT p
+FROM (
+  SELECT n.x AS p, n.y AS q, a
+  FROM (SELECT cast(row(a, random()) AS row(x bigint, y double)) AS n, a FROM t))
+WHERE p <> a OR q < 0 OR q >= 1
 ----
--- Known conservative over-rejection: a single use of an aliased
--- non-deterministic subscript index.
--- error: Non-deterministic expression reused
-SELECT s[i] AS u
-FROM (SELECT array[10, 20, 30, 40, 50] AS s, cast(rand() * 3 AS integer) + 1 AS i FROM t)
+-- An aliased non-deterministic subscript index reads a valid array element.
+-- error_v1: Non-deterministic expression reused
+-- count 0
+SELECT u
+FROM (
+  SELECT s[i] AS u
+  FROM (SELECT array[10, 20, 30, 40, 50] AS s, cast(random() * 3 AS integer) + 1 AS i FROM t))
+WHERE u NOT IN (10, 20, 30, 40, 50)
 ----
--- Accept: two independent non-deterministic draws.
--- count 15
-SELECT uuid() AS x, uuid() AS y FROM t
+-- A non-deterministic call is evaluated per row, not folded to a constant: the
+-- 15 rows produce 15 distinct draws.
+SELECT count(DISTINCT cast(uuid() AS varchar)) FROM t
 ----
--- Accept: a non-deterministic source used only once in a filter.
--- count 15
-SELECT a FROM t WHERE rand() < 2.0
+-- Two independent draws differ.
+SELECT uuid() = uuid() FROM t
 ----
--- Accept: a non-deterministic source referenced once without rename.
--- count 15
-SELECT r FROM (SELECT rand() AS r FROM t)
+-- A non-deterministic source used once in a filter that never passes.
+-- count 0
+SELECT a FROM t WHERE random() >= 2.0
 ----
--- Accept: a non-deterministic source referenced once, through a single rename.
--- count 15
-SELECT r AS x FROM (SELECT rand() AS r FROM t)
+-- A non-deterministic source referenced once is evaluated per row: distinct
+-- draws in every row.
+SELECT count(DISTINCT r) FROM (SELECT random() AS r FROM t)
 ----
--- Accept: a non-deterministic source renamed across nested projections but used
--- once.
--- count 15
-SELECT y AS z FROM (SELECT x AS y FROM (SELECT rand() AS x FROM t))
+-- Per-row evaluation survives a single rename.
+SELECT count(DISTINCT x) FROM (SELECT r AS x FROM (SELECT random() AS r FROM t))
 ----
--- Accept: a complex source read by a single subfield.
--- count 15
-SELECT s[1] AS x FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t)
+-- Per-row evaluation survives a rename chain across nested projections.
+SELECT count(DISTINCT z) FROM (SELECT y AS z FROM (SELECT x AS y FROM (SELECT random() AS x FROM t)))
 ----
--- Accept: a deterministic complex value reused via subfield.
--- count 15
+-- A complex source read by a single subfield yields an element of the source.
+-- duckdb: SELECT true FROM t
+SELECT x BETWEEN 1 AND 5
+FROM (SELECT s[1] AS x FROM (SELECT shuffle(sequence(1, 5)) AS s FROM t))
+----
+-- A deterministic complex value reused via subfield.
+-- duckdb: SELECT 1, 1 FROM t
 SELECT s[1] AS x, s[1] AS y FROM (SELECT sequence(1, 5) AS s FROM t)

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -300,6 +300,31 @@ SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t.b = t2.b) FROM t
 SELECT a FROM (VALUES (1), (CAST(NULL AS INTEGER)), (5)) AS l(a)
 WHERE a NOT IN (SELECT b FROM (VALUES (1), (3)) AS r(b))
 ----
+-- NOT IN where the subquery contains a NULL: every comparison is unknown, so
+-- no outer row qualifies (empty result). Exercises null-aware anti with a NULL
+-- build key.
+-- count 0
+SELECT a FROM (VALUES (1), (2), (5)) AS l(a)
+WHERE a NOT IN (SELECT b FROM (VALUES (2), (CAST(NULL AS INTEGER))) AS r(b))
+----
+-- Projected IN returns a three-valued flag: true on a hit, false on a clean
+-- miss, and NULL when the probe is NULL or the subquery holds a NULL and there
+-- is no hit.
+SELECT a, a IN (SELECT b FROM (VALUES (2), (CAST(NULL AS INTEGER))) AS r(b)) AS flag
+FROM (VALUES (1), (2), (CAST(NULL AS INTEGER))) AS l(a)
+----
+-- Correlated NOT EXISTS keeps every outer row with no matching subquery row,
+-- including the NULL outer key (whose correlation never matches).
+SELECT a FROM (VALUES (1), (3), (CAST(NULL AS INTEGER))) AS l(a)
+WHERE NOT EXISTS (SELECT 1 FROM v WHERE v.a = l.a)
+----
+-- NOT IN with a small outer and larger subquery (no NULL in the subquery):
+-- a non-matching outer is kept, a matching one excluded, and the NULL outer
+-- key yields NULL and is excluded. Outer smaller than the subquery so the
+-- antijoin may build on the outer side.
+SELECT a FROM (VALUES (7), (3), (CAST(NULL AS INTEGER))) AS l(a)
+WHERE a NOT IN (SELECT b FROM (VALUES (1), (2), (3), (4), (5)) AS r(b))
+----
 -- Uncorrelated `WHERE NOT EXISTS` over an empty subquery returns every
 -- outer row.
 SELECT a FROM t WHERE NOT EXISTS (SELECT 1 FROM v WHERE false)
@@ -393,14 +418,23 @@ SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a) FROM t
 -- are 1..3, u.a values are 1..5, t.a + 100 is never in u).
 SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a + 100) FROM t
 ----
+-- Correlated count whose equi correlation key is computed on the subquery
+-- side (u.a + 1 = t.a).
+SELECT (SELECT count(*) FROM u WHERE u.a + 1 = t.a) FROM t
+----
+-- Correlated count with a two-column equi correlation key (self-correlated t).
+SELECT (SELECT count(*) FROM t t2 WHERE t2.a = t.a AND t2.b = t.b) FROM t
+----
 -- Outer-column reference in a non-INNER join's ON condition inside a
 -- correlated subquery.
--- error: Cannot resolve column name: a
+-- error_v1: Cannot resolve column name: a
+-- duckdb: SELECT 5::bigint FROM t
 SELECT (SELECT max(u.a) FROM u LEFT JOIN v ON v.a = t.a) FROM t
 ----
 -- Correlated subquery whose body is a UNION ALL of two branches that each
 -- reference an outer column.
--- error: Correlated reference inside a UNION ALL branch is not supported yet
+-- error_v1: Correlated reference inside a UNION ALL branch is not supported yet
+-- error_v2: Correlated reference inside a UnionAll branch is not supported yet
 SELECT (SELECT max(a) FROM (SELECT u.a FROM u WHERE u.a = t.a UNION ALL SELECT v.a FROM v WHERE v.a = t.a)) FROM t
 ----
 -- Outer-column reference in the SELECT of an IN subquery: the
@@ -409,7 +443,7 @@ SELECT t.a IN (SELECT u.a + t.b FROM u WHERE u.a > 0) FROM t
 ----
 -- Outer-column reference inside an aggregate body of an IN subquery
 -- (HAVING max(u.a + t.b) > 0).
--- error: Outer-column reference in the aggregate body of an IN subquery is not supported yet
+-- error_v1: Outer-column reference in the aggregate body of an IN subquery is not supported yet
 SELECT t.a IN (SELECT u.a FROM u GROUP BY u.a HAVING max(u.a + t.b) > 0) FROM t
 ----
 -- EXISTS ignores the subquery's SELECT projection, so an outer-column
@@ -595,14 +629,14 @@ SELECT t.a FROM t WHERE EXISTS (
 -- has more than one row, so HAVING is never satisfied and the result
 -- is empty.
 -- count 0
--- error: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
+-- error_v1: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
 SELECT t.a FROM t WHERE EXISTS (
   SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 1
 )
 ----
 -- Correlated EXISTS over an aggregate body with HAVING that is
 -- satisfied for outers whose key appears in u.
--- error: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
+-- error_v1: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
 SELECT t.a FROM t WHERE EXISTS (
   SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) >= 1
 )
@@ -615,21 +649,22 @@ SELECT t.a FROM t WHERE t.a IN (
 ----
 -- Correlated NOT EXISTS over an aggregate body with HAVING. Outers
 -- with no surviving group are kept.
--- error: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
+-- error_v1: EXISTS over a global aggregate with HAVING or OFFSET is not supported yet
 SELECT t.a FROM t WHERE NOT EXISTS (
   SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 5
 )
 ----
 -- IN whose subquery body is a scalar aggregate, so the IN right-hand
 -- side column is the aggregate result itself (not a grouping key).
--- error: IN over a correlated global aggregate is not supported yet
+-- error_v1: IN over a correlated global aggregate is not supported yet
 SELECT t.a FROM t WHERE t.a IN (
   SELECT max(u.a) FROM u WHERE u.a <= t.a
 )
 ----
 -- Correlated scalar subquery whose body is a UNION ALL of two
 -- branches, each filtering by an outer column.
--- error: Correlated reference inside a UNION ALL branch is not supported yet
+-- error_v1: Correlated reference inside a UNION ALL branch is not supported yet
+-- error_v2: Correlated reference inside a UnionAll branch is not supported yet
 SELECT t.a, (
   SELECT count(*) FROM (
     SELECT u.a FROM u WHERE u.a > t.a
@@ -647,7 +682,7 @@ SELECT t.a, (
 ) FROM t
 ----
 -- Uncorrelated scalar subquery inside the UNNEST array constructor.
--- error: Unexpected expression: Subquery
+-- error_v1: Unexpected expression: Subquery
 SELECT v.x
 FROM (VALUES (ARRAY[10, 20, 30])) s(arr)
 CROSS JOIN UNNEST(ARRAY[(SELECT max(a) FROM u), arr[1]]) AS v(x)
@@ -656,15 +691,15 @@ CROSS JOIN UNNEST(ARRAY[(SELECT max(a) FROM u), arr[1]]) AS v(x)
 -- correlates to the input row above the UNNEST. DuckDB rejects nested
 -- lateral joins, so the expected result is hardcoded.
 -- duckdb: VALUES (1, 1), (2, 2)
--- error: Unexpected expression: Subquery
+-- error_v1: Unexpected expression: Subquery
 SELECT s.k, v.x
 FROM (VALUES (1), (2)) s(k)
 CROSS JOIN UNNEST(ARRAY[(SELECT max(a) FROM u WHERE u.a = s.k)]) AS v(x)
 ----
--- Correlated scalar subquery with LIMIT 1 body. The no-match outer
--- must survive with NULL.
--- error: LIMIT in a correlated scalar subquery is not supported yet
-SELECT u.a, (SELECT t.b FROM t WHERE t.a = u.a + 1 LIMIT 1) FROM u
+-- Correlated scalar subquery with LIMIT 1 body: the no-match outer row
+-- survives with NULL.
+-- error_v1: LIMIT in a correlated scalar subquery is not supported yet
+SELECT u.a, (SELECT t.b FROM t WHERE t.a = u.a + 1 ORDER BY t.b LIMIT 1) FROM u
 ----
 -- Correlated EXISTS with LIMIT 1 body.
 SELECT u.a FROM u WHERE EXISTS (SELECT 1 FROM t WHERE t.a > u.a LIMIT 1)
@@ -674,7 +709,7 @@ SELECT u.a FROM u WHERE NOT EXISTS (SELECT 1 FROM t WHERE t.a > u.a LIMIT 1)
 ----
 -- A correlated scalar whose body is a Join of two correlated
 -- single-row subqueries returns one row per outer.
--- error: Nested correlation across subquery boundaries is not supported yet
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
 SELECT u.a,
        (SELECT l.b + r.b
         FROM (SELECT max(b) AS b FROM t WHERE t.a = u.a) l,
@@ -685,15 +720,99 @@ FROM u
 -- with an uncorrelated single-row subquery. Outers with no matching
 -- left row must surface a single NULL row, not |right| NULL-extended
 -- rows.
--- error: Nested correlation across subquery boundaries is not supported yet
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
 SELECT u.a,
        (SELECT l.b + r.b
         FROM (SELECT max(b) AS b FROM t WHERE t.a = u.a + 10) l,
              (SELECT max(b) AS b FROM t) r)
 FROM u
 ----
+-- A correlated scalar whose body cross-joins two correlated derived
+-- tables. For k=1 the left side has two rows and the right side none,
+-- so the cross join is empty and the scalar is NULL; k=2 has one row on
+-- each side and returns their sum.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+WITH u(k, x) AS (VALUES (1, 10), (1, 20), (2, 30)),
+     v(k, x) AS (VALUES (2, 99))
+SELECT t.k,
+       (SELECT l.x + r.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) l,
+             (SELECT x FROM v WHERE v.k = t.k) r)
+FROM (VALUES (1), (2)) AS t(k)
+----
+-- When the left side is empty and the right side has multiple rows,
+-- the cross join is empty, so the scalar is NULL for that outer.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+WITH u(k, x) AS (VALUES (2, 99)),
+     v(k, x) AS (VALUES (1, 10), (1, 20), (2, 30))
+SELECT t.k,
+       (SELECT l.x + r.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) l,
+             (SELECT x FROM v WHERE v.k = t.k) r)
+FROM (VALUES (1), (2)) AS t(k)
+----
+-- Correlated scalar over a cross join with a predicate spanning both
+-- sides: only matching pairs contribute, and an outer with no matching
+-- pair yields NULL.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+WITH u(k, x) AS (VALUES (1, 10), (1, 20), (1, 30)),
+     v(k, x) AS (VALUES (1, 20))
+SELECT t.k,
+       (SELECT l.x + r.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) l,
+             (SELECT x FROM v WHERE v.k = t.k) r
+        WHERE l.x = r.x)
+FROM (VALUES (1), (2)) AS t(k)
+----
+-- A cross join that yields more than one row for an outer is a
+-- scalar-subquery cardinality violation.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+-- error_v2: Scalar sub-query has returned multiple rows
+WITH u(k, x) AS (VALUES (1, 10), (1, 20)),
+     v(k, x) AS (VALUES (1, 100), (1, 200))
+SELECT t.k,
+       (SELECT l.x + r.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) l,
+             (SELECT x FROM v WHERE v.k = t.k) r)
+FROM (VALUES (1)) AS t(k)
+----
+-- A scalar that selects only the left side: an empty cross join must
+-- still yield NULL, not the left value carried on the empty-side row.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+WITH u(k, x) AS (VALUES (1, 10), (1, 20), (2, 30)),
+     v(k, x) AS (VALUES (2, 99))
+SELECT t.k,
+       (SELECT l.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) l,
+             (SELECT x FROM v WHERE v.k = t.k) r)
+FROM (VALUES (1), (2)) AS t(k)
+----
+-- Duplicate outer rows with the same correlation value stay
+-- independent: each produces its own result row.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+WITH u(k, x) AS (VALUES (1, 10), (1, 20), (2, 30)),
+     v(k, x) AS (VALUES (2, 99))
+SELECT t.k,
+       (SELECT l.x + r.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) l,
+             (SELECT x FROM v WHERE v.k = t.k) r)
+FROM (VALUES (2), (2), (1)) AS t(k)
+----
+-- A scalar over a three-way correlated cross join. An empty side
+-- yields NULL; when every side has one row the scalar is their sum.
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
+WITH u(k, x) AS (VALUES (1, 10), (1, 20), (2, 30)),
+     v(k, x) AS (VALUES (2, 99)),
+     w(k, x) AS (VALUES (1, 7), (2, 8))
+SELECT t.k,
+       (SELECT a.x + b.x + c.x
+        FROM (SELECT x FROM u WHERE u.k = t.k) a,
+             (SELECT x FROM v WHERE v.k = t.k) b,
+             (SELECT x FROM w WHERE w.k = t.k) c)
+FROM (VALUES (1), (2)) AS t(k)
+----
 -- Correlated EXISTS over a Join with single-side correlation.
--- error: Nested correlation across subquery boundaries is not supported yet
+-- error_v1: Nested correlation across subquery boundaries is not supported yet
 SELECT u.a
 FROM u
 WHERE EXISTS (
@@ -719,7 +838,7 @@ SELECT (SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 0) FROM t
 -- Correlated IN whose right-hand side is the result of a scalar
 -- `count(*)` over a correlated body. For outers with no matching u
 -- rows, `count(*)` returns 0 — so `t.a IN (...)` matches when t.a = 0.
--- error: IN over a correlated aggregation is not supported yet
+-- error_v1: IN over a correlated aggregation is not supported yet
 SELECT t.a IN (SELECT count(*) FROM u WHERE u.a = t.a) FROM t
 ----
 -- Correlated IN whose right-hand side is the aggregate result of a
@@ -732,13 +851,13 @@ SELECT t.a IN (
 -- an inner column outside the GROUP BY clause: t.b is consumed by the
 -- aggregate (grouped by t.a only) and cannot become a join key at the
 -- outer level.
--- error: Correlation predicate references a column not in GROUP BY is not supported yet
+-- error_v1: Correlation predicate references a column not in GROUP BY is not supported yet
 SELECT u.a IN (
   SELECT count(*) FROM t WHERE t.b = u.a GROUP BY t.a
 ) FROM u
 ----
 -- Correlated IN whose body is a scalar aggregate with HAVING.
--- error: IN over a correlated aggregation is not supported yet
+-- error_v1: IN over a correlated aggregation is not supported yet
 SELECT t.a IN (
   SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 0
 ) FROM t
@@ -746,7 +865,7 @@ SELECT t.a IN (
 -- Correlated NOT IN whose body is a scalar aggregate that can return
 -- NULL (max over empty body). NULL on the right-hand side propagates
 -- NULL through NOT IN per SQL three-valued logic.
--- error: IN over a correlated global aggregate is not supported yet
+-- error_v1: IN over a correlated global aggregate is not supported yet
 SELECT t.a NOT IN (SELECT max(u.a) FROM u WHERE u.a > t.a) FROM t
 ----
 -- EXISTS over a correlated `count(*)` body where the WHERE
@@ -761,5 +880,27 @@ SELECT 1 IN (SELECT a FROM u)
 ----
 -- A non-constant, table-less IN left side (random()) has no plan-time value to
 -- embed as a one-row probe, so planning fails with a clear error.
--- error: Non-constant table-less left side of IN <subquery> is not supported yet
+-- error_v1: Non-constant table-less left side of IN <subquery> is not supported yet
 SELECT random() IN (SELECT a FROM u)
+----
+-- Correlated EXISTS over a GROUP BY body with no HAVING.
+SELECT EXISTS (SELECT 1 FROM u WHERE u.a > t.b GROUP BY u.a) FROM t
+----
+-- Correlated EXISTS where HAVING references only grouping keys.
+SELECT EXISTS (
+  SELECT 1 FROM u WHERE u.a > t.b GROUP BY u.a HAVING u.a > 2
+) FROM t
+----
+-- Correlated IN whose inner key is a grouping-key expression.
+SELECT t.a IN (SELECT u.a FROM u WHERE u.a > t.b GROUP BY u.a) FROM t
+----
+-- Correlated IN whose inner key is an aggregate result.
+SELECT t.a IN (
+  SELECT max(u.a) FROM u WHERE u.a > t.b GROUP BY u.a
+) FROM t
+----
+-- Correlated scalar subquery whose inner GROUP BY can return several rows per
+-- outer row; the scalar must error on the first outer row with multiple groups.
+-- error_v1: 0 vs. 1
+-- error_v2: Scalar sub-query has returned multiple rows
+SELECT (SELECT max(u.a) FROM u WHERE u.a > t.a GROUP BY u.a % 2) FROM t

--- a/axiom/optimizer/tests/sql/unionAll.sql
+++ b/axiom/optimizer/tests/sql/unionAll.sql
@@ -97,3 +97,11 @@ WITH
 SELECT * FROM v WHERE c = 1
 UNION ALL
 SELECT * FROM u
+----
+-- A window function with a compound partition key (a + b), as a direct UNION
+-- ALL leg, projects the correct columns.
+SELECT * FROM (
+  SELECT a, b, "row_number"() OVER (PARTITION BY a + b) AS r FROM t
+)
+UNION ALL
+SELECT a, b, a AS r FROM t WHERE a = 999

--- a/axiom/optimizer/v2/AggregateRecovery.cpp
+++ b/axiom/optimizer/v2/AggregateRecovery.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/AggregateRecovery.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+bool isCountStar(optimizer::AggregateCP aggregate) {
+  // `COUNT(*)` is the dialect's count aggregate (per FunctionRegistry)
+  // invoked with no args. Aggregates with args, or aggregates from a
+  // dialect that hasn't registered count, are not the count-bug case.
+  const auto& countName = FunctionRegistry::instance()->count();
+  return countName.has_value() && aggregate->name() == toName(*countName) &&
+      aggregate->args().empty();
+}
+
+bool argsAreEntirelyOuter(
+    optimizer::AggregateCP aggregate,
+    const PlanObjectSet& outerSet) {
+  if (aggregate->args().empty()) {
+    return false;
+  }
+  // "Entirely outer" requires at least one referenced column AND every
+  // referenced column to be in the outer set. An aggregate whose args
+  // are literals only (e.g., `count(1)`) has an empty column set,
+  // which would be vacuously a subset of any outer set; we don't want
+  // to flag those.
+  bool referencesAnyColumn = false;
+  for (ExprCP arg : aggregate->args()) {
+    if (arg->columns().empty()) {
+      continue;
+    }
+    referencesAnyColumn = true;
+    if (!arg->columns().isSubset(outerSet)) {
+      return false;
+    }
+  }
+  return referencesAnyColumn;
+}
+
+} // namespace
+
+AggregateCallVector AggregateRecovery::rewriteCountStar(
+    const AggregateCallVector& aggregates,
+    ColumnCP marker) {
+  AggregateCallVector rewritten;
+  rewritten.reserve(aggregates.size());
+  for (const auto* aggregate : aggregates) {
+    if (!isCountStar(aggregate)) {
+      rewritten.push_back(aggregate);
+      continue;
+    }
+    ExprCP newCondition = aggregate->condition() == nullptr
+        ? static_cast<ExprCP>(marker)
+        : exprFactory_.makeAnd(aggregate->condition(), marker);
+    rewritten.push_back(replaceCondition(aggregate, newCondition));
+  }
+  return rewritten;
+}
+
+AggregateCallVector AggregateRecovery::addFilterCondition(
+    const AggregateCallVector& aggregates,
+    ExprCP predicate) {
+  AggregateCallVector rewritten;
+  rewritten.reserve(aggregates.size());
+  for (const auto* aggregate : aggregates) {
+    ExprCP newCondition = aggregate->condition() == nullptr
+        ? predicate
+        : exprFactory_.makeAnd(aggregate->condition(), predicate);
+    rewritten.push_back(replaceCondition(aggregate, newCondition));
+  }
+  return rewritten;
+}
+
+void AggregateRecovery::validateAggregateArgs(
+    const AggregateCallVector& aggregates,
+    const ColumnVector& outerCorrelations) {
+  PlanObjectSet outerSet = PlanObjectSet::fromObjects(outerCorrelations);
+  for (const auto* aggregate : aggregates) {
+    VELOX_USER_CHECK(
+        !argsAreEntirelyOuter(aggregate, outerSet),
+        "Correlated subquery with an aggregate whose arguments reference "
+        "only outer columns is not supported yet");
+  }
+}
+
+optimizer::AggregateCP AggregateRecovery::makeBoolOr(ExprCP arg) {
+  VELOX_CHECK_EQ(
+      arg->value().type->kind(),
+      velox::TypeKind::BOOLEAN,
+      "bool_or expects a BOOLEAN argument");
+
+  const auto& boolOrName = FunctionRegistry::instance()->boolOr();
+  VELOX_USER_CHECK(
+      boolOrName.has_value(),
+      "Decorrelate semi recovery requires bool_or registered via "
+      "FunctionRegistry::registerBoolOr; the active dialect did not "
+      "register it");
+
+  const std::vector<velox::TypePtr> argTypes{velox::BOOLEAN()};
+  TypeCP intermediateType =
+      toType(velox::exec::resolveIntermediateType(*boolOrName, argTypes));
+
+  const auto& metadata = velox::exec::getAggregateFunctionMetadata(*boolOrName);
+  FunctionSet functions = arg->functions();
+  if (metadata.ignoreDuplicates) {
+    functions = functions | FunctionSet::kIgnoreDuplicatesAggregate;
+  }
+  if (metadata.orderSensitive) {
+    functions = functions | FunctionSet::kOrderSensitiveAggregate;
+  }
+  return builder_.makeAggregate(
+      toName(*boolOrName),
+      Value(toType(velox::BOOLEAN()), /*cardinality=*/2),
+      ExprVector{arg},
+      functions,
+      /*isDistinct=*/false,
+      /*condition=*/nullptr,
+      intermediateType,
+      /*orderKeys=*/{},
+      /*orderTypes=*/{});
+}
+
+optimizer::AggregateCP AggregateRecovery::replaceCondition(
+    optimizer::AggregateCP aggregate,
+    ExprCP condition) {
+  return builder_.makeAggregate(
+      aggregate->name(),
+      aggregate->value(),
+      aggregate->args(),
+      aggregate->functions(),
+      aggregate->isDistinct(),
+      condition,
+      aggregate->intermediateType(),
+      aggregate->orderKeys(),
+      aggregate->orderTypes());
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/AggregateRecovery.h
+++ b/axiom/optimizer/v2/AggregateRecovery.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Substrate for the decorrelate pass's Apply-over-Aggregate recovery
+/// skeleton. The recovery rewrites a correlated Apply whose body
+/// includes an Aggregate into a single linear chain
+/// `AssignUniqueId → LEFT JOIN → Aggregate`, where the LEFT JOIN's
+/// right side carries the `_include` marker synthesized by the Apply's
+/// terminus. This class collects the single-purpose transformations
+/// the chain needs; each one is independently testable and free of
+/// dispatch on Apply kind or body shape.
+class AggregateRecovery {
+ public:
+  AggregateRecovery(Builder& builder, ExprFactory& exprFactory)
+      : builder_(builder), exprFactory_(exprFactory) {}
+
+  /// Returns a new aggregate vector with `count(*)` rewritten to
+  /// `count() FILTER (WHERE marker)`. Other aggregates pass through
+  /// unchanged — their NULL handling already matches the
+  /// scalar-subquery-empty semantics; only `count(*)` treats the
+  /// padded NULL row as a real row (size = 1) instead of empty
+  /// (size = 0), so it's the only one needing the marker FILTER.
+  ///
+  /// If a `count(*)` already carries a FILTER condition (e.g. from a
+  /// HAVING-like rewrite), the marker is AND-combined with the
+  /// existing condition.
+  ///
+  /// `count(*)` is identified structurally as `name == "count"` with
+  /// empty `args()` — Velox uses the same Call (no args) for
+  /// `COUNT(*)`.
+  AggregateCallVector rewriteCountStar(
+      const AggregateCallVector& aggregates,
+      ColumnCP marker);
+
+  /// Returns a new aggregate vector with `predicate` AND-combined into
+  /// every aggregate's existing FILTER condition (or set as the
+  /// condition if the aggregate didn't have one). Used to inject an
+  /// eligibility marker (the LEFT JOIN pad-present predicate) so that
+  /// padded rows don't contribute to the recovery Aggregate's results.
+  AggregateCallVector addFilterCondition(
+      const AggregateCallVector& aggregates,
+      ExprCP predicate);
+
+  /// Throws `VELOX_USER_FAIL` if any aggregate's args reference only
+  /// outer-correlation columns. After the recovery's LEFT JOIN, the
+  /// padded row still carries outer column values; an aggregate like
+  /// `sum(L.col)` would include them once per outer row, producing
+  /// wrong results.
+  ///
+  /// Aggregates with no args (e.g. `count(*)`) are accepted; the
+  /// count-bug recovery handles them via `rewriteCountStar`.
+  static void validateAggregateArgs(
+      const AggregateCallVector& aggregates,
+      const ColumnVector& outerCorrelations);
+
+  /// Constructs a `bool_or(arg)` aggregate, used by the semi recovery
+  /// to collapse per-group eligibility booleans to a single mark per
+  /// outer row.
+  optimizer::AggregateCP makeBoolOr(ExprCP arg);
+
+ private:
+  // Returns a copy of `aggregate` with the FILTER condition replaced by
+  // `condition`. Other fields (name, args, distinct, orderKeys, etc.)
+  // are preserved.
+  optimizer::AggregateCP replaceCondition(
+      optimizer::AggregateCP aggregate,
+      ExprCP condition);
+
+  Builder& builder_;
+  ExprFactory& exprFactory_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/AlgebraicProperties.cpp
+++ b/axiom/optimizer/v2/AlgebraicProperties.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/AlgebraicProperties.h"
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+using JoinType = velox::core::JoinType;
+
+constexpr int kKindCount = 5;
+
+// Compact ordinal for indexing the algebraic-properties table.
+// kInner = 0, kLeft = 1, kFull = 2, semijoin (⋉) = 3, antijoin (▷)
+// = 4. The paper's LOP is left-oriented; callers normalize kRight
+// and kRightSemi* by swapping operands and looking up the left
+// form. kLeftSemiFilter and kLeftSemiProject share the ⋉ row
+// (identical reorderability); kAnti maps to ▷.
+int kindIndex(JoinType type) {
+  switch (type) {
+    case JoinType::kInner:
+      return 0;
+    case JoinType::kLeft:
+      return 1;
+    case JoinType::kFull:
+      return 2;
+    case JoinType::kLeftSemiFilter:
+    case JoinType::kLeftSemiProject:
+      return 3;
+    case JoinType::kAnti:
+      return 4;
+    default:
+      VELOX_NYI(
+          "Algebraic properties not defined for join type: {}; "
+          "callers must normalize kRight/kRightSemi* to their left "
+          "forms before lookup.",
+          velox::core::JoinTypeName::toName(type));
+  }
+}
+
+// Indexed [child][parent]. Conditional entries collapsed to
+// false; see header.
+constexpr AlgebraicProperties kTable[kKindCount][kKindCount] = {
+    // child = kInner
+    {
+        // parent = kInner
+        {.associative = true, .leftAsscom = true, .rightAsscom = true},
+        // parent = kLeft
+        {.associative = true, .leftAsscom = true, .rightAsscom = false},
+        // parent = kFull
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉
+        {.associative = true, .leftAsscom = true, .rightAsscom = false},
+        // parent = ▷
+        {.associative = true, .leftAsscom = true, .rightAsscom = false},
+    },
+    // child = kLeft
+    {
+        // parent = kInner
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = kLeft
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = kFull
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = ▷
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+    },
+    // child = kFull
+    {
+        // parent = kInner
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = kLeft
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = kFull
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ▷
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+    },
+    // child = ⋉
+    {
+        // parent = kInner
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = kLeft
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = kFull
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = ▷
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+    },
+    // child = ▷
+    {
+        // parent = kInner
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = kLeft
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = kFull
+        {.associative = false, .leftAsscom = false, .rightAsscom = false},
+        // parent = ⋉
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+        // parent = ▷
+        {.associative = false, .leftAsscom = true, .rightAsscom = false},
+    },
+};
+
+} // namespace
+
+AlgebraicProperties AlgebraicProperties::derive(
+    JoinType child,
+    JoinType parent) {
+  return kTable[kindIndex(child)][kindIndex(parent)];
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/AlgebraicProperties.h
+++ b/axiom/optimizer/v2/AlgebraicProperties.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "velox/core/PlanNode.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Algebraic equivalences between a lower (child) join `x1` and an
+/// upper (parent) join `x2` over operands (A, B, C), where `x1`
+/// joins A and B, and `x2` joins their result with C. Each field
+/// is true iff the corresponding rewrite produces the same result
+/// as the original tree.
+///
+/// Used by `HypergraphBuilder` to derive TES expansions per
+/// Moerkotte/Fender/Eich, "On the Correct and Complete Enumeration
+/// of the Core Search Space" (SIGMOD 2013).
+struct AlgebraicProperties {
+  /// (A x1 B) x2 C  ==  A x1 (B x2 C)
+  bool associative{false};
+  /// (A x1 B) x2 C  ==  (A x2 C) x1 B
+  bool leftAsscom{false};
+  /// A x1 (B x2 C)  ==  B x2 (A x1 C)
+  bool rightAsscom{false};
+
+  /// Returns the algebraic properties for the (child, parent) join
+  /// type pair. Encodes M/N Tables 2 and 3 for the left-form join
+  /// types the enumerator reorders: `kInner`, `kLeft`, `kFull`,
+  /// `kLeftSemiFilter`/`kLeftSemiProject` (semijoin ⋉, identical
+  /// reorderability), and `kAnti` (antijoin ▷, sharing ⋉'s rows).
+  /// Callers normalize `kRight`/`kRightSemi*` to their left forms
+  /// (operand swap) before lookup. Throws for other types via
+  /// `VELOX_NYI`, including the counting variants
+  /// (`kCountingLeftSemiFilter`/`kCountingAnti`), which stay opaque.
+  ///
+  /// Conditional entries (those the paper marks "+ if predicate
+  /// rejects nulls") are collapsed to false. The precondition that
+  /// makes this sound is that `PushdownAndPrune` already demotes
+  /// any outer join whose ancestor predicates reject nulls on its
+  /// null-padded side, so the conditional rows never apply within
+  /// a cluster.
+  static AlgebraicProperties derive(
+      velox::core::JoinType child,
+      velox::core::JoinType parent);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/AppendAll.h
+++ b/axiom/optimizer/v2/AppendAll.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Appends every element of `src` to `dst`. Used to concatenate
+/// `ColumnVector` / `ExprVector` when building output column lists or
+/// expression lists for new nodes.
+template <typename Dst, typename Src>
+void appendAll(Dst& dst, const Src& src) {
+  dst.insert(dst.end(), src.begin(), src.end());
+}
+
+/// Returns a new vector containing the first `count` elements of `src`.
+/// Caller must ensure `count <= src.size()`.
+template <typename V>
+V prefix(const V& src, size_t count) {
+  return V(src.begin(), src.begin() + count);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Builder.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+Builder::Builder() : functionNames_{queryCtx()->functionNames()} {
+  const auto& reversibles = FunctionRegistry::instance()->reversibleFunctions();
+  reversibleFunctions_.reserve(reversibles.size() * 2);
+  for (const auto& [name, reverseName] : reversibles) {
+    reversibleFunctions_.emplace(toName(name), toName(reverseName));
+    reversibleFunctions_.emplace(toName(reverseName), toName(name));
+  }
+}
+
+namespace {
+
+// Returns true if `args` should be swapped to put a literal on the
+// right, or — when neither side is a literal — to put the lower-id
+// expression on the left.
+bool shouldInvert(ExprCP left, ExprCP right) {
+  const bool leftIsLiteral = left->is(PlanType::kLiteralExpr);
+  const bool rightIsLiteral = right->is(PlanType::kLiteralExpr);
+  if (leftIsLiteral && !rightIsLiteral) {
+    return true;
+  }
+  if (!leftIsLiteral && !rightIsLiteral && left->id() > right->id()) {
+    return true;
+  }
+  return false;
+}
+
+} // namespace
+
+void Builder::canonicalizeCall(Name& name, ExprVector& args) const {
+  if (args.size() != 2) {
+    return;
+  }
+  auto it = reversibleFunctions_.find(name);
+  if (it == reversibleFunctions_.end()) {
+    return;
+  }
+  if (!shouldInvert(args[0], args[1])) {
+    return;
+  }
+  std::swap(args[0], args[1]);
+  name = it->second;
+}
+
+const Literal*
+Builder::makeLiteral(velox::Variant&& variant, TypeCP type, float cardinality) {
+  const Value value(type, cardinality);
+  // Look up by the caller's Variant first, so a cache hit registers nothing.
+  Literal::KeyView view{type, &variant};
+  if (auto it = literals_.find(view); it != literals_.end()) {
+    return *it;
+  }
+  auto* registered = queryCtx()->registerVariant(
+      std::make_unique<velox::Variant>(std::move(variant)));
+  auto* literal = optimizer::make<Literal>(value, registered);
+  literals_.insert(literal);
+  return literal;
+}
+
+const Literal* Builder::makeLiteral(
+    const Value& value,
+    const velox::Variant* variant) {
+  Literal::KeyView view{value.type, variant};
+  if (auto it = literals_.find(view); it != literals_.end()) {
+    return *it;
+  }
+  auto* literal = optimizer::make<Literal>(value, variant);
+  literals_.insert(literal);
+  return literal;
+}
+
+const Call* Builder::makeCall(
+    Name name,
+    const Value& value,
+    ExprVector args,
+    FunctionSet functions) {
+  if (functions.contains(FunctionSet::kNonDeterministic)) {
+    // Skip dedup: each evaluation of a non-deterministic call produces an
+    // independent value, so identical calls must stay distinct objects.
+    return optimizer::make<Call>(name, value, std::move(args), functions);
+  }
+  canonicalizeCall(name, args);
+  Call::KeyView view{name, value.type, args};
+  if (auto it = calls_.find(view); it != calls_.end()) {
+    return *it;
+  }
+  auto* call = optimizer::make<Call>(name, value, std::move(args), functions);
+  calls_.insert(call);
+  return call;
+}
+
+const optimizer::Aggregate* Builder::makeAggregate(
+    Name name,
+    const Value& value,
+    ExprVector args,
+    FunctionSet functions,
+    bool isDistinct,
+    ExprCP condition,
+    TypeCP intermediateType,
+    ExprVector orderKeys,
+    OrderTypeVector orderTypes) {
+  optimizer::Aggregate::KeyView view{
+      name, args, isDistinct, condition, orderKeys, orderTypes};
+  if (auto it = aggregateCalls_.find(view); it != aggregateCalls_.end()) {
+    return *it;
+  }
+  auto* aggregate = optimizer::make<optimizer::Aggregate>(
+      name,
+      value,
+      std::move(args),
+      functions,
+      isDistinct,
+      condition,
+      intermediateType,
+      std::move(orderKeys),
+      std::move(orderTypes));
+  aggregateCalls_.insert(aggregate);
+  return aggregate;
+}
+
+void Builder::addEquivalences(const Join::Key& key) {
+  if (key.joinType != velox::core::JoinType::kInner) {
+    return;
+  }
+  for (size_t i = 0; i < key.leftKeys.size(); ++i) {
+    ExprCP leftKey = key.leftKeys[i];
+    ExprCP rightKey = key.rightKeys[i];
+    if (leftKey->isColumn() && rightKey->isColumn()) {
+      leftKey->as<Column>()->equals(rightKey->as<Column>());
+    }
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Hash-consing factory for tree-IR nodes and selected Expr leaves. Identical
+/// sub-trees produce the same pointer, so identity equality is O(1) and side-
+/// table lookups keyed by node identity hit one canonical entry per logical
+/// sub-tree.
+///
+/// Everything is interned by pointer: each dedup set stores `const T*` and
+/// recovers identity via `T::KeyHash` / `T::KeyEq`, so a cache hit allocates
+/// nothing. Nodes are constructed from an owning `Key` (e.g. `Scan::Key`)
+/// passed to `make<T>`; the `Expr` leaves `Literal`, `Call`, and
+/// `optimizer::Aggregate` use `makeLiteral` / `makeCall` / `makeAggregate`
+/// (their `KeyHash` / `KeyEq` live on the `Expr` classes themselves). `Column`
+/// is intentionally NOT hash-consed: `Column::equivalence_` is mutable state
+/// mutated by `Column::equals()`, and dedup would leak equivalence classes
+/// across unrelated subtrees.
+class Builder {
+ public:
+  /// Snapshots `queryCtx()` and the function registry; the resulting
+  /// `Builder` is bound to that `QueryGraphContext` for its lifetime.
+  Builder();
+
+  /// Returns a canonical node `T` for 'key', constructing one if not already
+  /// present. Interned by pointer: the dedup set stores `const T*` and recovers
+  /// identity via `T::KeyHash` / `T::KeyEq`. Looks up by the in-flight `key`
+  /// (transparent, no allocation on a hit); on a miss, moves the key into the
+  /// newly constructed node. `Expr` leaves use `makeLiteral` / `makeCall` /
+  /// `makeAggregate`.
+  template <typename T>
+  const T* make(typename T::Key key) {
+    auto& dedup = setFor<T>();
+    if (auto it = dedup.find(key); it != dedup.end()) {
+      return *it;
+    }
+    if constexpr (std::is_same_v<T, Join>) {
+      // Before construction: the Join ctor caches partitioning from these.
+      addEquivalences(key);
+    }
+    const T* node = optimizer::make<T>(std::move(key));
+    dedup.insert(node);
+    return node;
+  }
+
+  /// Registers 'variant' in the `QueryGraphContext` arena and returns a
+  /// canonical `Literal` of 'type' carrying it. Cardinality defaults to
+  /// 1 (a single distinct value — appropriate for literal constants).
+  const Literal*
+  makeLiteral(velox::Variant&& variant, TypeCP type, float cardinality = 1);
+
+  /// Returns a canonical `Literal` of 'value' carrying the already-registered
+  /// 'variant' (owned by the `QueryGraphContext` arena).
+  const Literal* makeLiteral(const Value& value, const velox::Variant* variant);
+
+  /// Returns a canonical `Call`. Non-deterministic calls are never deduped —
+  /// two textually identical `random()` invocations must stay distinct objects
+  /// because each produces an independent value. Reversible binary calls (e.g.
+  /// `lt`/`gt`, `eq`, `plus`) are canonicalized before dedup so equivalent
+  /// forms share one `Call*` (e.g. `2 > a` is rewritten to `a < 2`).
+  /// 'functions' is the call's own bits OR-ed with each arg's `functions()`.
+  const Call* makeCall(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      FunctionSet functions);
+
+  /// Returns a canonical aggregate `Call`. Result type and 'intermediateType'
+  /// are determined by (name, args), so identity excludes them.
+  const optimizer::Aggregate* makeAggregate(
+      Name name,
+      const Value& value,
+      ExprVector args,
+      FunctionSet functions,
+      bool isDistinct,
+      ExprCP condition,
+      TypeCP intermediateType,
+      ExprVector orderKeys,
+      OrderTypeVector orderTypes);
+
+  /// Canonical `Literal` for boolean constant 'value'.
+  const Literal* makeBoolean(bool value) {
+    return makeLiteral(velox::Variant(value), toType(velox::BOOLEAN()));
+  }
+
+  /// Canonical `Literal` for SQL NULL of 'type'.
+  const Literal* makeNull(TypeCP type) {
+    return makeLiteral(velox::Variant::null(type->kind()), type);
+  }
+
+  /// `Values` node carrying zero rows with the given output schema.
+  /// Used to replace subtrees a rewrite proved produce no rows.
+  const Values* makeEmptyValues(ColumnVector outputColumns) {
+    return make<Values>({/*source=*/nullptr,
+                         /*rows=*/nullptr,
+                         std::move(outputColumns)});
+  }
+
+  /// Interned `Name`s for well-known functions, snapshotted from the
+  /// active `QueryGraphContext` at construction so callers can compare
+  /// or build calls against well-known operator names by pointer
+  /// equality, without repeated registry lookups.
+  const FunctionNames& functionNames() const {
+    return functionNames_;
+  }
+
+ private:
+  // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
+  // swaps 'args' (and renames to the reverse) when `args[0]` should
+  // come second per the canonical order: literal-on-right, lower-id
+  // expr on left when neither is a literal. No-op otherwise.
+  void canonicalizeCall(Name& name, ExprVector& args) const;
+
+  // Adds an inner join's equi-key columns to one equivalence class (see
+  // `Column::equals`): equated columns hold the same value on every output row,
+  // so any surviving member partitions the output as the dropped key did.
+  // No-op for non-inner joins (an outer join's build key may be null-padded, so
+  // its columns are not equal on every row) and for non-column keys.
+  static void addEquivalences(const Join::Key& key);
+
+  template <typename T>
+  auto& setFor() {
+    if constexpr (std::is_same_v<T, Scan>) {
+      return scans_;
+    } else if constexpr (std::is_same_v<T, Filter>) {
+      return filters_;
+    } else if constexpr (std::is_same_v<T, Project>) {
+      return projects_;
+    } else if constexpr (std::is_same_v<T, Limit>) {
+      return limits_;
+    } else if constexpr (std::is_same_v<T, Sort>) {
+      return sorts_;
+    } else if constexpr (std::is_same_v<T, TopN>) {
+      return topNs_;
+    } else if constexpr (std::is_same_v<T, Aggregate>) {
+      return aggregates_;
+    } else if constexpr (std::is_same_v<T, GroupId>) {
+      return groupIds_;
+    } else if constexpr (std::is_same_v<T, MarkDistinct>) {
+      return markDistincts_;
+    } else if constexpr (std::is_same_v<T, Values>) {
+      return values_;
+    } else if constexpr (std::is_same_v<T, Unnest>) {
+      return unnests_;
+    } else if constexpr (std::is_same_v<T, UnionAll>) {
+      return unions_;
+    } else if constexpr (std::is_same_v<T, Join>) {
+      return joins_;
+    } else if constexpr (std::is_same_v<T, Window>) {
+      return windows_;
+    } else if constexpr (std::is_same_v<T, TopNRowNumber>) {
+      return topNRowNumbers_;
+    } else if constexpr (std::is_same_v<T, Apply>) {
+      return applies_;
+    } else if constexpr (std::is_same_v<T, EnforceSingleRow>) {
+      return enforceSingleRows_;
+    } else if constexpr (std::is_same_v<T, AssignUniqueId>) {
+      return assignUniqueIds_;
+    } else if constexpr (std::is_same_v<T, EnforceDistinct>) {
+      return enforceDistincts_;
+    } else if constexpr (std::is_same_v<T, Exchange>) {
+      return exchanges_;
+    } else if constexpr (std::is_same_v<T, TableWrite>) {
+      return tableWrites_;
+    } else {
+      static_assert(sizeof(T) == 0, "No dedup map for this node type");
+    }
+  }
+
+  const FunctionNames functionNames_;
+
+  // Maps a reversible binary function name to its reverse name.
+  // Symmetric reversibles (e.g. `eq`) map to themselves; asymmetric
+  // ones (e.g. `lt` → `gt`) map across.
+  folly::F14FastMap<Name, Name> reversibleFunctions_;
+
+  // Dedup container for hash-consed `T`: stores canonical `const T*`, keyed by
+  // the node/expr's own identity via transparent `T::KeyHash` / `T::KeyEq`.
+  template <typename T>
+  using DedupSet =
+      folly::F14FastSet<const T*, typename T::KeyHash, typename T::KeyEq>;
+
+  DedupSet<Scan> scans_;
+  DedupSet<Filter> filters_;
+  DedupSet<Project> projects_;
+  DedupSet<Limit> limits_;
+  DedupSet<Sort> sorts_;
+  DedupSet<TopN> topNs_;
+  DedupSet<Aggregate> aggregates_;
+  DedupSet<GroupId> groupIds_;
+  DedupSet<MarkDistinct> markDistincts_;
+  DedupSet<Values> values_;
+  DedupSet<Unnest> unnests_;
+  DedupSet<UnionAll> unions_;
+  DedupSet<Join> joins_;
+  DedupSet<Window> windows_;
+  DedupSet<TopNRowNumber> topNRowNumbers_;
+  DedupSet<Apply> applies_;
+  DedupSet<EnforceSingleRow> enforceSingleRows_;
+  DedupSet<AssignUniqueId> assignUniqueIds_;
+  DedupSet<EnforceDistinct> enforceDistincts_;
+  DedupSet<Exchange> exchanges_;
+  DedupSet<TableWrite> tableWrites_;
+
+  // Expr leaves, interned via `makeLiteral` / `makeCall` / `makeAggregate`.
+  DedupSet<Literal> literals_;
+  DedupSet<Call> calls_;
+  DedupSet<optimizer::Aggregate> aggregateCalls_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -1,0 +1,25 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_library(axiom_optimizer_v2 Builder.cpp Node.cpp NodePrinter.cpp PhysicalProperties.cpp)
+
+target_link_libraries(
+  axiom_optimizer_v2
+  axiom_common
+  axiom_connectors
+  axiom_logical_plan
+  axiom_optimizer
+  velox_common_base
+  velox_core
+)

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -19,22 +19,28 @@ endif()
 add_library(
   axiom_optimizer_v2
   AggregateRecovery.cpp
+  AlgebraicProperties.cpp
   Builder.cpp
   CostModel.cpp
   DecorrelatePass.cpp
+  DPhyp.cpp
   EstimateLeafStatsPass.cpp
   EstimateProvider.cpp
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
+  HypergraphBuilder.cpp
   JoinCondition.cpp
   JoinFanout.cpp
   JoinHypergraph.cpp
+  JoinTreeEmitter.cpp
   LimitAndOrderPass.cpp
   MemoOp.cpp
   Node.cpp
   NodePrinter.cpp
   PhysicalProperties.cpp
+  PlanPhysicalPass.cpp
+  PlanSet.cpp
   PushdownAndPrunePass.cpp
   ScanHandle.cpp
   TranslatePass.cpp

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(
   Node.cpp
   NodePrinter.cpp
   PhysicalProperties.cpp
+  PushdownAndPrunePass.cpp
   TranslatePass.cpp
 )
 

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -14,7 +14,9 @@
 
 add_library(
   axiom_optimizer_v2
+  AggregateRecovery.cpp
   Builder.cpp
+  DecorrelatePass.cpp
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   ExprFactory.cpp
   ExprSimplifier.cpp
   JoinCondition.cpp
+  LimitAndOrderPass.cpp
   Node.cpp
   NodePrinter.cpp
   PhysicalProperties.cpp

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -12,20 +12,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(AXIOM_BUILD_TESTING)
+  add_subdirectory(tests)
+endif()
+
 add_library(
   axiom_optimizer_v2
   AggregateRecovery.cpp
   Builder.cpp
+  CostModel.cpp
   DecorrelatePass.cpp
+  EstimateLeafStatsPass.cpp
+  EstimateProvider.cpp
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
   JoinCondition.cpp
+  JoinFanout.cpp
+  JoinHypergraph.cpp
   LimitAndOrderPass.cpp
+  MemoOp.cpp
   Node.cpp
   NodePrinter.cpp
   PhysicalProperties.cpp
   PushdownAndPrunePass.cpp
+  ScanHandle.cpp
   TranslatePass.cpp
 )
 

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -18,9 +18,11 @@ add_library(
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
+  JoinCondition.cpp
   Node.cpp
   NodePrinter.cpp
   PhysicalProperties.cpp
+  TranslatePass.cpp
 )
 
 target_link_libraries(
@@ -31,6 +33,7 @@ target_link_libraries(
   axiom_optimizer
   velox_common_base
   velox_core
+  velox_exec
   velox_expression
   velox_vector
 )

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -12,7 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(axiom_optimizer_v2 Builder.cpp Node.cpp NodePrinter.cpp PhysicalProperties.cpp)
+add_library(
+  axiom_optimizer_v2
+  Builder.cpp
+  ExprEmitter.cpp
+  ExprFactory.cpp
+  ExprSimplifier.cpp
+  Node.cpp
+  NodePrinter.cpp
+  PhysicalProperties.cpp
+)
 
 target_link_libraries(
   axiom_optimizer_v2
@@ -22,4 +31,6 @@ target_link_libraries(
   axiom_optimizer
   velox_common_base
   velox_core
+  velox_expression
+  velox_vector
 )

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -24,8 +24,10 @@ add_library(
   CostModel.cpp
   DecorrelatePass.cpp
   DPhyp.cpp
+  EmitPass.cpp
   EstimateLeafStatsPass.cpp
   EstimateProvider.cpp
+  ExpandAggregatePass.cpp
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
@@ -38,9 +40,11 @@ add_library(
   MemoOp.cpp
   Node.cpp
   NodePrinter.cpp
+  Optimize.cpp
   PhysicalProperties.cpp
   PlanPhysicalPass.cpp
   PlanSet.cpp
+  PrecomputeProjectionsPass.cpp
   PushdownAndPrunePass.cpp
   ScanHandle.cpp
   TranslatePass.cpp

--- a/axiom/optimizer/v2/Cost.h
+++ b/axiom/optimizer/v2/Cost.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Default per-input-row fanout assumed for an UNNEST when per-array
+/// size statistics are unavailable. The cardinality of an Unnest
+/// relation and the cost of its cross-join-unnest edge must use the
+/// same value so the two estimates agree.
+constexpr float kDefaultUnnestFanout = 10;
+
+/// Cost of a candidate physical plan or subplan, used to score memo
+/// entries during cost-based planning. The comparable score lives in
+/// 'cost'; 'cardinality' propagates into the cost of consumers above.
+struct Cost {
+  /// Total estimated cost, or nullopt when unknown. Lower is better; used to
+  /// compare memo entries with equivalent logical content. Unknown propagates:
+  /// a cost derived from an unknown cardinality is itself unknown, so candidate
+  /// ranking must treat unknown as not-comparable rather than substituting a
+  /// concrete fallback.
+  std::optional<float> cost;
+
+  /// Estimated output row count, or nullopt when unknown (a missing
+  /// input statistic propagates rather than being replaced by a concrete
+  /// fallback). Feeds into 'cost' of consumers that scan or process this
+  /// subplan's output.
+  std::optional<float> cardinality;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/CostModel.cpp
+++ b/axiom/optimizer/v2/CostModel.cpp
@@ -1,0 +1,382 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/CostModel.h"
+
+#include <folly/container/F14Set.h>
+
+#include "axiom/optimizer/Cost.h"
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/JoinFanout.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+using optimizer::add;
+using optimizer::maxOf;
+using optimizer::mul;
+
+using BySetMap = folly::F14FastMap<RelationSet, Estimate>;
+
+// Reads the memoized estimate for a child cover. DPhyp costs children before
+// their parents, so a join's child covers are always present when the join is
+// costed.
+const Estimate& coverEstimate(const RelationSet& cover, const BySetMap& bySet) {
+  const auto it = bySet.find(cover);
+  VELOX_CHECK(
+      it != bySet.end(), "Child cover estimate missing during join costing");
+  return it->second;
+}
+
+// Merges 'from' into 'into', keeping existing entries. Sources have disjoint
+// column-id spaces (a join's two child covers, or an unnest's single input), so
+// a collision would only re-insert an equal Value.
+void mergeConstraints(const ConstraintMap& from, ConstraintMap& into) {
+  for (const auto& [id, value] : from) {
+    into.emplace(id, value);
+  }
+}
+
+// Row count of one side of an edge: the product of the cardinalities of the
+// leaf relations the side spans. Fixed per relation (leaf estimates), so it is
+// independent of join order. Unknown if any relation's cardinality is unknown.
+std::optional<float> sideRowCount(
+    const RelationSet& side,
+    const JoinHypergraph& graph) {
+  std::optional<float> rows{1.0f};
+  side.forEach(
+      [&](int32_t id) { rows = mul(rows, graph.relation(id).cardinality()); });
+  return rows;
+}
+
+// Selectivity of an inner equi-edge relative to the cross product of its
+// operands: 1 / max(jointNdvLeft, jointNdvRight), where each side's joint key
+// NDV is the product of its per-key NDVs capped at the side's row count (a side
+// cannot have more distinct key tuples than rows — the cap keeps a correlated
+// composite key from being over-counted). The cap is the leaf relations' row
+// count, a fixed per-relation value, so a cover's cardinality — the product of
+// its operands' cardinalities and its internal edges' selectivities — stays
+// independent of the order the edges are applied. Key NDVs come from
+// `constraints` (the cover's refined per-column Values — post-filter, or the
+// derived NDV of an aggregate output) with the column's base `value()` as
+// fallback. An unknown key NDV makes it unknown; a zero-NDV key makes it 0
+// (empty join).
+std::optional<float> innerEdgeSelectivity(
+    const JoinEdge& edge,
+    const JoinHypergraph& graph,
+    const ConstraintMap& constraints) {
+  const auto& leftKeys = edge.leftKeys();
+  const auto& rightKeys = edge.rightKeys();
+  float jointNdvLeft{1};
+  float jointNdvRight{1};
+  for (size_t i = 0; i < leftKeys.size(); ++i) {
+    const std::optional<float> leftNdv =
+        value(constraints, leftKeys[i]).cardinality;
+    const std::optional<float> rightNdv =
+        value(constraints, rightKeys[i]).cardinality;
+    if (!leftNdv.has_value() || !rightNdv.has_value()) {
+      return std::nullopt;
+    }
+    if (*leftNdv == 0 || *rightNdv == 0) {
+      return 0.0f;
+    }
+    jointNdvLeft *= *leftNdv;
+    jointNdvRight *= *rightNdv;
+  }
+  if (const auto leftRows = sideRowCount(edge.left(), graph)) {
+    jointNdvLeft = std::min(jointNdvLeft, *leftRows);
+  }
+  if (const auto rightRows = sideRowCount(edge.right(), graph)) {
+    jointNdvRight = std::min(jointNdvRight, *rightRows);
+  }
+  return 1.0f / std::max(jointNdvLeft, jointNdvRight);
+}
+
+// Product of the operand cardinalities and the selectivities of the edges
+// crossing the join (its primary edge plus any inner extra edges of a cyclic
+// cover). This is the inner-join match count, and — for an all-inner cover —
+// the cover's output cardinality.
+std::optional<float> innerMatchCardinality(
+    const JoinOp& join,
+    const JoinHypergraph& graph,
+    const ConstraintMap& constraints,
+    std::optional<float> leftCardinality,
+    std::optional<float> rightCardinality) {
+  std::optional<float> matched = mul(leftCardinality, rightCardinality);
+  matched = mul(
+      matched,
+      innerEdgeSelectivity(graph.edges()[join.edgeIndex], graph, constraints));
+  for (size_t extraIndex : join.extraEdges) {
+    matched = mul(
+        matched,
+        innerEdgeSelectivity(graph.edges()[extraIndex], graph, constraints));
+  }
+  return matched;
+}
+
+// Estimated output row width of a subplan covering `cover`: the sum of the byte
+// widths (`Value::byteSize`) of `coverOutputColumns`. That set
+// already carries one representative per equivalence group equated within the
+// cover, so equal columns are counted once — and exactly as the emitter
+// materializes them.
+float coveredRowBytes(const RelationSet& cover, const JoinHypergraph& graph) {
+  float bytes{0};
+  graph.coverOutputColumns(cover).forEach<Column>(
+      [&](const Column* column) { bytes += column->value().byteSize(); });
+  return bytes;
+}
+
+// Records the leaf's estimate: its subtree cardinality and post-filter column
+// NDVs.
+const Estimate& leafEstimate(
+    const LeafOp& leaf,
+    const JoinHypergraph& graph,
+    EstimateProvider& estimateProvider,
+    BySetMap& bySet) {
+  const RelationSet cover = leaf.cover();
+  const auto it = bySet.find(cover);
+  if (it != bySet.end()) {
+    return it->second;
+  }
+  const auto* node = graph.relation(leaf.relationId).node();
+  return bySet.emplace(cover, estimateProvider.estimate(node)).first->second;
+}
+
+Cost leafCost(
+    const LeafOp& leaf,
+    const JoinHypergraph& graph,
+    EstimateProvider& estimateProvider,
+    BySetMap& bySet) {
+  const auto& estimate = leafEstimate(leaf, graph, estimateProvider, bySet);
+  Cost out;
+  out.cardinality = estimate.cardinality;
+  // A leaf's cost is its cardinality; an unknown cardinality is an unknown
+  // cost.
+  out.cost = estimate.cardinality;
+  return out;
+}
+
+// Records the estimate for a cross-join-unnest cover: the input cover's
+// constraints pass through (the unnest adds columns but does not change the
+// input columns' NDVs) and its cardinality scales by the unnest fanout.
+const Estimate& unnestEstimate(const JoinOp& join, BySetMap& bySet) {
+  const RelationSet cover = join.cover();
+  const auto it = bySet.find(cover);
+  if (it != bySet.end()) {
+    return it->second;
+  }
+  const Estimate& input = coverEstimate(join.left->cover(), bySet);
+  Estimate result;
+  mergeConstraints(input.constraints, result.constraints);
+  result.cardinality =
+      maxOf(1.0f, mul(input.cardinality, kDefaultUnnestFanout));
+  return bySet.emplace(cover, std::move(result)).first->second;
+}
+
+// Cost for a JoinOp wrapping a directed cross-join-unnest edge.
+// `join->left` is the input-side plan (the orientation enforcement in
+// DPhyp guarantees this); cardinality scales by the unnest fanout.
+Cost unnestJoinCost(
+    const JoinOp& join,
+    const JoinHypergraph& graph,
+    BySetMap& bySet) {
+  using optimizer::Costs;
+  const std::optional<float> inputCardinality = join.left->cost.cardinality;
+  const float rowBytes = coveredRowBytes(join.cover(), graph);
+  Cost out;
+  out.cardinality = unnestEstimate(join, bySet).cardinality;
+  // The per-row cost depends on the output cardinality; when that is unknown
+  // the whole cost is unknown (propagated, not fabricated).
+  const std::optional<float> perRowCost = out.cardinality.has_value()
+      ? std::optional<float>{Costs::hashRowCost(*out.cardinality, rowBytes)}
+      : std::nullopt;
+  out.cost =
+      add(add(join.left->cost.cost, mul(inputCardinality, perRowCost)),
+          mul(out.cardinality, perRowCost));
+  return out;
+}
+
+// Records the output cardinality for an equi-join cover. For an inner cover
+// this is the product of the operand cardinalities and the crossing edges'
+// selectivities, which is the same regardless of the order the joins are
+// applied. For outer/semi/anti the per-join-type formula is applied to the
+// preserved side.
+//
+// TODO: For covers of three or more relations whose join is outer/semi/anti,
+// the preserved side and the "last" edge depend on how the candidate splits the
+// cover, so the estimate is not yet independent of that split; computing it
+// from a fixed decomposition of the cover would remove the dependence.
+const Estimate&
+joinEstimate(const JoinOp& join, const JoinHypergraph& graph, BySetMap& bySet) {
+  const RelationSet cover = join.cover();
+  const auto it = bySet.find(cover);
+  if (it != bySet.end()) {
+    return it->second;
+  }
+  const Estimate& left = coverEstimate(join.left->cover(), bySet);
+  const Estimate& right = coverEstimate(join.right->cover(), bySet);
+  const auto& edge = graph.edges()[join.edgeIndex];
+
+  Estimate result;
+  // Combine the child covers' refined constraints so a join key that is an
+  // aggregate output (or a post-filter column) is costed from its derived NDV
+  // rather than the unknown base value.
+  mergeConstraints(left.constraints, result.constraints);
+  mergeConstraints(right.constraints, result.constraints);
+
+  const std::optional<float> matched = innerMatchCardinality(
+      join, graph, result.constraints, left.cardinality, right.cardinality);
+  if (edge.joinType() == velox::core::JoinType::kInner) {
+    result.cardinality = maxOf(1.0f, matched);
+  } else {
+    const bool edgeLeftIsPhysicalLeft =
+        edge.left().isSubset(join.left->cover());
+    result.cardinality = maxOf(
+        1.0f,
+        JoinFanout::outputCardinality(
+            edge.joinType(),
+            edgeLeftIsPhysicalLeft ? left.cardinality : right.cardinality,
+            edgeLeftIsPhysicalLeft ? right.cardinality : left.cardinality,
+            matched));
+  }
+  return bySet.emplace(cover, std::move(result)).first->second;
+}
+
+Cost hashJoinCost(
+    const JoinOp& join,
+    const JoinHypergraph& graph,
+    BySetMap& bySet) {
+  using optimizer::Costs;
+  const auto& edge = graph.edges()[join.edgeIndex];
+
+  // A join may apply several inner edges at once (cyclic join graph). DPhyp has
+  // already dropped edges made redundant by transitive equality, so every
+  // remaining edge restricts further. Collect all equi-key pairs, oriented to
+  // the physical left/right subplans so the joint-NDV cap uses the matching
+  // side cardinality.
+  ExprVector leftKeys;
+  ExprVector rightKeys;
+  const auto addEdgeKeys = [&](const JoinEdge& edgeToAdd) {
+    const bool leftIsLeft = edgeToAdd.left().isSubset(join.left->cover());
+    const auto& edgeLeftKeys =
+        leftIsLeft ? edgeToAdd.leftKeys() : edgeToAdd.rightKeys();
+    const auto& edgeRightKeys =
+        leftIsLeft ? edgeToAdd.rightKeys() : edgeToAdd.leftKeys();
+    leftKeys.insert(leftKeys.end(), edgeLeftKeys.begin(), edgeLeftKeys.end());
+    rightKeys.insert(
+        rightKeys.end(), edgeRightKeys.begin(), edgeRightKeys.end());
+  };
+  addEdgeKeys(edge);
+  for (size_t extraIndex : join.extraEdges) {
+    addEdgeKeys(graph.edges()[extraIndex]);
+  }
+
+  // Pure non-equi edges have no keys; treat them as if they had one
+  // so the per-key cost terms still contribute.
+  const auto numKeys = static_cast<float>(std::max<size_t>(1, leftKeys.size()));
+  // Build-side (right) output row width.
+  const float rowBytes = coveredRowBytes(join.right->cover(), graph);
+  const std::optional<float> leftCard = join.left->cost.cardinality;
+  const std::optional<float> rightCard = join.right->cost.cardinality;
+
+  Cost out;
+  out.cardinality = joinEstimate(join, graph, bySet).cardinality;
+
+  // Per-row hash-build and probe cost formulas. Each term that
+  // reads a cardinality is unknown when that cardinality is unknown.
+  if (!rightCard.has_value()) {
+    // Build and probe unit costs both depend on the right (build) side; an
+    // unknown build cardinality makes the join cost unknown.
+    out.cost = std::nullopt;
+    return out;
+  }
+  const float buildUnitCost = Costs::hashBuildCost(*rightCard, rowBytes) +
+      numKeys * 2 * Costs::kHashColumnCost + numKeys * Costs::kKeyCompareCost;
+  // The probe key-compare term scales by min(1, output cardinality); when the
+  // output cardinality is unknown that term — and so the probe unit cost — is
+  // unknown.
+  const std::optional<float> probeUnitCost = out.cardinality.has_value()
+      ? std::optional<
+            float>{Costs::hashTableCost(*rightCard) + numKeys * Costs::kHashColumnCost + numKeys * Costs::kKeyCompareCost * std::min<float>(1, *out.cardinality)}
+      : std::nullopt;
+  const float rowUnitCost = Costs::hashRowCost(*rightCard, rowBytes);
+
+  // Left-to-right association matches the original flat sum bit-for-bit when
+  // every term is known, so build-side selection is unchanged in that case.
+  out.cost =
+      add(add(add(add(join.left->cost.cost, join.right->cost.cost),
+                  mul(*rightCard, buildUnitCost)),
+              mul(leftCard, probeUnitCost)),
+          mul(out.cardinality, rowUnitCost));
+  return out;
+}
+
+} // namespace
+
+std::optional<float> DefaultCostModel::shuffleCost(
+    MemoOpCP op,
+    const JoinHypergraph& graph) const {
+  return mul(
+      op->cost.cardinality,
+      coveredRowBytes(op->cover(), graph) * Costs::kByteShuffleCost);
+}
+
+std::optional<float> DefaultCostModel::broadcastCost(
+    MemoOpCP op,
+    const JoinHypergraph& graph,
+    int32_t numWorkers) const {
+  return mul(shuffleCost(op, graph), static_cast<float>(numWorkers));
+}
+
+bool DefaultCostModel::broadcastFits(
+    MemoOpCP op,
+    const JoinHypergraph& graph,
+    int64_t limitBytes) const {
+  if (limitBytes <= 0) {
+    return true;
+  }
+  if (!op->cost.cardinality.has_value()) {
+    return false;
+  }
+  return *op->cost.cardinality * coveredRowBytes(op->cover(), graph) <=
+      static_cast<float>(limitBytes);
+}
+
+DefaultCostModel::DefaultCostModel(EstimateProvider& estimateProvider)
+    : estimateProvider_{estimateProvider} {}
+
+Cost DefaultCostModel::cost(MemoOpCP op, const JoinHypergraph& graph) const {
+  switch (op->kind()) {
+    case MemoOpKind::kLeaf:
+      return leafCost(*op->as<LeafOp>(), graph, estimateProvider_, bySet_);
+    case MemoOpKind::kJoin: {
+      const auto* join = op->as<JoinOp>();
+      const auto& edge = graph.edges()[join->edgeIndex];
+      if (edge.isUnnest()) {
+        return unnestJoinCost(*join, graph, bySet_);
+      }
+      return hashJoinCost(*join, graph, bySet_);
+    }
+    case MemoOpKind::kExchange:
+      VELOX_UNREACHABLE("ExchangeOp cost is set at construction");
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/CostModel.h
+++ b/axiom/optimizer/v2/CostModel.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/optimizer/v2/Cost.h"
+#include "axiom/optimizer/v2/EstimateProvider.h"
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+#include "axiom/optimizer/v2/MemoOp.h"
+#include "axiom/optimizer/v2/RelationSet.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Pluggable cost source: given a candidate `MemoOp` plan, returns its cost.
+/// A node's children have their `cost` fields populated before the node is
+/// costed, so an implementation may read them without recomputing. Also prices
+/// the distributed-exchange costs (shuffle, broadcast), so a custom model
+/// controls the whole cost surface, not just per-op cost.
+///
+/// A model may cache per-cover estimates for the single hypergraph it is
+/// costing, so it is not required to be thread-safe: construct one per
+/// (single-threaded) planning run.
+class CostModel {
+ public:
+  virtual ~CostModel() = default;
+
+  /// Returns the cost (and output cardinality) of executing the plan
+  /// rooted at `op`. `graph` provides access to the relations and
+  /// edges referenced by leaves and joins.
+  virtual Cost cost(MemoOpCP op, const JoinHypergraph& graph) const = 0;
+
+  /// Cost of repartitioning `op`'s output with a remote (across-task) exchange.
+  /// Returns nullopt when the output cardinality is unknown.
+  virtual std::optional<float> shuffleCost(
+      MemoOpCP op,
+      const JoinHypergraph& graph) const = 0;
+
+  /// Cost of broadcasting `op`'s output to every one of `numWorkers` tasks,
+  /// each of which receives a full copy. Returns nullopt when the output
+  /// cardinality is unknown.
+  virtual std::optional<float> broadcastCost(
+      MemoOpCP op,
+      const JoinHypergraph& graph,
+      int32_t numWorkers) const = 0;
+
+  /// True if `op`'s estimated output fits `limitBytes`, so each task can hold a
+  /// full broadcast copy. Unknown cardinality is not broadcastable. A
+  /// non-positive `limitBytes` disables the limit (always fits).
+  virtual bool broadcastFits(
+      MemoOpCP op,
+      const JoinHypergraph& graph,
+      int64_t limitBytes) const = 0;
+};
+
+/// Default cost model used when callers don't supply one. Costs leaves at their
+/// cardinality and costs joins with hash-join formulas (build asymmetric
+/// in the build-side cardinality, probe asymmetric in the probe-side
+/// cardinality).
+///
+/// Carries a per-cover estimate memo (`bySet_`): as DPhyp costs candidates
+/// bottom-up, each cover's cardinality is computed once — for an inner cover,
+/// as the product of the base cardinalities and the per-edge selectivities,
+/// which is the same regardless of the order the joins are applied — and reused
+/// by every later candidate for the same cover. So the cardinality DPhyp costs
+/// on does not depend on which join order reached the cover. Leaf estimates are
+/// seeded from `estimateProvider`. `RelationSet` ids are cluster-local, so
+/// construct one model per cluster.
+///
+/// Future work: pull row width and column counts from the relations covered by
+/// each MemoOp; add `cost()` dispatch for non-join MemoOp kinds (aggregate, the
+/// `ExchangeOp` node itself, ...) as those land.
+class DefaultCostModel : public CostModel {
+ public:
+  /// `estimateProvider` supplies the per-node cardinality and column-NDV
+  /// estimates used to seed each leaf cover. It is shared across the query's
+  /// clusters and must outlive this model.
+  explicit DefaultCostModel(EstimateProvider& estimateProvider);
+
+  Cost cost(MemoOpCP op, const JoinHypergraph& graph) const override;
+
+  /// Prices the exchange as `cardinality × output row bytes ×
+  /// Costs::kByteShuffleCost`.
+  std::optional<float> shuffleCost(MemoOpCP op, const JoinHypergraph& graph)
+      const override;
+
+  /// `shuffleCost(op)` times `numWorkers`.
+  std::optional<float> broadcastCost(
+      MemoOpCP op,
+      const JoinHypergraph& graph,
+      int32_t numWorkers) const override;
+
+  /// True when `cardinality × output row bytes` is within `limitBytes`.
+  bool broadcastFits(
+      MemoOpCP op,
+      const JoinHypergraph& graph,
+      int64_t limitBytes) const override;
+
+ private:
+  EstimateProvider& estimateProvider_;
+
+  // Per-cover estimate (see class doc): the cover's cardinality and its refined
+  // per-column NDVs, so a join key that is a post-filter column or an aggregate
+  // output is costed from a derived NDV rather than the unknown base value.
+  // Mutable because `cost` is const; safe under the single-threaded planning
+  // assumption.
+  mutable folly::F14FastMap<RelationSet, Estimate> bySet_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/DPhyp.cpp
+++ b/axiom/optimizer/v2/DPhyp.cpp
@@ -1,0 +1,1005 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/DPhyp.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <folly/container/F14Set.h>
+#include <folly/small_vector.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/CostModel.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+DPhyp::DPhyp(
+    const JoinHypergraph& graph,
+    const CostModel& costModel,
+    int64_t enumerationBudget,
+    int32_t numWorkers,
+    int64_t broadcastSizeLimit)
+    : graph_{graph},
+      costModel_{costModel},
+      enumerationBudget_{enumerationBudget},
+      numWorkers_{numWorkers},
+      broadcastSizeLimit_{broadcastSizeLimit} {
+  VELOX_CHECK_GE(
+      graph_.relations().size(),
+      2,
+      "DPhyp requires at least two relations to enumerate join orders");
+}
+
+namespace {
+
+// Vertices reachable from `set` via one hyperedge whose "other" side
+// is fully outside `set`. Excludes any vertex in `forbidden`.
+RelationSet neighborhood(
+    const JoinHypergraph& graph,
+    RelationSet set,
+    RelationSet forbidden) {
+  RelationSet result;
+  for (const auto& edge : graph.edges()) {
+    RelationSet other;
+    if (edge.left().isSubset(set) && !edge.right().hasIntersection(set)) {
+      other = edge.right();
+    } else if (
+        edge.right().isSubset(set) && !edge.left().hasIntersection(set)) {
+      other = edge.left();
+    } else {
+      continue;
+    }
+    other.except(forbidden);
+    result.unionSet(other);
+  }
+  return result;
+}
+
+// Returns the join type for the same join with operands swapped.
+velox::core::JoinType flipJoinType(velox::core::JoinType kind) {
+  switch (kind) {
+    case velox::core::JoinType::kInner:
+    case velox::core::JoinType::kFull:
+      return kind;
+    case velox::core::JoinType::kLeft:
+      return velox::core::JoinType::kRight;
+    case velox::core::JoinType::kRight:
+      return velox::core::JoinType::kLeft;
+    case velox::core::JoinType::kLeftSemiFilter:
+      return velox::core::JoinType::kRightSemiFilter;
+    case velox::core::JoinType::kRightSemiFilter:
+      return velox::core::JoinType::kLeftSemiFilter;
+    case velox::core::JoinType::kLeftSemiProject:
+      return velox::core::JoinType::kRightSemiProject;
+    case velox::core::JoinType::kRightSemiProject:
+      return velox::core::JoinType::kLeftSemiProject;
+    default:
+      // kAnti is single-orientation; it has no reversed JoinType spelling.
+      VELOX_UNREACHABLE(
+          "Unsupported join type for orientation flip: {}",
+          velox::core::JoinTypeName::toName(kind));
+  }
+}
+
+// True if the edge's right (build-on-the-preserved-side) orientation is a
+// valid Velox plan. Both the kRightSemiProject build-side flip of a
+// kLeftSemiProject and the reversed-anti lowering (kRightSemiProject +
+// Filter(not mark)) put the edge's residual filter on a kRightSemiProject,
+// which Velox forbids for null-aware joins (PlanNode.h). So a null-aware
+// edge carrying a filter is single-orientation.
+bool hasRightProjectVariant(const JoinEdge& edge) {
+  return !(edge.nullAware() && !edge.filter().empty());
+}
+
+// Caps DPhyp's connected-subgraph/complement enumeration. DPhyp is polynomial
+// in the number of csg/cmp pairs for sparse graphs but exponential for dense
+// ones (e.g. a same-key N-way join the transitive-equality closure turns into a
+// clique), so the bound caps worst-case planning time; sparse real queries stay
+// far below it. A cap <= 0 is unlimited. Once the count exceeds the cap the
+// budget trips and stays tripped, so the recursion unwinds and the caller falls
+// back to greedy ordering.
+class EnumerationBudget {
+ public:
+  // A cap <= 0 disables the budget (unlimited enumeration).
+  explicit EnumerationBudget(int64_t cap) : cap_{cap}, enforced_{cap > 0} {}
+
+  // Counts one csg/cmp pair and returns true once the budget is exceeded (and
+  // on every later call), signalling the caller to stop. Always false while
+  // disabled or unlimited.
+  bool consume() {
+    if (!enforced_) {
+      return false;
+    }
+    if (!exceeded_ && ++count_ > cap_) {
+      exceeded_ = true;
+    }
+    return exceeded_;
+  }
+
+  // True once the budget has been exceeded; guards the recursion.
+  bool exceeded() const {
+    return exceeded_;
+  }
+
+  // Restarts the count for a fresh (per-component) enumeration.
+  void reset() {
+    count_ = 0;
+    exceeded_ = false;
+    enforced_ = cap_ > 0;
+  }
+
+  // Stops enforcement; greedy's polynomial GOO loop must run to completion.
+  void disable() {
+    enforced_ = false;
+  }
+
+ private:
+  // Pair cap; <= 0 when unlimited (then `enforced_` is false and this is
+  // unused).
+  const int64_t cap_;
+  int64_t count_{0};
+  bool exceeded_{false};
+  bool enforced_;
+};
+
+// Moerkotte/Neumann 2006 DPhyp (csg/cmp recursion).
+class Enumerator {
+ public:
+  // `enumerationBudget` caps the csg/cmp pairs evaluated before falling back to
+  // greedy ordering; <= 0 means unlimited. See `EnumerationBudget`.
+  Enumerator(
+      const JoinHypergraph& graph,
+      const CostModel& costModel,
+      folly::F14NodeMap<RelationSet, PlanSet>& memo,
+      int64_t enumerationBudget,
+      int32_t numWorkers,
+      int64_t broadcastSizeLimit,
+      std::vector<std::unique_ptr<MemoOp>>& enforcementOps)
+      : graph_{graph},
+        costModel_{costModel},
+        memo_{memo},
+        budget_{enumerationBudget},
+        numWorkers_{numWorkers},
+        broadcastSizeLimit_{broadcastSizeLimit},
+        enforcementOps_{enforcementOps} {}
+
+  // Runs the DP enumeration over `component` (a connected relation set).
+  // Returns true if it gave up after exceeding the enumeration budget (the
+  // component is too dense); the caller then plans the component greedily.
+  // Resets the budget counters so each component is enumerated — and its budget
+  // judged — independently.
+  bool solveComponent(RelationSet component) {
+    budget_.reset();
+    initLeaves(component);
+    folly::small_vector<int32_t, 16> ids;
+    component.forEach([&](int32_t id) { ids.push_back(id); });
+    // Descending id: each (subgraph, complement) pair is emitted once.
+    for (auto it = ids.rbegin(); it != ids.rend(); ++it) {
+      const RelationSet subgraph = RelationSet::singleton(*it);
+      emitCsg(subgraph);
+      enumerateCsgRec(subgraph, RelationSet::prefixThrough(*it));
+    }
+    return budget_.exceeded();
+  }
+
+  // Runs the DP enumeration over the whole graph (a single connected
+  // component).
+  bool solve() {
+    return solveComponent(
+        RelationSet::prefixThrough(graph_.relations().back().id()));
+  }
+
+  // Greedy operator ordering (GOO) for `component`: repeatedly merge the
+  // connected pair of subplans with the smallest join-output cardinality until
+  // one remains. Polynomial, used when `solve` overflows the enumeration
+  // budget. Cardinality (not plan cost) drives which pair to merge — the
+  // classic GOO heuristic of keeping intermediate results small; the
+  // build/probe orientation within a chosen pair is still cost-optimal
+  // (cardinality is orientation-invariant). Returns the component's root plan,
+  // or nullptr if a relation's cardinality is unknown. Reuses any matching
+  // subplans already in the memo (all memoized subplans are valid), so a
+  // partially-filled memo from an overflowed `solveComponent` is fine.
+  MemoOpCP greedy(RelationSet component) {
+    budget_.disable();
+    initLeaves(component);
+    // A join touching a relation of unknown cardinality has unknown cardinality
+    // too, so a component with any such relation can never be assembled. Bail
+    // before doing merge work; the caller falls back to syntactic order.
+    bool allCardinalitiesKnown = true;
+    component.forEach([&](int32_t id) {
+      const auto it = memo_.find(RelationSet::singleton(id));
+      if (it == memo_.end() || !it->second.cardinality().has_value()) {
+        allCardinalitiesKnown = false;
+      }
+    });
+    if (!allCardinalitiesKnown) {
+      return nullptr;
+    }
+    std::vector<RelationSet> fragments;
+    component.forEach(
+        [&](int32_t id) { fragments.push_back(RelationSet::singleton(id)); });
+    while (fragments.size() > 1) {
+      std::optional<float> bestCardinality;
+      size_t bestLeft = 0;
+      size_t bestRight = 0;
+      RelationSet bestCombined;
+      for (size_t i = 0; i < fragments.size(); ++i) {
+        for (size_t j = i + 1; j < fragments.size(); ++j) {
+          RelationSet combined{fragments[i]};
+          combined.unionSet(fragments[j]);
+          emitCsgCmp(fragments[i], fragments[j]);
+          const auto it = memo_.find(combined);
+          // emitCsgCmp records a pair only when an edge connects it and the
+          // join is costable — considerCandidate drops uncostable plans — so a
+          // missing entry means no edge or an unknown-NDV join key, and a
+          // present entry always has a known cardinality.
+          if (it == memo_.end()) {
+            continue;
+          }
+          const float cardinality = *it->second.cardinality();
+          if (!bestCardinality.has_value() || cardinality < *bestCardinality) {
+            bestCardinality = cardinality;
+            bestLeft = i;
+            bestRight = j;
+            bestCombined = combined;
+          }
+        }
+      }
+      if (!bestCardinality.has_value()) {
+        // No remaining fragment pair can be costed into a single join. In a
+        // connected component connectivity is never the blocker — contracting
+        // merged fragments keeps the graph connected, so an edge-joined pair
+        // always exists — so every such pair must have unknown cardinality (a
+        // join key without NDV). Genuine cross products are split into separate
+        // components upstream, not handled here. Caller falls back to syntactic
+        // order.
+        return nullptr;
+      }
+      fragments[bestLeft] = bestCombined;
+      fragments.erase(fragments.begin() + bestRight);
+    }
+    const auto it = memo_.find(component);
+    return it == memo_.end() ? nullptr : it->second.cheapest();
+  }
+
+ private:
+  // Adds a LeafOp for every relation in `relations` not already in the memo.
+  void initLeaves(RelationSet relations) {
+    relations.forEach([&](int32_t id) {
+      const RelationSet singleton = RelationSet::singleton(id);
+      if (memo_.contains(singleton)) {
+        return;
+      }
+      auto leaf = std::make_unique<LeafOp>(
+          Cost{},
+          static_cast<int8_t>(id),
+          graph_.relation(id).node()->physicalProperties().globalPartition);
+      leaf->cost = costModel_.cost(leaf.get(), graph_);
+      memo_[singleton].addPlan(std::move(leaf), graph_, costModel_);
+    });
+  }
+
+  void emitCsg(RelationSet subgraph) {
+    if (budget_.exceeded()) {
+      return;
+    }
+    const RelationSet forbidden = RelationSet::prefixThrough(subgraph.min());
+    const RelationSet neighbors = neighborhood(graph_, subgraph, forbidden);
+    // Descending id ensures each (subgraph, complement) pair is emitted once.
+    std::vector<int8_t> orderedNeighbors;
+    orderedNeighbors.reserve(neighbors.size());
+    neighbors.forEach([&](int32_t id) {
+      orderedNeighbors.push_back(static_cast<int8_t>(id));
+    });
+    std::sort(orderedNeighbors.rbegin(), orderedNeighbors.rend());
+    for (int8_t vertexId : orderedNeighbors) {
+      const RelationSet complement = RelationSet::singleton(vertexId);
+      emitCsgCmp(subgraph, complement);
+      // Complement must stay disjoint from subgraph; `forbidden`
+      // alone does not cover subgraph when emitCsg is invoked with
+      // a non-singleton subgraph.
+      RelationSet cmpForbidden{forbidden};
+      cmpForbidden.unionSet(subgraph);
+      RelationSet vertexTail = RelationSet::prefixThrough(vertexId);
+      vertexTail.intersect(neighbors);
+      cmpForbidden.unionSet(vertexTail);
+      enumerateCmpRec(subgraph, complement, cmpForbidden);
+    }
+  }
+
+  void emitCsgCmp(RelationSet subgraph, RelationSet complement) {
+    if (budget_.consume()) {
+      return;
+    }
+    const auto itLeft = memo_.find(subgraph);
+    const auto itRight = memo_.find(complement);
+    VELOX_DCHECK(itLeft != memo_.end(), "subgraph not memoized");
+    VELOX_DCHECK(itRight != memo_.end(), "complement not memoized");
+    MemoOpCP leftPlan = itLeft->second.cheapest();
+    MemoOpCP rightPlan = itRight->second.cheapest();
+    RelationSet combined{subgraph};
+    combined.unionSet(complement);
+
+    // Collect every edge crossing this partition (TES-covered). Standard
+    // DPhyp applies all predicates connecting the two subgraphs at the join;
+    // with a cyclic join graph more than one edge can cross.
+    folly::small_vector<std::pair<size_t, bool>, 4> crossing;
+    for (size_t edgeIndex{0}; edgeIndex < graph_.edges().size(); ++edgeIndex) {
+      const auto& edge = graph_.edges()[edgeIndex];
+      const bool forward =
+          edge.left().isSubset(subgraph) && edge.right().isSubset(complement);
+      const bool reverse =
+          edge.left().isSubset(complement) && edge.right().isSubset(subgraph);
+      if (!forward && !reverse) {
+        continue;
+      }
+      // Skip edges whose TES is not yet covered.
+      if (!graph_.tes()[edgeIndex].isSubset(combined)) {
+        continue;
+      }
+      crossing.push_back({edgeIndex, forward});
+    }
+
+    if (crossing.empty()) {
+      return;
+    }
+    if (crossing.size() == 1) {
+      emitSingleEdge(
+          crossing[0].first, crossing[0].second, leftPlan, rightPlan, combined);
+      return;
+    }
+
+    // Several inner edges cross: apply them as one inner join over all their
+    // keys. A non-inner edge co-crossing has no single well-defined join
+    // type here and is not supported; fail rather than drop a predicate.
+    for (const auto& [edgeIndex, forward] : crossing) {
+      const auto& edge = graph_.edges()[edgeIndex];
+      VELOX_CHECK(
+          edge.joinType() == velox::core::JoinType::kInner && !edge.isUnnest(),
+          "Multiple edges cross one join partition with a non-inner edge: {}",
+          velox::core::JoinTypeName::toName(edge.joinType()));
+    }
+    std::sort(
+        crossing.begin(), crossing.end(), [](const auto& lhs, const auto& rhs) {
+          return lhs.first < rhs.first;
+        });
+
+    // Drop an edge whose every key is in an equivalence class already covered
+    // by a kept edge: it expresses a transitive equality the kept edges enforce
+    // (closure can add several same-class edges across one partition), so it
+    // would only add redundant join keys. Each side already equates its
+    // same-class columns (the class's first edge was applied when the side was
+    // built), so the dropped equality still holds. The lowest-index edge of
+    // each class is kept, which is deterministic.
+    folly::F14FastSet<EquivalenceP> seenClasses;
+    const auto keyClass = [](ExprCP key) -> EquivalenceP {
+      return key->isColumn() ? key->as<Column>()->equivalence() : nullptr;
+    };
+    const auto coveredBySeen = [&](const JoinEdge& joinEdge) {
+      if (joinEdge.leftKeys().empty()) {
+        return false;
+      }
+      for (ExprCP key : joinEdge.leftKeys()) {
+        const EquivalenceP equivalenceClass = keyClass(key);
+        if (equivalenceClass == nullptr ||
+            !seenClasses.contains(equivalenceClass)) {
+          return false;
+        }
+      }
+      return true;
+    };
+    const auto markClasses = [&](const JoinEdge& joinEdge) {
+      for (ExprCP key : joinEdge.leftKeys()) {
+        if (const EquivalenceP equivalenceClass = keyClass(key)) {
+          seenClasses.insert(equivalenceClass);
+        }
+      }
+    };
+
+    const size_t primary{crossing.front().first};
+    markClasses(graph_.edges()[primary]);
+    std::vector<size_t> extras;
+    extras.reserve(crossing.size() - 1);
+    for (size_t i = 1; i < crossing.size(); ++i) {
+      const size_t edgeIndex = crossing[i].first;
+      const JoinEdge& edge = graph_.edges()[edgeIndex];
+      if (coveredBySeen(edge)) {
+        continue;
+      }
+      markClasses(edge);
+      extras.push_back(edgeIndex);
+    }
+    considerCandidate(
+        leftPlan,
+        rightPlan,
+        primary,
+        velox::core::JoinType::kInner,
+        combined,
+        /*reversedAnti=*/false,
+        extras);
+    considerCandidate(
+        rightPlan,
+        leftPlan,
+        primary,
+        velox::core::JoinType::kInner,
+        combined,
+        /*reversedAnti=*/false,
+        extras);
+  }
+
+  // Emits join candidates for a single edge crossing the partition,
+  // preserving orientation rules (native-only for unnest / anti /
+  // null-aware semi-project; both orientations otherwise).
+  void emitSingleEdge(
+      size_t edgeIndex,
+      bool forward,
+      MemoOpCP leftPlan,
+      MemoOpCP rightPlan,
+      RelationSet combined) {
+    const auto& edge = graph_.edges()[edgeIndex];
+    // `probeOnLeft` plays the edge's left operand; `probeOnRight` its right.
+    MemoOpCP probeOnLeft = forward ? leftPlan : rightPlan;
+    MemoOpCP probeOnRight = forward ? rightPlan : leftPlan;
+
+    const bool nativeOnly = edge.isUnnest() ||
+        edge.joinType() == velox::core::JoinType::kAnti ||
+        (edge.joinType() == velox::core::JoinType::kLeftSemiProject &&
+         !hasRightProjectVariant(edge));
+    if (nativeOnly) {
+      considerCandidate(
+          probeOnLeft, probeOnRight, edgeIndex, edge.joinType(), combined);
+      // Antijoin can additionally build on the preserved (left) side by
+      // probing with the right input (the reversed orientation).
+      if (edge.joinType() == velox::core::JoinType::kAnti &&
+          hasRightProjectVariant(edge)) {
+        considerCandidate(
+            probeOnRight,
+            probeOnLeft,
+            edgeIndex,
+            edge.joinType(),
+            combined,
+            /*reversedAnti=*/true);
+      }
+      return;
+    }
+
+    // Flip the joinType when the subgraph plays the edge's right operand.
+    const auto leftTypeForSubgraph =
+        forward ? edge.joinType() : flipJoinType(edge.joinType());
+    considerCandidate(
+        leftPlan, rightPlan, edgeIndex, leftTypeForSubgraph, combined);
+    considerCandidate(
+        rightPlan,
+        leftPlan,
+        edgeIndex,
+        flipJoinType(leftTypeForSubgraph),
+        combined);
+  }
+
+  // Records an enforcement exchange and returns a stable pointer to it.
+  MemoOpCP makeExchange(MemoOpCP child, Partitioning partitioning, Cost cost) {
+    auto op =
+        std::make_unique<ExchangeOp>(cost, child, std::move(partitioning));
+    MemoOpCP ptr = op.get();
+    enforcementOps_.push_back(std::move(op));
+    return ptr;
+  }
+
+  // Cheapest plan for `cover` in `required`: an already-matching plan if one
+  // exists, else the cheapest wrapped in a repartition exchange to `required`.
+  // Null when `cover` has no costable plan (e.g. a relation with no stats), so
+  // the caller drops the strategy rather than building on an unrankable child.
+  MemoOpCP bestOnPartitioning(RelationSet cover, Partitioning required) {
+    const auto it = memo_.find(cover);
+    if (it == memo_.end()) {
+      return nullptr;
+    }
+    const auto selection =
+        it->second.best({.globalPartition = required}, graph_, costModel_);
+    if (selection.plan == nullptr) {
+      return nullptr;
+    }
+    if (selection.plan->outputPartitioning().sameClassAs(required)) {
+      return selection.plan;
+    }
+    return makeExchange(selection.plan, std::move(required), selection.cost);
+  }
+
+  // Cheapest plan for `cover` standard-hash partitioned on `keys`.
+  MemoOpCP repartitioned(
+      RelationSet cover,
+      const ExprVector& keys,
+      bool replicateNullsAndAny) {
+    return bestOnPartitioning(
+        cover,
+        Partitioning::globalHash(
+            keysInCoverSchema(keys, cover), replicateNullsAndAny));
+  }
+
+  // Cheapest plan for `cover` repartitioned on `keys` using `targetType`
+  // (a connector partitioning), so it co-locates with a side already bucketed
+  // that way.
+  MemoOpCP repartitionedTo(
+      RelationSet cover,
+      const ExprVector& keys,
+      const connector::PartitionType* targetType) {
+    Partitioning required =
+        Partitioning::globalHash(keysInCoverSchema(keys, cover));
+    required.partitionType = targetType;
+    return bestOnPartitioning(cover, std::move(required));
+  }
+
+  // Cheapest plan for `cover` already connector-bucketed on `keys`, or null
+  // when `cover` is unmemoized or has no such plan.
+  MemoOpCP bucketedOn(RelationSet cover, const ExprVector& keys) {
+    const auto it = memo_.find(cover);
+    if (it == memo_.end()) {
+      return nullptr;
+    }
+    return it->second.bestBucketed(keysInCoverSchema(keys, cover));
+  }
+
+  // Cheapest plan for `cover` broadcast to all tasks. Null when `cover` has no
+  // costable plan, or when its estimated size exceeds the broadcast limit (it
+  // would not fit in each task's memory) — the caller then relies on the
+  // co-partition candidate.
+  MemoOpCP broadcastChild(RelationSet cover) {
+    const auto it = memo_.find(cover);
+    if (it == memo_.end()) {
+      return nullptr;
+    }
+    MemoOpCP base = it->second.cheapest();
+    if (base == nullptr) {
+      return nullptr;
+    }
+    if (!costModel_.broadcastFits(base, graph_, broadcastSizeLimit_)) {
+      return nullptr;
+    }
+    Cost cost = base->cost;
+    cost.cost = add(
+        base->cost.cost, costModel_.broadcastCost(base, graph_, numWorkers_));
+    return makeExchange(base, Partitioning::globalBroadcast(), cost);
+  }
+
+  // Equi-keys oriented to the physical (left, right) children across the
+  // primary and extra edges.
+  std::pair<ExprVector, ExprVector> orientedKeys(
+      MemoOpCP left,
+      size_t edgeIndex,
+      const std::vector<size_t>& extraEdges) {
+    ExprVector leftKeys;
+    ExprVector rightKeys;
+    const auto collect = [&](const JoinEdge& edge) {
+      const bool leftIsLeft = edge.left().isSubset(left->cover());
+      const auto& edgeLeft = leftIsLeft ? edge.leftKeys() : edge.rightKeys();
+      const auto& edgeRight = leftIsLeft ? edge.rightKeys() : edge.leftKeys();
+      leftKeys.insert(leftKeys.end(), edgeLeft.begin(), edgeLeft.end());
+      rightKeys.insert(rightKeys.end(), edgeRight.begin(), edgeRight.end());
+    };
+    collect(graph_.edges()[edgeIndex]);
+    for (size_t extra : extraEdges) {
+      collect(graph_.edges()[extra]);
+    }
+    return {std::move(leftKeys), std::move(rightKeys)};
+  }
+
+  // Rewrites each partition key to the representative of its equivalence group
+  // within 'cover' — the column that survives in a subplan over 'cover'.
+  // Partition keys are taken from the raw edge keys, but an equi-join collapses
+  // each equated group to that one representative in its output; without this
+  // rewrite a key could name a collapsed-away column the output no longer
+  // carries.
+  ExprVector keysInCoverSchema(
+      const ExprVector& keys,
+      const RelationSet& cover) {
+    const auto reps = graph_.coverColumnReps(cover);
+    ExprVector result;
+    result.reserve(keys.size());
+    for (ExprCP key : keys) {
+      const auto it =
+          key->isColumn() ? reps.find(key->as<Column>()) : reps.end();
+      result.push_back(it != reps.end() ? it->second : key);
+    }
+    return result;
+  }
+
+  // Builds, costs, and (if costable) inserts one join candidate with the given
+  // output partitioning. The children are already distribution-enforced.
+  void addJoinCandidate(
+      MemoOpCP left,
+      MemoOpCP right,
+      size_t edgeIndex,
+      velox::core::JoinType joinType,
+      RelationSet combined,
+      bool reversedAnti,
+      std::vector<size_t> extraEdges,
+      Partitioning outputPartitioning) {
+    // One budget unit per candidate, not per csg/cmp pair: at numWorkers>1 a
+    // pair fans out into several distribution variants, so candidate count is
+    // the work that explodes on a clique.
+    budget_.consume();
+    auto candidate = std::make_unique<JoinOp>(
+        Cost{},
+        left,
+        right,
+        edgeIndex,
+        joinType,
+        reversedAnti,
+        std::move(extraEdges),
+        std::move(outputPartitioning));
+    candidate->cost = costModel_.cost(candidate.get(), graph_);
+    // An uncostable subplan cannot be ranked or built on; drop it.
+    if (!candidate->cost.cost.has_value()) {
+      return;
+    }
+    memo_[combined].addPlan(std::move(candidate), graph_, costModel_);
+  }
+
+  // Adds join candidates that avoid shuffling the bucketed side(s): both sides
+  // co-located when both are bucketed, or the unbucketed side repartitioned to
+  // the bucketed side's connector partitioning. The output is partitioned on
+  // the probe (left) keys with the preserved bucket type.
+  void addCoBucketedCandidate(
+      MemoOpCP left,
+      MemoOpCP right,
+      const ExprVector& leftKeys,
+      const ExprVector& rightKeys,
+      size_t edgeIndex,
+      velox::core::JoinType joinType,
+      RelationSet combined,
+      bool reversedAnti,
+      const std::vector<size_t>& extraEdges) {
+    MemoOpCP leftBucketed = bucketedOn(left->cover(), leftKeys);
+    MemoOpCP rightBucketed = bucketedOn(right->cover(), rightKeys);
+    if (leftBucketed == nullptr && rightBucketed == nullptr) {
+      return;
+    }
+
+    const auto add = [&](MemoOpCP leftChild,
+                         MemoOpCP rightChild,
+                         const connector::PartitionType* outputType) {
+      Partitioning outputPartitioning =
+          Partitioning::globalHash(keysInCoverSchema(leftKeys, combined));
+      outputPartitioning.partitionType = outputType;
+      addJoinCandidate(
+          leftChild,
+          rightChild,
+          edgeIndex,
+          joinType,
+          combined,
+          reversedAnti,
+          extraEdges,
+          std::move(outputPartitioning));
+    };
+
+    if (leftBucketed != nullptr && rightBucketed != nullptr) {
+      const connector::PartitionType* leftType =
+          leftBucketed->outputPartitioning().partitionType;
+      const connector::PartitionType* rightType =
+          rightBucketed->outputPartitioning().partitionType;
+      // copartition is only a feasibility check; the output reuses the
+      // min-partition-count input's layout-owned type, whose count equals
+      // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
+      if (const auto compatible = leftType->copartition(*rightType)) {
+        const connector::PartitionType* outputType =
+            leftType->numPartitions() <= rightType->numPartitions() ? leftType
+                                                                    : rightType;
+        VELOX_DCHECK_EQ(
+            outputType->numPartitions(),
+            compatible->numPartitions(),
+            "Co-bucketed output must reuse a layout type matching copartition's count");
+        add(leftBucketed, rightBucketed, outputType);
+      }
+      return;
+    }
+
+    if (leftBucketed != nullptr) {
+      const connector::PartitionType* leftType =
+          leftBucketed->outputPartitioning().partitionType;
+      MemoOpCP rightAligned =
+          repartitionedTo(right->cover(), rightKeys, leftType);
+      if (rightAligned != nullptr) {
+        add(leftBucketed, rightAligned, leftType);
+      }
+    } else {
+      // Only the right side is bucketed here (the both-null case returned
+      // early).
+      const connector::PartitionType* rightType =
+          rightBucketed->outputPartitioning().partitionType;
+      MemoOpCP leftAligned =
+          repartitionedTo(left->cover(), leftKeys, rightType);
+      if (leftAligned != nullptr) {
+        add(leftAligned, rightBucketed, rightType);
+      }
+    }
+  }
+
+  void considerCandidate(
+      MemoOpCP left,
+      MemoOpCP right,
+      size_t edgeIndex,
+      velox::core::JoinType joinType,
+      RelationSet combined,
+      bool reversedAnti = false,
+      std::vector<size_t> extraEdges = {}) {
+    // Single-fragment: children as selected, no exchange, no output
+    // partitioning.
+    if (numWorkers_ == 1) {
+      addJoinCandidate(
+          left,
+          right,
+          edgeIndex,
+          joinType,
+          combined,
+          reversedAnti,
+          std::move(extraEdges),
+          {});
+      return;
+    }
+
+    // Unnest expands rows worker-locally, so it needs no exchange and keeps the
+    // probe (left) partitioning.
+    if (graph_.edges()[edgeIndex].isUnnest()) {
+      addJoinCandidate(
+          left,
+          right,
+          edgeIndex,
+          joinType,
+          combined,
+          reversedAnti,
+          std::move(extraEdges),
+          left->outputPartitioning());
+      return;
+    }
+
+    const auto [leftKeys, rightKeys] =
+        orientedKeys(left, edgeIndex, extraEdges);
+    if (!leftKeys.empty()) {
+      // Partition strategy: co-partition both inputs on the join keys; the
+      // output is partitioned on the keys for same-key reuse above. A
+      // null-aware anti/semi join (NOT IN / IN) needs the existence side's
+      // null keys on every probe partition; the existence side is the edge's
+      // right operand, which may be either physical child depending on
+      // orientation.
+      const auto& edge = graph_.edges()[edgeIndex];
+      const bool existenceOnLeft =
+          edge.nullAware() && edge.right().isSubset(left->cover());
+      const bool existenceOnRight =
+          edge.nullAware() && edge.right().isSubset(right->cover());
+      MemoOpCP leftPart =
+          repartitioned(left->cover(), leftKeys, existenceOnLeft);
+      MemoOpCP rightPart =
+          repartitioned(right->cover(), rightKeys, existenceOnRight);
+      if (leftPart != nullptr && rightPart != nullptr) {
+        addJoinCandidate(
+            leftPart,
+            rightPart,
+            edgeIndex,
+            joinType,
+            combined,
+            reversedAnti,
+            extraEdges,
+            Partitioning::globalHash(keysInCoverSchema(leftKeys, combined)));
+      }
+
+      // Skipped for null-aware anti/semi: a connector-bucketed existence side
+      // confines a null key to one bucket, so probe rows in other buckets would
+      // miss it — those need the replicating shuffle or broadcast strategies.
+      if (!edge.nullAware()) {
+        addCoBucketedCandidate(
+            left,
+            right,
+            leftKeys,
+            rightKeys,
+            edgeIndex,
+            joinType,
+            combined,
+            reversedAnti,
+            extraEdges);
+      }
+    }
+
+    // Broadcast the build (right); the probe (left) keeps its partitioning.
+    // Only when the join does not preserve the build — broadcasting a preserved
+    // side would emit its rows on every task. A reversed anti join builds on
+    // its preserved (left) side, so its build is preserved and cannot be
+    // broadcast.
+    if (canBroadcastBuild(joinType) && !reversedAnti) {
+      MemoOpCP broadcastBuild = broadcastChild(right->cover());
+      if (broadcastBuild != nullptr) {
+        addJoinCandidate(
+            left,
+            broadcastBuild,
+            edgeIndex,
+            joinType,
+            combined,
+            reversedAnti,
+            extraEdges,
+            left->outputPartitioning());
+      }
+    }
+  }
+
+  // Returns subsets of `neighborBits` in popcount-ascending order,
+  // breaking same-popcount ties by bit value so the result is
+  // fully deterministic. Inline storage covers up to 4 neighbors
+  // (2^4 = 16 subsets) without a heap allocation; larger
+  // neighborhoods spill to heap transparently.
+  using SubsetVector = folly::small_vector<uint64_t, 16>;
+  SubsetVector subsetsBySize(uint64_t neighborBits) {
+    SubsetVector subsets;
+    for (uint64_t subset = neighborBits; subset > 0;
+         subset = (subset - 1) & neighborBits) {
+      subsets.push_back(subset);
+    }
+    std::sort(subsets.begin(), subsets.end(), [](uint64_t a, uint64_t b) {
+      const int popA = __builtin_popcountll(a);
+      const int popB = __builtin_popcountll(b);
+      return std::tie(popA, a) < std::tie(popB, b);
+    });
+    return subsets;
+  }
+
+  void enumerateCsgRec(RelationSet subgraph, RelationSet forbidden) {
+    if (budget_.exceeded()) {
+      return;
+    }
+
+    const RelationSet neighbors = neighborhood(graph_, subgraph, forbidden);
+    if (neighbors.empty()) {
+      return;
+    }
+
+    const auto subsets = subsetsBySize(neighbors.bits());
+    for (uint64_t subset : subsets) {
+      const RelationSet combined = RelationSet{subgraph.bits() | subset};
+      if (memo_.find(combined) != memo_.end()) {
+        emitCsg(combined);
+      }
+    }
+
+    RelationSet newForbidden{forbidden};
+    newForbidden.unionSet(neighbors);
+    for (uint64_t subset : subsets) {
+      const RelationSet combined = RelationSet{subgraph.bits() | subset};
+      enumerateCsgRec(combined, newForbidden);
+    }
+  }
+
+  void enumerateCmpRec(
+      RelationSet subgraph,
+      RelationSet complement,
+      RelationSet forbidden) {
+    if (budget_.exceeded()) {
+      return;
+    }
+
+    const RelationSet neighbors = neighborhood(graph_, complement, forbidden);
+    if (neighbors.empty()) {
+      return;
+    }
+
+    const auto subsets = subsetsBySize(neighbors.bits());
+    for (uint64_t subset : subsets) {
+      const RelationSet grown = RelationSet{complement.bits() | subset};
+      if (memo_.find(grown) != memo_.end()) {
+        emitCsgCmp(subgraph, grown);
+      }
+    }
+
+    RelationSet newForbidden{forbidden};
+    newForbidden.unionSet(neighbors);
+    for (uint64_t subset : subsets) {
+      const RelationSet grown = RelationSet{complement.bits() | subset};
+      enumerateCmpRec(subgraph, grown, newForbidden);
+    }
+  }
+
+  const JoinHypergraph& graph_;
+  const CostModel& costModel_;
+  folly::F14NodeMap<RelationSet, PlanSet>& memo_;
+  // Pair budget; <= 0 means unlimited.
+  EnumerationBudget budget_;
+  // Target task count; > 1 enables remote-exchange candidate generation.
+  const int32_t numWorkers_;
+  // Max estimated build size a broadcast candidate may replicate; <= 0
+  // disables.
+  const int64_t broadcastSizeLimit_;
+  // Owner of enforcement exchanges created during candidate generation.
+  std::vector<std::unique_ptr<MemoOp>>& enforcementOps_;
+};
+
+} // namespace
+
+const MemoOp* DPhyp::enumerate() {
+#ifndef NDEBUG
+  // The single-component caller requires a connected graph; the disconnected
+  // case goes through enumerate(components).
+  graph_.checkConsistency();
+#endif
+  memo_.clear();
+  Enumerator enumerator{
+      graph_,
+      costModel_,
+      memo_,
+      enumerationBudget_,
+      numWorkers_,
+      broadcastSizeLimit_,
+      enforcementOps_};
+  const bool budgetExceeded = enumerator.solve();
+
+  RelationSet allRelations;
+  for (const auto& relation : graph_.relations()) {
+    allRelations.add(relation.id());
+  }
+
+  if (budgetExceeded) {
+    // The graph is too dense for exhaustive DP; restart greedily.
+    memo_.clear();
+    return enumerator.greedy(allRelations);
+  }
+
+  const auto rootIt = memo_.find(allRelations);
+  if (rootIt == memo_.end()) {
+    // No costable plan for the full set: some relation or edge lacked stats.
+    // The caller falls back to the query's syntactic join order.
+    return nullptr;
+  }
+  return rootIt->second.cheapest();
+}
+
+std::vector<MemoOpCP> DPhyp::enumerate(
+    const std::vector<RelationSet>& components) {
+  memo_.clear();
+  Enumerator enumerator{
+      graph_,
+      costModel_,
+      memo_,
+      enumerationBudget_,
+      numWorkers_,
+      broadcastSizeLimit_,
+      enforcementOps_};
+
+  std::vector<MemoOpCP> roots;
+  roots.reserve(components.size());
+  for (const RelationSet& component : components) {
+    // Enumerate and budget each component independently, so a single dense
+    // component falls back to greedy without forcing greedy on the others. The
+    // shared memo holds only valid subplans, so greedy reuses whatever DP
+    // already produced for the overflowed component.
+    MemoOpCP root;
+    if (enumerator.solveComponent(component)) {
+      root = enumerator.greedy(component);
+    } else {
+      const auto it = memo_.find(component);
+      root = it == memo_.end() ? nullptr : it->second.cheapest();
+    }
+    if (root == nullptr) {
+      // A component has no costable plan: some relation or edge lacked stats.
+      // Signal whole-cluster fall back to syntactic order by returning empty.
+      return {};
+    }
+    roots.push_back(root);
+  }
+  return roots;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/DPhyp.h
+++ b/axiom/optimizer/v2/DPhyp.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+#include "axiom/optimizer/v2/MemoOp.h"
+#include "axiom/optimizer/v2/PlanSet.h"
+#include "axiom/optimizer/v2/RelationSet.h"
+#include "folly/container/F14Map.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+class CostModel;
+
+/// Bottom-up DP join-order enumeration over a `JoinHypergraph`
+/// (Moerkotte/Neumann 2006 DPhyp: connected-subgraph + complement
+/// enumeration).
+///
+/// Invariants:
+///   - The hypergraph passed to the constructor must outlive the
+///     `DPhyp` instance.
+///   - The hypergraph must contain at least two relations.
+class DPhyp {
+ public:
+  /// `enumerationBudget` caps the number of connected-subgraph/complement pairs
+  /// the DP evaluates before falling back to greedy (GOO) ordering; <= 0 means
+  /// unlimited. See `OptimizerOptions::dphypEnumerationBudget`. `numWorkers` is
+  /// the target task count: when > 1 the enumeration generates remote-exchange
+  /// (repartition / broadcast) candidates; at 1 it stays single-fragment.
+  /// `broadcastSizeLimit` caps the estimated build size a broadcast candidate
+  /// may replicate to every task (bytes); <= 0 disables the limit. See
+  /// `OptimizerOptions::broadcastSizeLimit`.
+  DPhyp(
+      const JoinHypergraph& graph,
+      const CostModel& costModel,
+      int64_t enumerationBudget,
+      int32_t numWorkers,
+      int64_t broadcastSizeLimit);
+
+  /// Runs the enumeration and returns the root `MemoOp` for the full
+  /// relation set, or nullptr when no costable plan exists (some relation
+  /// or edge had unknown cost). A nullptr return tells the caller to fall
+  /// back to the query's syntactic join order.
+  MemoOpCP enumerate();
+
+  /// Runs enumeration once and returns the optimal plan for each
+  /// connected component in `components`. Each entry must be a connected
+  /// relation set and together they must cover all relations. Use when
+  /// the hypergraph is disconnected (genuine cross products); the caller
+  /// combines the per-component plans with cross joins. Returns an empty
+  /// vector when any component has no costable plan (some relation or edge
+  /// had unknown cost), telling the caller to fall back to syntactic order.
+  std::vector<MemoOpCP> enumerate(const std::vector<RelationSet>& components);
+
+ private:
+  const JoinHypergraph& graph_;
+  const CostModel& costModel_;
+  const int64_t enumerationBudget_;
+  const int32_t numWorkers_;
+  const int64_t broadcastSizeLimit_;
+  folly::F14NodeMap<RelationSet, PlanSet> memo_;
+
+  // Owns the remote-exchange (repartition / broadcast) MemoOps the enumeration
+  // creates to enforce a join's required input partitioning. They are children
+  // of join candidates, not entries of any relation set's PlanSet, so they live
+  // here for the optimizer's lifetime rather than in the memo map.
+  std::vector<std::unique_ptr<MemoOp>> enforcementOps_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -1,0 +1,2476 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/DecorrelatePass.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/v2/AggregateRecovery.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "axiom/optimizer/v2/JoinCondition.h"
+#include "axiom/optimizer/v2/NodeExpressions.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// Returns the subset of `inputColumns` referenced anywhere inside
+// `body`'s tree (in expressions on body's nodes and recursive
+// sub-nodes). Refs at the Apply boundary (caller's `Apply.filter`)
+// are NOT included — those become `Join.filter` at terminus and
+// don't block iteration; only refs INSIDE body block terminus.
+//
+// Recompute (not incremental): a peel may have absorbed body's only
+// occurrence of an outer col (drop the ref) or only one of several
+// (ref still in body via other occurrences). Subtracting per-peel
+// would be wrong; only this walk gives the right answer.
+//
+// TODO: cache per-node correlation sets to avoid re-walking the full
+// body on every iteration. Optimization, not correctness.
+ColumnVector recomputeCorrelations(
+    NodeCP body,
+    const ColumnVector& inputColumns) {
+  PlanObjectSet inputSet = PlanObjectSet::fromObjects(inputColumns);
+  PlanObjectSet found;
+
+  auto walk = [&](auto& self, NodeCP node) -> void {
+    forEachExpressionInNode(node, [&](ExprCP expr) {
+      expr->columns().forEach<Column>([&](const Column* column) {
+        if (inputSet.contains(column)) {
+          found.add(column);
+        }
+      });
+    });
+    for (NodeCP child : node->inputs()) {
+      self(self, child);
+    }
+  };
+  walk(walk, body);
+
+  ColumnVector result;
+  for (ColumnCP column : inputColumns) {
+    if (found.contains(column)) {
+      result.push_back(column);
+    }
+  }
+  return result;
+}
+
+// True when a kLeftSemiProject Apply's body Aggregate can be dropped
+// without changing the mark: grouping keys are non-empty and neither
+// the accumulated filter nor `inBodyKey` references any aggregate-
+// result column.
+bool canElideBodyAggregate(
+    ApplyCP node,
+    AggregateCP aggregate,
+    const ExprVector& accumulatedFilter) {
+  const size_t numGroupingKeys = aggregate->groupingKeys().size();
+  if (numGroupingKeys == 0) {
+    return false;
+  }
+
+  if (accumulatedFilter.empty() && node->inBodyKey() == nullptr) {
+    return true;
+  }
+
+  PlanObjectSet aggregateResultColumns;
+  for (size_t i = numGroupingKeys; i < aggregate->outputColumns().size(); ++i) {
+    aggregateResultColumns.add(aggregate->outputColumns()[i]);
+  }
+
+  for (ExprCP conjunct : accumulatedFilter) {
+    if (conjunct->columns().hasIntersection(aggregateResultColumns)) {
+      return false;
+    }
+  }
+
+  if (node->inBodyKey() != nullptr &&
+      node->inBodyKey()->columns().hasIntersection(aggregateResultColumns)) {
+    return false;
+  }
+  return true;
+}
+
+// Appends each element of `src` to `dst` unless `dst` already
+// contains it.
+template <typename Dst, typename Src>
+void appendUnique(Dst& dst, const Src& src) {
+  PlanObjectSet seen = PlanObjectSet::fromObjects(dst);
+  for (auto&& element : src) {
+    if (!seen.contains(element)) {
+      seen.add(element);
+      dst.push_back(element);
+    }
+  }
+}
+
+// Returns nullptr if `expr` is null; otherwise delegates to
+// `ExprFactory::substitute`.
+ExprCP substituteOrNull(
+    ExprFactory& exprFactory,
+    ExprCP expr,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  return expr == nullptr ? nullptr
+                         : exprFactory.substitute(expr, sources, targets);
+}
+
+// Decorrelate pass implementation. The per-Apply loop:
+// recompute `correlationColumns` from body; if empty, hit terminus;
+// otherwise dispatch a peel rule by body's outermost operator and
+// continue.
+class Decorrelator : public NodeRewriter<> {
+ public:
+  explicit Decorrelator(Builder& builder)
+      : NodeRewriter(builder), exprFactory_(builder) {}
+
+ protected:
+  NodeCP rewriteApply(ApplyCP node, NoContext& context) override {
+    // Bottom-up: nested Apply nodes inside input / body get
+    // decorrelated first via the base rewriter's dispatch.
+    NodeCP input = rewrite(node->input(), context);
+    NodeCP body = rewrite(node->body(), context);
+
+    ExprVector accumulatedFilter = node->filter();
+
+    // Recompute correlations from body before each iteration;
+    // terminus when empty.
+    while (true) {
+      ColumnVector correlations =
+          recomputeCorrelations(body, input->outputColumns());
+
+      if (correlations.empty()) {
+        return terminus(node, input, body, accumulatedFilter);
+      }
+
+      // Dispatch by body's outermost operator.
+      if (body->is(NodeType::kFilter)) {
+        // Filter peel: absorb all predicates into Apply.filter; body
+        // shrinks to Filter's child.
+        const Filter* filterBody = body->as<Filter>();
+        appendAll(accumulatedFilter, filterBody->predicates());
+        body = filterBody->input();
+        continue;
+      }
+
+      if (body->is(NodeType::kProject)) {
+        // Project peel returns the fully-decorrelated subtree (it
+        // builds the inner Apply and recurses). Driver loop ends here.
+        if (node->isLeftSemiProject()) {
+          return projectPeelSemi(node, input, body, accumulatedFilter);
+        }
+        return projectPeelLeft(node, input, body, accumulatedFilter);
+      }
+
+      if (body->is(NodeType::kAggregate)) {
+        // Aggregate peel returns the fully-decorrelated subtree.
+        return aggregatePeel(node, input, body, accumulatedFilter);
+      }
+
+      if (body->is(NodeType::kLimit)) {
+        return limitPeel(node, input, body, accumulatedFilter);
+      }
+
+      if (body->is(NodeType::kJoin)) {
+        return joinPeel(node, input, body, accumulatedFilter);
+      }
+
+      if (body->is(NodeType::kAssignUniqueId)) {
+        return assignUniqueIdPeel(node, input, body, accumulatedFilter);
+      }
+
+      VELOX_NYI(
+          "Correlated reference inside a {} branch is not supported yet",
+          body->nodeType());
+    }
+  }
+
+ private:
+  // Project peel (Rule A): Project lifts above Apply. Apply's body
+  // becomes Project's child; the lifted Project above the decorrelated
+  // inner Apply reproduces the original output schema using Project's
+  // original exprs (which may reference L cols, now visible above the
+  // inner Apply per the relaxed contract).
+  //
+  // Recurses on the inner Apply so the driver continues peeling whatever
+  // remains in body (more Filters / Projects below, or terminus).
+  NodeCP projectPeelLeft(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    const Project* projectBody = body->as<Project>();
+    NodeCP newBody = projectBody->input();
+
+    // If accumulatedFilter references any of Project's output cols,
+    // substitute those refs with Project's corresponding exprs. After
+    // Project peels, body becomes newBody, and Project's outputs no
+    // longer exist below — but their values are computed by Project's
+    // exprs, which reference newBody cols (and possibly outer cols) —
+    // all visible in the inner Apply's outputColumns. Pass-through
+    // Project entries (where expr == output col) substitute to
+    // themselves — no-op.
+    ExprVector newAccumulatedFilter = exprFactory_.substitute(
+        accumulatedFilter, projectBody->outputColumns(), projectBody->exprs());
+
+    // Build inner Apply with body = Project's child. Inner Apply
+    // inherits the outer's includeMarker. Body cols that alias input
+    // cols by identity collapse to a single slot.
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(
+        input->outputColumns().size() + newBody->outputColumns().size() + 1);
+    appendAll(innerOutputColumns, input->outputColumns());
+    appendUnique(innerOutputColumns, newBody->outputColumns());
+    innerOutputColumns.push_back(node->includeMarker());
+
+    // Recompute correlations for the inner body. Project peel may have
+    // lifted outer-column refs out of body (into the lifted Project
+    // above), shrinking the correlation set.
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(newBody, input->outputColumns());
+
+    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+        input,
+        newBody,
+        std::move(innerCorrelations),
+        node->kind(),
+        std::move(newAccumulatedFilter),
+        node->enforceSingleRow(),
+        node->markColumn(),
+        node->inLhs(),
+        node->inBodyKey(),
+        node->includeMarker(),
+        std::move(innerOutputColumns),
+    });
+
+    // Recurse: continue peeling whatever's in newBody, or hit terminus.
+    NodeCP decorrelatedInner = rewrite(innerApply);
+
+    // Build lifted Project. Its exprs reproduce the original Apply's
+    // output schema:
+    //   input.cols → pass-through.
+    //   Project's original output cols → IF(_include, expr, NULL) so
+    //     non-default-null exprs evaluate to NULL on pad rows post-Join.
+    //     Skip cols that already appear in input — they collapse to the
+    //     same slot.
+    //   includeMarker → pass-through.
+    ExprVector liftedExprs;
+    liftedExprs.reserve(
+        input->outputColumns().size() + projectBody->exprs().size() + 1);
+    appendAll(liftedExprs, input->outputColumns());
+    PlanObjectSet liftedSeen =
+        PlanObjectSet::fromObjects(input->outputColumns());
+    ColumnCP includeMarker = node->includeMarker();
+    const auto& projectOutputs = projectBody->outputColumns();
+    for (size_t i = 0; i < projectBody->exprs().size(); ++i) {
+      ColumnCP outputColumn = projectOutputs[i];
+      if (liftedSeen.contains(outputColumn)) {
+        continue;
+      }
+      liftedSeen.add(outputColumn);
+      ExprCP expr = projectBody->exprs()[i];
+      const Literal* nullLiteral = builder().makeNull(expr->value().type);
+      liftedExprs.push_back(
+          exprFactory_.makeIf(includeMarker, expr, nullLiteral));
+    }
+    liftedExprs.push_back(includeMarker);
+
+    return builder().make<Project>(Project::Key{
+        decorrelatedInner,
+        std::move(liftedExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Project peel (Rule B) for kLeftSemiProject. Project dissolves
+  // into the mark predicate: substitute refs to Project's output cols
+  // in `inBodyKey` (and `Apply.filter`) with Project's corresponding
+  // exprs. Body becomes Project's child; no Project lives above Apply
+  // (kSemi's output doesn't carry body cols, so there's nothing for a
+  // lifted Project to feed). Recurses on the inner Apply.
+  NodeCP projectPeelSemi(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    const Project* projectBody = body->as<Project>();
+    NodeCP newBody = projectBody->input();
+
+    // Substitution: Project's output cols → Project's exprs.
+    // (Pass-through entries have expr == output col, so they substitute
+    // to themselves — no-op.)
+    ExprCP newInBodyKey = substituteOrNull(
+        exprFactory_,
+        node->inBodyKey(),
+        projectBody->outputColumns(),
+        projectBody->exprs());
+    ExprVector newAccumulatedFilter = exprFactory_.substitute(
+        accumulatedFilter, projectBody->outputColumns(), projectBody->exprs());
+
+    // Recompute inner correlations against the new body.
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(newBody, input->outputColumns());
+
+    // Inner Apply.outputColumns for kLeftSemiProject:
+    //   input.cols ++ markColumn (per Apply contract).
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(input->outputColumns().size() + 1);
+    appendAll(innerOutputColumns, input->outputColumns());
+    innerOutputColumns.push_back(node->markColumn());
+
+    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+        input,
+        newBody,
+        std::move(innerCorrelations),
+        velox::core::JoinType::kLeftSemiProject,
+        newAccumulatedFilter,
+        /*enforceSingleRow=*/false,
+        node->markColumn(),
+        node->inLhs(),
+        newInBodyKey,
+        /*includeMarker=*/nullptr,
+        std::move(innerOutputColumns),
+    });
+
+    return rewrite(innerApply);
+  }
+
+  // Peels a Limit body operator. Handles all kind × count
+  // combinations; kSemi+IN with count >= 1 and non-zero Limit.offset
+  // are NYI.
+  NodeCP limitPeel(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    LimitCP limitBody = body->as<Limit>();
+    VELOX_USER_CHECK_EQ(
+        limitBody->offset(),
+        0,
+        "Decorrelate: Limit with non-zero offset in correlated body "
+        "not yet supported");
+    // Translate rewrites `LIMIT 0` to `Values(empty)` before this pass,
+    // so decorrelate never sees a zero-count Limit body.
+    const int64_t count{limitBody->count()};
+    VELOX_CHECK_GE(count, 1);
+    const bool isInSubquery =
+        node->isLeftSemiProject() && node->inLhs() != nullptr;
+
+    if (node->isLeftSemiProject() && !isInSubquery) {
+      return limitPeelDropForExists(node, input, limitBody, accumulatedFilter);
+    }
+    if (isInSubquery) {
+      VELOX_NYI(
+          "Decorrelate: kLeftSemiProject IN over Limit with count >= 1 "
+          "not yet implemented (LIMIT must precede the IN equi check)");
+    }
+    VELOX_USER_CHECK(
+        node->isLeft(),
+        "Decorrelate Limit peel: unexpected Apply kind {}",
+        node->kind());
+    return limitPeelLeftWindowed(
+        node, input, limitBody, count, accumulatedFilter);
+  }
+
+  // kSemi+EXISTS+count>=1: drop Limit, recurse on body = Limit.input.
+  // Existence is unchanged when truncating to first N for N>=1.
+  NodeCP limitPeelDropForExists(
+      ApplyCP node,
+      NodeCP input,
+      LimitCP limitBody,
+      ExprVector accumulatedFilter) {
+    NodeCP newBody = limitBody->input();
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(input->outputColumns().size() + 1);
+    appendAll(innerOutputColumns, input->outputColumns());
+    innerOutputColumns.push_back(node->markColumn());
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(newBody, input->outputColumns());
+    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+        input,
+        newBody,
+        std::move(innerCorrelations),
+        node->kind(),
+        std::move(accumulatedFilter),
+        /*enforceSingleRow=*/false,
+        node->markColumn(),
+        node->inLhs(),
+        node->inBodyKey(),
+        /*includeMarker=*/nullptr,
+        std::move(innerOutputColumns),
+    });
+    return rewrite(innerApply);
+  }
+
+  // kLeft+count>=1: per-outer LIMIT via Window+Filter. Tags input with
+  // a per-outer `rn`, decorrelates `Apply(taggedInput, body, kLeft)`,
+  // then keeps the first `count` body rows per `rn`. When the outer
+  // Apply has enforceSingleRow=true, EnforceDistinct on `rn` asserts
+  // <=1 row per outer.
+  //
+  // If `body` is a Sort, its ORDER BY is lifted into the row_number
+  // window's OVER clause so the per-outer LIMIT picks the
+  // sort-deterministic first `count` rows per partition.
+  NodeCP limitPeelLeftWindowed(
+      ApplyCP node,
+      NodeCP input,
+      LimitCP limitBody,
+      int64_t count,
+      ExprVector accumulatedFilter) {
+    ColumnCP rowNumberPartition = makeIdColumn();
+    NodeCP taggedInput = builder().make<AssignUniqueId>(
+        AssignUniqueId::Key{input, rowNumberPartition});
+
+    NodeCP newBody = limitBody->input();
+    ExprVector windowOrderKeys;
+    OrderTypeVector windowOrderTypes;
+    if (newBody->is(NodeType::kSort)) {
+      SortCP sortBody = newBody->as<Sort>();
+      windowOrderKeys = sortBody->orderKeys();
+      windowOrderTypes = sortBody->orderTypes();
+      newBody = sortBody->input();
+    }
+    ColumnCP innerIncludeMarker = makeIncludeColumn();
+
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(
+        taggedInput->outputColumns().size() + newBody->outputColumns().size() +
+        1);
+    appendAll(innerOutputColumns, taggedInput->outputColumns());
+    appendUnique(innerOutputColumns, newBody->outputColumns());
+    innerOutputColumns.push_back(innerIncludeMarker);
+
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(newBody, taggedInput->outputColumns());
+
+    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+        taggedInput,
+        newBody,
+        std::move(innerCorrelations),
+        velox::core::JoinType::kLeft,
+        std::move(accumulatedFilter),
+        /*enforceSingleRow=*/false,
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        innerIncludeMarker,
+        std::move(innerOutputColumns),
+    });
+    NodeCP decorrelatedInner = rewrite(innerApply);
+
+    ColumnCP rowNumberColumn = makeIdColumn("__limit_rn");
+    NodeCP windowed = addRowNumberWindow(
+        decorrelatedInner,
+        rowNumberPartition,
+        rowNumberColumn,
+        std::move(windowOrderKeys),
+        std::move(windowOrderTypes));
+
+    const Literal* countLiteral =
+        builder().makeLiteral(velox::Variant(count), toType(velox::BIGINT()));
+    NodeCP filtered = builder().make<Filter>(Filter::Key{
+        windowed,
+        ExprVector{
+            exprFactory_.makeLessThanOrEqual(rowNumberColumn, countLiteral)},
+    });
+
+    // Trivially holds for count=1; for count>=2 the EnforceDistinct
+    // fires when an outer has >1 matches.
+    NodeCP enforced = node->enforceSingleRow()
+        ? enforceScalarSingleRow(filtered, rowNumberPartition)
+        : filtered;
+
+    // Outer Apply's includeMarker is sourced from the inner Apply's
+    // includeMarker so per-outer LIMIT preserves the real-vs-pad signal.
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      if (outputColumn == node->includeMarker()) {
+        finalExprs.push_back(innerIncludeMarker);
+      } else {
+        finalExprs.push_back(outputColumn);
+      }
+    }
+    return builder().make<Project>(Project::Key{
+        enforced,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // A `row_number()` window function over the default running frame,
+  // writing into `rowNumberColumn`.
+  WindowFunction rowNumberWindowFunction(ColumnCP rowNumberColumn) {
+    const auto& rowNumberName = FunctionRegistry::instance()->rowNumber();
+    VELOX_USER_CHECK(
+        rowNumberName.has_value(),
+        "Decorrelate requires row_number registered via "
+        "FunctionRegistry::registerRowNumber");
+    ExprCP call = builder().makeCall(
+        toName(*rowNumberName),
+        rowNumberColumn->value(),
+        ExprVector{},
+        FunctionSet{} | FunctionSet::kNonDeterministic |
+            FunctionSet::kNonDefaultNullBehavior);
+    return WindowFunction{call, Frame::toCurrentRow(), /*ignoreNulls=*/false};
+  }
+
+  // Wraps 'input' in a Window that emits `row_number() OVER
+  // (PARTITION BY partition [ORDER BY orderKeys])` into
+  // 'rowNumberColumn'. Empty 'orderKeys' yields an unordered
+  // row_number assignment.
+  NodeCP addRowNumberWindow(
+      NodeCP input,
+      ColumnCP partition,
+      ColumnCP rowNumberColumn,
+      ExprVector orderKeys,
+      OrderTypeVector orderTypes) {
+    WindowFunctions functions;
+    functions.push_back(rowNumberWindowFunction(rowNumberColumn));
+
+    ColumnVector outputs;
+    outputs.reserve(input->outputColumns().size() + 1);
+    appendAll(outputs, input->outputColumns());
+    outputs.push_back(rowNumberColumn);
+
+    return builder().make<Window>(Window::Key{
+        input,
+        std::move(functions),
+        ExprVector{partition},
+        std::move(orderKeys),
+        std::move(orderTypes),
+        std::move(outputs),
+    });
+  }
+
+  // Peels a Join body operator. Serializes `Apply(L, Join(A, B, ...))`
+  // into a chain `Apply(Apply(L, A), B)`. Most kind / correlation
+  // combinations dispatched out to helpers; kFull and several mixed
+  // cases are NYI loud pending further design.
+  NodeCP joinPeel(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    JoinCP joinBody = body->as<Join>();
+
+    ExprVector joinPredicate = flattenJoinPredicate(joinBody);
+
+    if (joinBody->isFull()) {
+      VELOX_NYI(
+          "Decorrelate: Apply over kFull Join in body is not yet "
+          "supported (tree-only execution can't preserve both sides' "
+          "unmatched rows without DAG support)");
+    }
+
+    if (node->isLeft()) {
+      return joinPeelLeft(
+          node,
+          input,
+          joinBody,
+          std::move(joinPredicate),
+          std::move(accumulatedFilter));
+    }
+
+    if (node->isLeftSemiProject()) {
+      return joinPeelSemi(
+          node,
+          input,
+          joinBody,
+          std::move(joinPredicate),
+          std::move(accumulatedFilter));
+    }
+
+    VELOX_FAIL(
+        "Decorrelate joinPeel: unexpected outer Apply kind {}", node->kind());
+  }
+
+  // Flattens Join's split form (equi-pairs as `eq(leftKeys[i],
+  // rightKeys[i])` plus `filter`) into a single conjunct vector.
+  ExprVector flattenJoinPredicate(JoinCP joinBody) {
+    ExprVector conjuncts;
+    conjuncts.reserve(joinBody->leftKeys().size() + joinBody->filter().size());
+    for (size_t i = 0; i < joinBody->leftKeys().size(); ++i) {
+      conjuncts.push_back(exprFactory_.makeEq(
+          joinBody->leftKeys()[i], joinBody->rightKeys()[i]));
+    }
+    appendAll(conjuncts, joinBody->filter());
+    return conjuncts;
+  }
+
+  // Outer Apply is kLeft (scalar). Supports kInner cross-join (no
+  // predicate) and kLeft with predicate. kInner with a Join-node
+  // predicate (requires per-rn pad-collapse over matches) and other
+  // kinds NYI loud.
+  NodeCP joinPeelLeft(
+      ApplyCP node,
+      NodeCP input,
+      JoinCP joinBody,
+      ExprVector joinPredicate,
+      ExprVector accumulatedFilter) {
+    if (!joinBody->isInner() && !joinBody->isLeft()) {
+      VELOX_NYI(
+          "Decorrelate joinPeel: outer kLeft over Join.kind={} not yet "
+          "implemented",
+          joinBody->joinType());
+    }
+    if (joinBody->isInner() && !joinPredicate.empty()) {
+      VELOX_NYI(
+          "Decorrelate joinPeel: outer kLeft over kInner Join with "
+          "predicate not yet implemented (needs per-rn pad-collapse)");
+    }
+
+    NodeCP leftSide = joinBody->left();
+    NodeCP rightSide = joinBody->right();
+    ExprVector applyBFilter;
+    if (joinBody->isLeft()) {
+      applyBFilter = std::move(joinPredicate);
+    }
+    appendAll(applyBFilter, accumulatedFilter);
+
+    if (joinBody->isInner()) {
+      return joinPeelLeftInner(
+          node, input, leftSide, rightSide, std::move(applyBFilter));
+    }
+
+    // Body is kLeft. Chain: applyA over A, then applyB over B with
+    // applyA's output as input. joinPredicate becomes applyB.filter
+    // (the LEFT JOIN's ON condition); kLeft pad on no match preserves
+    // the body LEFT JOIN's semantics.
+
+    // applyA: input = L, body = leftSide.
+    ColumnCP applyAIncludeMarker = makeIncludeColumn();
+    ColumnVector applyAOutputs;
+    applyAOutputs.reserve(
+        input->outputColumns().size() + leftSide->outputColumns().size() + 1);
+    appendAll(applyAOutputs, input->outputColumns());
+    appendUnique(applyAOutputs, leftSide->outputColumns());
+    applyAOutputs.push_back(applyAIncludeMarker);
+
+    ColumnVector applyACorrelations =
+        recomputeCorrelations(leftSide, input->outputColumns());
+
+    NodeCP applyA = builder().make<Apply>(Apply::Key{
+        input,
+        leftSide,
+        std::move(applyACorrelations),
+        velox::core::JoinType::kLeft,
+        /*filter=*/ExprVector{},
+        node->enforceSingleRow(),
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        applyAIncludeMarker,
+        std::move(applyAOutputs),
+    });
+
+    // applyB: input = applyA, body = rightSide.
+    ColumnCP applyBIncludeMarker = makeIncludeColumn();
+    ColumnVector applyBOutputs;
+    applyBOutputs.reserve(
+        applyA->outputColumns().size() + rightSide->outputColumns().size() + 1);
+    appendAll(applyBOutputs, applyA->outputColumns());
+    appendUnique(applyBOutputs, rightSide->outputColumns());
+    applyBOutputs.push_back(applyBIncludeMarker);
+
+    ColumnVector applyBCorrelations =
+        recomputeCorrelations(rightSide, applyA->outputColumns());
+
+    NodeCP applyB = builder().make<Apply>(Apply::Key{
+        applyA,
+        rightSide,
+        std::move(applyBCorrelations),
+        velox::core::JoinType::kLeft,
+        std::move(applyBFilter),
+        node->enforceSingleRow(),
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        applyBIncludeMarker,
+        std::move(applyBOutputs),
+    });
+
+    NodeCP decorrelatedChain = rewrite(applyB);
+
+    // Final Project: shape to outer Apply's outputColumns. Body is
+    // kLeft, so the inner LEFT JOIN's right-side pad rows are legitimate
+    // body output (left preserved with NULL right cols) and stay
+    // included; applyA's marker alone gates inclusion.
+    ExprCP includeMarker = applyAIncludeMarker;
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      if (outputColumn == node->includeMarker()) {
+        finalExprs.push_back(includeMarker);
+      } else {
+        finalExprs.push_back(outputColumn);
+      }
+    }
+    return builder().make<Project>(Project::Key{
+        decorrelatedChain,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Outer kLeft over a body kInner cross-join. The leg cascade uses
+  // kLeft legs so outers and left rows survive, but that over-produces
+  // pad rows when one side is empty and the other has >1 rows, which
+  // would duplicate the outer. Restore `outer LEFT JOIN (A x B)`
+  // semantics with a per-rn pad-collapse: keep every real (a, b) row
+  // and, for an outer with no match, keep exactly one pad row. See
+  // Decorrelate-join-rules.md §"INNER pad-row drop".
+  NodeCP joinPeelLeftInner(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP leftSide,
+      NodeCP rightSide,
+      ExprVector applyBFilter) {
+    ColumnCP rowId = makeIdColumn();
+    NodeCP taggedInput =
+        builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowId});
+
+    // Legs never enforce single row: an empty side makes the cross join
+    // empty (a valid 0-row scalar), which a per-leg check would misread
+    // as the other side's rows. ESR is applied once after the collapse.
+    ColumnCP markA = makeIncludeColumn();
+    ColumnVector applyAOutputs;
+    applyAOutputs.reserve(
+        taggedInput->outputColumns().size() + leftSide->outputColumns().size() +
+        1);
+    appendAll(applyAOutputs, taggedInput->outputColumns());
+    appendUnique(applyAOutputs, leftSide->outputColumns());
+    applyAOutputs.push_back(markA);
+    NodeCP applyA = builder().make<Apply>(Apply::Key{
+        taggedInput,
+        leftSide,
+        recomputeCorrelations(leftSide, taggedInput->outputColumns()),
+        velox::core::JoinType::kLeft,
+        /*filter=*/ExprVector{},
+        /*enforceSingleRow=*/false,
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        markA,
+        std::move(applyAOutputs),
+    });
+
+    ColumnCP markB = makeIncludeColumn();
+    ColumnVector applyBOutputs;
+    applyBOutputs.reserve(
+        applyA->outputColumns().size() + rightSide->outputColumns().size() + 1);
+    appendAll(applyBOutputs, applyA->outputColumns());
+    appendUnique(applyBOutputs, rightSide->outputColumns());
+    applyBOutputs.push_back(markB);
+    NodeCP applyB = builder().make<Apply>(Apply::Key{
+        applyA,
+        rightSide,
+        recomputeCorrelations(rightSide, applyA->outputColumns()),
+        velox::core::JoinType::kLeft,
+        std::move(applyBFilter),
+        /*enforceSingleRow=*/false,
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        markB,
+        std::move(applyBOutputs),
+    });
+
+    NodeCP chain = rewrite(applyB);
+
+    // A real body row requires both sides to match. Leg markers are
+    // `true` on a match and NULL on a pad, so fold to a clean boolean
+    // (NULL → false) before the window: `bool_or` over all-NULL markers
+    // would otherwise yield NULL and drop the pad row. Materialize it
+    // as a column so the window and filter can reference it.
+    ColumnCP matched = makeIncludeColumn();
+    NodeCP marked = appendColumn(
+        chain,
+        matched,
+        exprFactory_.makeCoalesce(
+            exprFactory_.makeAnd(markA, markB), builder().makeBoolean(false)));
+
+    // Per-outer window: `anyMatch` over the whole partition, and a
+    // `padOrdinal` row_number to designate the single pad row to keep.
+    ColumnCP anyMatch = Column::createBoolean("__any_match");
+    ColumnCP padOrdinal = makeIdColumn("__pad_rn");
+    NodeCP windowed =
+        addPadCollapseWindow(marked, rowId, matched, anyMatch, padOrdinal);
+
+    // Keep real rows; for a match-less outer keep only its first row (a
+    // pad) and drop the duplicate pads.
+    ExprCP one = builder().makeLiteral(
+        velox::Variant(static_cast<int64_t>(1)), toType(velox::BIGINT()));
+    ExprCP keep = exprFactory_.makeOr(
+        matched,
+        exprFactory_.makeAnd(
+            exprFactory_.makeNot(anyMatch),
+            exprFactory_.makeEq(padOrdinal, one)));
+    NodeCP filtered =
+        builder().make<Filter>(Filter::Key{windowed, ExprVector{keep}});
+
+    NodeCP enforced = node->enforceSingleRow()
+        ? enforceScalarSingleRow(filtered, rowId)
+        : filtered;
+
+    // Shape to the outer Apply's contract. The kept pad row carries
+    // real left-side values (gated only by applyA's marker), so body
+    // columns must be NULLed when this outer had no match; otherwise a
+    // left-only scalar would leak the pad's value. Outer columns are
+    // valid on a pad and pass through; the matched marker becomes the
+    // outer includeMarker. rowId, leg markers, and window columns drop
+    // here.
+    PlanObjectSet outerColumns =
+        PlanObjectSet::fromObjects(input->outputColumns());
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      if (outputColumn == node->includeMarker()) {
+        finalExprs.push_back(matched);
+      } else if (outerColumns.contains(outputColumn)) {
+        finalExprs.push_back(outputColumn);
+      } else {
+        finalExprs.push_back(exprFactory_.makeIf(
+            matched,
+            outputColumn,
+            builder().makeNull(outputColumn->value().type)));
+      }
+    }
+    return builder().make<Project>(Project::Key{
+        enforced,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Returns a Project that passes `input`'s columns through unchanged
+  // and appends `column` computed as `expr`.
+  NodeCP appendColumn(NodeCP input, ColumnCP column, ExprCP expr) {
+    const auto& inputColumns = input->outputColumns();
+
+    ExprVector exprs;
+    ColumnVector outputs;
+    exprs.reserve(inputColumns.size() + 1);
+    outputs.reserve(inputColumns.size() + 1);
+    appendAll(exprs, inputColumns);
+    appendAll(outputs, inputColumns);
+    exprs.push_back(expr);
+    outputs.push_back(column);
+    return builder().make<Project>(
+        Project::Key{input, std::move(exprs), std::move(outputs)});
+  }
+
+  // Window over PARTITION BY `partition` computing `anyMatch =
+  // bool_or(marker)` across the whole partition and `padOrdinal =
+  // row_number()` (running frame; used only to pick one pad row).
+  NodeCP addPadCollapseWindow(
+      NodeCP input,
+      ColumnCP partition,
+      ColumnCP marker,
+      ColumnCP anyMatch,
+      ColumnCP padOrdinal) {
+    const auto& boolOrName = FunctionRegistry::instance()->boolOr();
+    VELOX_USER_CHECK(
+        boolOrName.has_value(),
+        "Decorrelate kInner cross-join recovery requires bool_or "
+        "registered via FunctionRegistry::registerBoolOr");
+
+    // bool_or yields a BOOLEAN (two distinct values).
+    ExprCP boolOrCall = builder().makeCall(
+        toName(*boolOrName),
+        Value(toType(velox::BOOLEAN()), /*cardinality=*/2),
+        ExprVector{marker},
+        marker->functions() | FunctionSet::kNonDeterministic |
+            FunctionSet::kNonDefaultNullBehavior);
+
+    WindowFunctions functions;
+    functions.push_back(
+        WindowFunction{
+            boolOrCall, Frame::wholePartition(), /*ignoreNulls=*/false});
+    functions.push_back(rowNumberWindowFunction(padOrdinal));
+
+    ColumnVector outputs;
+    outputs.reserve(input->outputColumns().size() + 2);
+    appendAll(outputs, input->outputColumns());
+    outputs.push_back(anyMatch);
+    outputs.push_back(padOrdinal);
+
+    return builder().make<Window>(Window::Key{
+        input,
+        std::move(functions),
+        ExprVector{partition},
+        /*orderKeys=*/{},
+        /*orderTypes=*/{},
+        std::move(outputs),
+    });
+  }
+
+  // Outer Apply is kLeftSemiProject. Currently supports EXISTS shape
+  // (inLhs == nullptr) over kInner cross-join body; mark = markA AND
+  // markB. IN shape and other Join kinds NYI loud.
+  NodeCP joinPeelSemi(
+      ApplyCP node,
+      NodeCP input,
+      JoinCP joinBody,
+      ExprVector joinPredicate,
+      ExprVector accumulatedFilter) {
+    if (node->inLhs() != nullptr) {
+      VELOX_NYI(
+          "Decorrelate joinPeel: outer kLeftSemiProject IN over Join "
+          "body not yet implemented");
+    }
+    if (!joinBody->isInner() || !joinPredicate.empty()) {
+      VELOX_NYI(
+          "Decorrelate joinPeel: outer kLeftSemiProject EXISTS over "
+          "Join.kind={} with predicate {} not yet implemented",
+          joinBody->joinType(),
+          joinPredicate.empty() ? "empty" : "non-empty");
+    }
+
+    // Cross-join EXISTS: mark = (∃a) AND (∃b).
+    NodeCP leftSide = joinBody->left();
+    NodeCP rightSide = joinBody->right();
+
+    ColumnCP markA = Column::createBoolean("_join_chain_markA");
+    ColumnVector applyAOutputs;
+    applyAOutputs.reserve(input->outputColumns().size() + 1);
+    appendAll(applyAOutputs, input->outputColumns());
+    applyAOutputs.push_back(markA);
+    ColumnVector applyACorrelations =
+        recomputeCorrelations(leftSide, input->outputColumns());
+    NodeCP applyA = builder().make<Apply>(Apply::Key{
+        input,
+        leftSide,
+        std::move(applyACorrelations),
+        velox::core::JoinType::kLeftSemiProject,
+        /*filter=*/ExprVector{},
+        /*enforceSingleRow=*/false,
+        markA,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        /*includeMarker=*/nullptr,
+        std::move(applyAOutputs),
+    });
+
+    ColumnCP markB = Column::createBoolean("_join_chain_markB");
+    ColumnVector applyBOutputs;
+    applyBOutputs.reserve(applyA->outputColumns().size() + 1);
+    appendAll(applyBOutputs, applyA->outputColumns());
+    applyBOutputs.push_back(markB);
+    ColumnVector applyBCorrelations =
+        recomputeCorrelations(rightSide, applyA->outputColumns());
+    NodeCP applyB = builder().make<Apply>(Apply::Key{
+        applyA,
+        rightSide,
+        std::move(applyBCorrelations),
+        velox::core::JoinType::kLeftSemiProject,
+        /*filter=*/std::move(accumulatedFilter),
+        /*enforceSingleRow=*/false,
+        markB,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        /*includeMarker=*/nullptr,
+        std::move(applyBOutputs),
+    });
+
+    NodeCP decorrelatedChain = rewrite(applyB);
+
+    // Final Project: markColumn = markA AND markB.
+    ExprCP combinedMark = exprFactory_.makeAnd(markA, markB);
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      if (outputColumn == node->markColumn()) {
+        finalExprs.push_back(combinedMark);
+      } else {
+        finalExprs.push_back(outputColumn);
+      }
+    }
+    return builder().make<Project>(Project::Key{
+        decorrelatedChain,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Peels an AssignUniqueId body operator by lifting it above Apply.
+  // Body = `AssignUniqueId(child, idColumn)`. The inner Apply
+  // decorrelates `child`; an `AssignUniqueId` placed above re-supplies
+  // `idColumn` to the result. ID values differ from the original (per
+  // Apply-output row instead of per child row), but the column's
+  // identity and schema position are preserved — consumers that rely
+  // only on uniqueness (the common case for ESR-style enforcement)
+  // are unaffected.
+  NodeCP assignUniqueIdPeel(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    AssignUniqueIdCP assignUniqueIdBody = body->as<AssignUniqueId>();
+    NodeCP newBody = assignUniqueIdBody->input();
+    ColumnCP idColumn = assignUniqueIdBody->idColumn();
+
+    ColumnCP innerIncludeMarker =
+        node->isLeft() ? makeIncludeColumn() : nullptr;
+
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(
+        input->outputColumns().size() +
+        (node->isLeftSemiProject() ? 1 : newBody->outputColumns().size() + 1));
+    appendAll(innerOutputColumns, input->outputColumns());
+    if (node->isLeftSemiProject()) {
+      innerOutputColumns.push_back(node->markColumn());
+    } else {
+      PlanObjectSet innerSeen =
+          PlanObjectSet::fromObjects(input->outputColumns());
+      for (ColumnCP column : newBody->outputColumns()) {
+        if (!innerSeen.contains(column)) {
+          innerSeen.add(column);
+          innerOutputColumns.push_back(column);
+        }
+      }
+      innerOutputColumns.push_back(innerIncludeMarker);
+    }
+
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(newBody, input->outputColumns());
+
+    NodeCP innerApply = builder().make<Apply>(Apply::Key{
+        input,
+        newBody,
+        std::move(innerCorrelations),
+        node->kind(),
+        std::move(accumulatedFilter),
+        node->enforceSingleRow(),
+        node->markColumn(),
+        node->inLhs(),
+        node->inBodyKey(),
+        innerIncludeMarker,
+        std::move(innerOutputColumns),
+    });
+    NodeCP decorrelatedInner = rewrite(innerApply);
+
+    NodeCP withId = builder().make<AssignUniqueId>(
+        AssignUniqueId::Key{decorrelatedInner, idColumn});
+
+    // Final Project reorders `withId`'s cols to match
+    // `node->outputColumns()` and aliases the inner includeMarker to
+    // the outer's (kLeft only).
+    ExprVector finalExprs;
+    finalExprs.reserve(node->outputColumns().size());
+    for (ColumnCP outputColumn : node->outputColumns()) {
+      if (node->isLeft() && outputColumn == node->includeMarker()) {
+        finalExprs.push_back(innerIncludeMarker);
+      } else {
+        finalExprs.push_back(outputColumn);
+      }
+    }
+    return builder().make<Project>(Project::Key{
+        withId,
+        std::move(finalExprs),
+        node->outputColumns(),
+    });
+  }
+
+  // Aggregate peel (Rule A) for kLeft (Cases 1, 2, 3).
+  //
+  // Shape:
+  //   - Project (strip rn, COALESCE empty-input aggs, reorder)
+  //     - Aggregate (groupingKeys = [rn, gby],
+  //                  aggregates = user aggs FILTER (_include)
+  //                            ++ arbitrary(L.col) for each L.col)
+  //       - Apply (kLeft, filter = F_pre)  ← recurses
+  //         - body  = Project(agg.input, [..., _include := true])
+  //         - input = AssignUniqueId(L) → tagged_L
+  //
+  // In scope: kind = kLeft; gby empty or non-empty; F_post empty
+  // (accFilter doesn't reference Agg's aggregate-result output cols —
+  // refs to gby output cols are fine, they're pass-through in lifted
+  // Agg).
+  //
+  // COALESCE for non-NULL empty-input aggregates: applied in final
+  // Project. The lifted Agg's aggregate-result output uses a fresh
+  // Column* (slot-identity invariant); the original aggregate output
+  // Column* is reused at the final Project's output position so parent
+  // expressions resolve.
+  NodeCP aggregatePeel(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    AggregateCP aggregate = body->as<Aggregate>();
+
+    if (node->isLeftSemiProject()) {
+      return aggregatePeelSemi(node, input, body, accumulatedFilter);
+    }
+    if (!node->isLeft()) {
+      VELOX_NYI(
+          "Decorrelate: Aggregate peel for kind={} not yet supported",
+          node->kind());
+    }
+    if (aggregate->input()->is(NodeType::kGroupId)) {
+      VELOX_NYI("Decorrelate: Aggregate peel over GROUPING SETS NYI");
+    }
+
+    const size_t numGroupingKeys = aggregate->groupingKeys().size();
+    auto [filterPreConjuncts, filterPostConjuncts] =
+        splitFilterPreAndPost(accumulatedFilter, aggregate, numGroupingKeys);
+
+    // Equi-correlated scalar aggregate with no boundary pre-filter, no inner
+    // GROUP BY, and aggregates that don't reference the outer: group the body
+    // once by the correlation key and LEFT JOIN it back to the outer,
+    // aggregating once per key instead of once per outer row. With no inner
+    // GROUP BY the grouped body has one row per correlation key, so the
+    // join-back yields one row per outer. Other correlations use the general
+    // shape below.
+    if (filterPreConjuncts.empty() && numGroupingKeys == 0 &&
+        !aggregateArgsReferenceOuter(aggregate, input->outputColumns())) {
+      if (auto correlation =
+              liftEquiCorrelation(aggregate->input(), input->outputColumns())) {
+        return aggregatePeelEqui(
+            node,
+            input,
+            aggregate,
+            std::move(*correlation),
+            filterPostConjuncts);
+      }
+    }
+
+    // Case 4 NYI guard: kLeft + non-empty F_post + non-empty gby.
+    // The IF-in-outer-Project shape is correct only when the lifted
+    // Aggregate produces exactly one row per outer (empty gby). With
+    // non-empty gby it produces N rows per outer; IF-in-Project would
+    // emit all N rows with selective NULLs while the original kLeft
+    // Apply over Aggregate with HAVING-style filter drops failing rows
+    // and pads ONCE if all fail. Wrong row counts.
+    if (!filterPostConjuncts.empty() && numGroupingKeys > 0) {
+      VELOX_NYI(
+          "Decorrelate Case 4 (kLeft, Apply.filter non-null with F_post, "
+          "Agg.gby non-empty) is not yet implemented");
+    }
+
+    // Validator: reject aggregates whose args reference ONLY outer
+    // correlation columns (e.g., `max(t.a)`, `count(t.a)`). These are
+    // "pure-outer" aggregates: SQL semantics demand outer-scope
+    // collapse (one output row per outer scope), but the lifted shape
+    // produces per-(rn, gby) results — wrong row count and wrong
+    // values. A separate rewrite is required (tracked as the
+    // pure-outer aggregate semantics work); until it lands we decline
+    // here.
+    //
+    // Aggregates with literal-only args (e.g., `count(1)`) are NOT
+    // pure-outer — no column refs at all, and the lifted shape handles
+    // them correctly via FILTER(_include). The check is "ARGS
+    // REFERENCE AT LEAST ONE COLUMN AND EVERY REFERENCED COLUMN IS
+    // OUTER".
+    AggregateRecovery::validateAggregateArgs(
+        aggregate->aggregates(), node->correlationColumns());
+    AggregateRecovery recovery(builder(), exprFactory_);
+
+    // Build the recovered chain bottom-up.
+    auto innerApply = buildAggregateInnerApply(
+        input, aggregate, std::move(filterPreConjuncts));
+    NodeCP decorrelatedInner = rewrite(innerApply.apply);
+
+    auto wraps = buildAggregateWraps(aggregate, numGroupingKeys);
+    NodeCP liftedAggregate = buildLiftedAggregate(
+        input,
+        aggregate,
+        recovery,
+        innerApply.rowIdColumn,
+        innerApply.includeMarker,
+        wraps,
+        numGroupingKeys,
+        decorrelatedInner);
+
+    // With an inner GROUP BY the lifted aggregate groups by (rowId, gby keys),
+    // so it can emit several rows per outer row; grouping on the rowId alone no
+    // longer guarantees one row per outer. A scalar subquery must raise on the
+    // first outer with more than one group, so assert uniqueness on the rowId.
+    if (node->enforceSingleRow() && numGroupingKeys > 0) {
+      liftedAggregate =
+          enforceScalarSingleRow(liftedAggregate, innerApply.rowIdColumn);
+    }
+
+    ExprCP filterPostSubstituted = buildFilterPostSubstituted(
+        filterPostConjuncts, aggregate, wraps, numGroupingKeys);
+
+    return buildAggregateFinalProject(
+        node,
+        input,
+        aggregate,
+        wraps,
+        filterPostSubstituted,
+        liftedAggregate,
+        numGroupingKeys);
+  }
+
+  // True if any aggregate's arguments reference an outer (input) column.
+  // Such aggregates need the outer columns visible below the aggregation,
+  // which the grouped join-back form cannot provide.
+  static bool aggregateArgsReferenceOuter(
+      AggregateCP aggregate,
+      const ColumnVector& outerColumns) {
+    for (const auto* call : aggregate->aggregates()) {
+      for (ExprCP argument : call->args()) {
+        if (argument->columns().containsAny(outerColumns)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  // Equi-correlation lifted from an Aggregate's input for the grouped
+  // join-back decorrelation.
+  struct EquiCorrelation {
+    // The aggregate's input with the correlation predicates removed.
+    NodeCP cleanBody;
+    // Equi keys: `leftKeys` over the outer input, `rightKeys` over
+    // `cleanBody`.
+    ExprVector leftKeys;
+    ExprVector rightKeys;
+  };
+
+  // Lifts the equi-correlation out of an Aggregate's input. Succeeds only
+  // when the correlation sits in a Filter chain above a correlation-free
+  // subtree and every correlation conjunct is an equality partitioning
+  // cleanly into an outer-side and a body-side expression; returns nullopt
+  // otherwise.
+  std::optional<EquiCorrelation> liftEquiCorrelation(
+      NodeCP aggregateInput,
+      const ColumnVector& inputColumns) {
+    ExprVector correlation;
+    ExprVector localPredicates;
+    NodeCP base = aggregateInput;
+    while (base->is(NodeType::kFilter)) {
+      const Filter* filter = base->as<Filter>();
+      for (ExprCP conjunct : filter->predicates()) {
+        (conjunct->columns().containsAny(inputColumns) ? correlation
+                                                       : localPredicates)
+            .push_back(conjunct);
+      }
+      base = filter->input();
+    }
+
+    // The subtree below the lifted Filters must be correlation-free, and
+    // there must be at least one correlation conjunct to lift.
+    if (correlation.empty() ||
+        !recomputeCorrelations(base, inputColumns).empty()) {
+      return std::nullopt;
+    }
+
+    JoinCondition::Split split = JoinCondition::splitEquiKeys(
+        correlation,
+        PlanObjectSet::fromObjects(inputColumns),
+        PlanObjectSet::fromObjects(base->outputColumns()));
+    if (!split.residual.empty()) {
+      return std::nullopt;
+    }
+
+    NodeCP cleanBody = localPredicates.empty()
+        ? base
+        : builder().make<Filter>(Filter::Key{base, std::move(localPredicates)});
+    return EquiCorrelation{
+        cleanBody, std::move(split.leftKeys), std::move(split.rightKeys)};
+  }
+
+  // Decorrelates an equi-correlated kLeft Aggregate Apply (no inner GROUP
+  // BY) by grouping the (correlation-free) body once by the correlation
+  // key, then LEFT JOINing the result back to the outer on the correlation
+  // equi keys. Empty-input aggregates receive their empty value on outer
+  // rows with no match via the COALESCE in `wraps`; a post-aggregation
+  // filter is applied at the final Project.
+  NodeCP aggregatePeelEqui(
+      ApplyCP node,
+      NodeCP input,
+      AggregateCP aggregate,
+      EquiCorrelation correlation,
+      const ExprVector& filterPostConjuncts) {
+    std::vector<AggregateWrap> wraps =
+        buildAggregateWraps(aggregate, /*numGroupingKeys=*/0);
+
+    // The correlation keys become the new Aggregate's grouping keys and the
+    // join-back's right keys: reuse the body column for a plain column, mint
+    // a fresh column for a computed key.
+    ColumnVector rightKeyColumns;
+    rightKeyColumns.reserve(correlation.rightKeys.size());
+    for (ExprCP key : correlation.rightKeys) {
+      rightKeyColumns.push_back(
+          key->is(PlanType::kColumnExpr)
+              ? key->as<Column>()
+              : Column::create("__groupingKey", key->value()));
+    }
+
+    // Aggregate output: [correlation key columns, raw aggregate outputs].
+    ColumnVector aggregateOutputColumns;
+    aggregateOutputColumns.reserve(rightKeyColumns.size() + wraps.size());
+    appendAll(aggregateOutputColumns, rightKeyColumns);
+    for (const auto& wrap : wraps) {
+      aggregateOutputColumns.push_back(wrap.liftedOutput);
+    }
+
+    AggregateCallVector aggregates = aggregate->aggregates();
+    NodeCP groupedBody = builder().make<Aggregate>(Aggregate::Key{
+        correlation.cleanBody,
+        std::move(correlation.rightKeys),
+        std::move(aggregates),
+        std::move(aggregateOutputColumns),
+    });
+
+    // LEFT JOIN the grouped body back to the outer on the correlation equi
+    // keys. The output keeps the outer columns and the (raw) aggregate
+    // outputs; the correlation key columns are internal and dropped.
+    ColumnVector joinOutput;
+    joinOutput.reserve(input->outputColumns().size() + wraps.size());
+    appendAll(joinOutput, input->outputColumns());
+    for (const auto& wrap : wraps) {
+      joinOutput.push_back(wrap.liftedOutput);
+    }
+
+    ExprVector rightKeyExprs;
+    appendAll(rightKeyExprs, rightKeyColumns);
+
+    NodeCP join = builder().make<Join>(Join::Key{
+        input,
+        groupedBody,
+        velox::core::JoinType::kLeft,
+        std::move(correlation.leftKeys),
+        std::move(rightKeyExprs),
+        /*filter=*/{},
+        /*nullAware=*/false,
+        /*nullAsValue=*/false,
+        std::move(joinOutput),
+    });
+
+    ExprCP filterPostSubstituted = buildFilterPostSubstituted(
+        filterPostConjuncts, aggregate, wraps, /*numGroupingKeys=*/0);
+
+    return buildAggregateFinalProject(
+        node,
+        input,
+        aggregate,
+        wraps,
+        filterPostSubstituted,
+        join,
+        /*numGroupingKeys=*/0);
+  }
+
+  // For each aggregate in the original Aggregate, decides what the
+  // lifted Aggregate should emit (`liftedOutput`) and what the final
+  // Project should produce at the original output position
+  // (`finalExpression`). Empty-input value resolution via the
+  // FunctionRegistry: aggregates whose empty value is non-NULL (count,
+  // count_if, etc.) need COALESCE; others pass through.
+  //
+  // Slot-identity invariant: a Column* must carry the same value
+  // across all output positions. For COALESCE-needing aggregates,
+  // the lifted Aggregate's raw output
+  // (NULL for pad rows) and the final Project's COALESCE output
+  // (non-NULL for pad rows) must occupy DIFFERENT Column*s. We
+  // allocate a fresh Column* for the lifted raw output and reuse the
+  // original output Column* at the final Project — parent expressions
+  // referencing the original Column* see the coalesced value.
+  struct AggregateWrap {
+    // What the lifted Aggregate emits for this aggregate. Either the
+    // original output Column* (no COALESCE needed) or a fresh Column*.
+    ColumnCP liftedOutput;
+    // The expression at the final Project's output position. Either
+    // the original Column* itself (pass-through) or a COALESCE Call.
+    ExprCP finalExpression;
+  };
+
+  std::vector<AggregateWrap> buildAggregateWraps(
+      AggregateCP aggregate,
+      size_t numGroupingKeys) {
+    std::vector<AggregateWrap> wraps;
+    wraps.reserve(aggregate->aggregates().size());
+    const auto* registry = FunctionRegistry::instance();
+    for (size_t i = 0; i < aggregate->aggregates().size(); ++i) {
+      const auto* aggregateCall = aggregate->aggregates()[i];
+      // outputColumns positional layout: [gby_cols, agg_result_cols].
+      ColumnCP originalOutput = aggregate->outputColumns()[numGroupingKeys + i];
+
+      std::vector<const velox::Type*> argumentTypes;
+      argumentTypes.reserve(aggregateCall->args().size());
+      for (ExprCP argument : aggregateCall->args()) {
+        argumentTypes.push_back(argument->value().type);
+      }
+      velox::Variant emptyValue = registry->aggregateResultForEmptyInput(
+          aggregateCall->name(), argumentTypes);
+
+      if (emptyValue.isNull()) {
+        wraps.push_back({originalOutput, originalOutput});
+      } else {
+        ColumnCP rawOutput =
+            Column::create(originalOutput->name(), originalOutput->value());
+        const Literal* emptyLiteral = builder().makeLiteral(
+            std::move(emptyValue), originalOutput->value().type);
+        ExprCP coalesceExpression =
+            exprFactory_.makeCoalesce(rawOutput, emptyLiteral);
+        wraps.push_back({rawOutput, coalesceExpression});
+      }
+    }
+    return wraps;
+  }
+
+  // Splits the accumulated Apply.filter into F_pre (no refs to
+  // aggregate-result columns; applied pre-aggregation as Join.filter)
+  // and F_post (refs aggregate-result columns; applied post-
+  // aggregation via the final Project's IF wrap per Case 3).
+  //
+  // Refs to grouping-key columns are treated as F_pre — those columns
+  // pass through the lifted Aggregate unchanged and are valid pre- or
+  // post-aggregation.
+  std::pair<ExprVector, ExprVector> splitFilterPreAndPost(
+      const ExprVector& accumulatedFilter,
+      AggregateCP aggregate,
+      size_t numGroupingKeys) {
+    if (accumulatedFilter.empty()) {
+      return {ExprVector{}, ExprVector{}};
+    }
+    PlanObjectSet aggregateResultColumns;
+    for (size_t i = numGroupingKeys; i < aggregate->outputColumns().size();
+         ++i) {
+      aggregateResultColumns.add(aggregate->outputColumns()[i]);
+    }
+    ExprVector pre;
+    ExprVector post;
+    for (ExprCP conjunct : accumulatedFilter) {
+      bool referencesAggregateResult = false;
+      conjunct->columns().forEach<Column>([&](const Column* column) {
+        if (aggregateResultColumns.contains(column)) {
+          referencesAggregateResult = true;
+        }
+      });
+      (referencesAggregateResult ? post : pre).push_back(conjunct);
+    }
+    return {std::move(pre), std::move(post)};
+  }
+
+  // Result of the inner-Apply construction step of Aggregate peel.
+  struct InnerApplyResult {
+    NodeCP apply;
+    ColumnCP rowIdColumn;
+    ColumnCP includeMarker;
+  };
+
+  // Builds the inner Apply (kLeft, filter = F_pre) over
+  // AssignUniqueId(input) with body = aggregate's input. The Apply's
+  // includeMarker is consumed by the lifted Aggregate's FILTER.
+  // The driver recurses on this inner Apply to handle any remaining
+  // peels in the Aggregate's input chain. enforceSingleRow is false:
+  // the lifted Aggregate above guarantees ≤1 row per row-id by
+  // grouping on it, so no separate per-row assertion is needed.
+  InnerApplyResult buildAggregateInnerApply(
+      NodeCP input,
+      AggregateCP aggregate,
+      ExprVector filterPre) {
+    ColumnCP rowIdColumn = makeIdColumn();
+    NodeCP taggedInput =
+        builder().make<AssignUniqueId>(AssignUniqueId::Key{input, rowIdColumn});
+
+    NodeCP body = aggregate->input();
+
+    // Fresh includeMarker per inner Apply.
+    ColumnCP includeMarker = makeIncludeColumn();
+
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(
+        taggedInput->outputColumns().size() + body->outputColumns().size() + 1);
+    appendAll(innerOutputColumns, taggedInput->outputColumns());
+    PlanObjectSet bodySeen =
+        PlanObjectSet::fromObjects(taggedInput->outputColumns());
+    for (ColumnCP column : body->outputColumns()) {
+      if (!bodySeen.contains(column)) {
+        bodySeen.add(column);
+        innerOutputColumns.push_back(column);
+      }
+    }
+    innerOutputColumns.push_back(includeMarker);
+
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(body, taggedInput->outputColumns());
+
+    NodeCP applyNode = builder().make<Apply>(Apply::Key{
+        taggedInput,
+        body,
+        std::move(innerCorrelations),
+        velox::core::JoinType::kLeft,
+        std::move(filterPre),
+        /*enforceSingleRow=*/false,
+        /*markColumn=*/nullptr,
+        /*inLhs=*/nullptr,
+        /*inBodyKey=*/nullptr,
+        includeMarker,
+        std::move(innerOutputColumns),
+    });
+    return {applyNode, rowIdColumn, includeMarker};
+  }
+
+  // Builds the lifted Aggregate above the decorrelated inner Apply.
+  //
+  // groupingKeys = [rowId, original gby...]: each (rowId, gby_values)
+  // tuple corresponds to one outer row's worth of body rows grouped by
+  // the original gby. The outer-input columns (L.cols) are NOT in
+  // groupingKeys (they would inflate cardinality with no benefit);
+  // they ride out via `arbitrary(L.col)` aggregates instead, without
+  // the _include FILTER (pad rows have real L.col values that we want
+  // preserved).
+  //
+  // aggregates = (a) original aggregates with `count(*)` rewritten and
+  // the `_include` marker AND-folded into every aggregate's FILTER
+  // condition; plus (b) `arbitrary(L.col)` for each outer-input
+  // column.
+  NodeCP buildLiftedAggregate(
+      NodeCP input,
+      AggregateCP aggregate,
+      AggregateRecovery& recovery,
+      ColumnCP rowIdColumn,
+      ColumnCP includeMarker,
+      const std::vector<AggregateWrap>& wraps,
+      size_t numGroupingKeys,
+      NodeCP decorrelatedInner) {
+    AggregateCallVector liftedAggregates =
+        recovery.rewriteCountStar(aggregate->aggregates(), includeMarker);
+    liftedAggregates =
+        recovery.addFilterCondition(liftedAggregates, includeMarker);
+    for (ColumnCP outerColumn : input->outputColumns()) {
+      liftedAggregates.push_back(makeArbitrary(outerColumn));
+    }
+
+    ExprVector groupingKeys;
+    groupingKeys.reserve(1 + numGroupingKeys);
+    groupingKeys.push_back(rowIdColumn);
+    appendAll(groupingKeys, aggregate->groupingKeys());
+
+    // outputColumns positional contract:
+    //   [groupingKeys (rowId, gby_cols),
+    //    user aggregate outputs (wraps[i].liftedOutput),
+    //    arbitrary(L.col) outputs (reuse L.col Column*s)]
+    ColumnVector liftedOutputColumns;
+    liftedOutputColumns.reserve(
+        1 + numGroupingKeys + wraps.size() + input->outputColumns().size());
+    liftedOutputColumns.push_back(rowIdColumn);
+    for (size_t i = 0; i < numGroupingKeys; ++i) {
+      liftedOutputColumns.push_back(aggregate->outputColumns()[i]);
+    }
+    for (const auto& wrap : wraps) {
+      liftedOutputColumns.push_back(wrap.liftedOutput);
+    }
+    appendAll(liftedOutputColumns, input->outputColumns());
+
+    return builder().make<Aggregate>(Aggregate::Key{
+        decorrelatedInner,
+        std::move(groupingKeys),
+        std::move(liftedAggregates),
+        std::move(liftedOutputColumns),
+    });
+  }
+
+  // Substitutes each aggregate-result column reference in F_post
+  // conjuncts with the corresponding `c_coal` expression
+  // (= wraps[i].finalExpression). Ensures F_post evaluates over the
+  // COALESCE-corrected per-outer values rather than the raw
+  // aggregate results.
+  ExprCP buildFilterPostSubstituted(
+      const ExprVector& filterPostConjuncts,
+      AggregateCP aggregate,
+      const std::vector<AggregateWrap>& wraps,
+      size_t numGroupingKeys) {
+    if (filterPostConjuncts.empty()) {
+      return nullptr;
+    }
+    ColumnVector substitutionSource;
+    ExprVector substitutionTarget;
+    substitutionSource.reserve(wraps.size());
+    substitutionTarget.reserve(wraps.size());
+    for (size_t i = 0; i < wraps.size(); ++i) {
+      substitutionSource.push_back(
+          aggregate->outputColumns()[numGroupingKeys + i]);
+      substitutionTarget.push_back(wraps[i].finalExpression);
+    }
+    ExprCP combined = exprFactory_.andAll(filterPostConjuncts);
+    return exprFactory_.substitute(
+        combined, substitutionSource, substitutionTarget);
+  }
+
+  // Final Project: shapes `child`'s output to node->outputColumns()
+  // (= L.cols ++ gby_cols ++ aggregate_results ++ includeMarker).
+  //   - L.cols: pass-through from the input columns (the outer side of
+  //     the join-back, or the lifted `arbitrary` outputs).
+  //   - gby_cols: pass-through from the grouping-key outputs.
+  //   - aggregate_results: each `wrap.finalExpression` (pass-through
+  //     or COALESCE), additionally wrapped in IF(F_post_subst, ...,
+  //     NULL) when a post-aggregation filter is present. The IF preserves
+  //     the outer row and nulls the aggregate values when the filter
+  //     fails — kLeft semantics for HAVING-style predicates.
+  NodeCP buildAggregateFinalProject(
+      ApplyCP node,
+      NodeCP input,
+      AggregateCP aggregate,
+      const std::vector<AggregateWrap>& wraps,
+      ExprCP filterPostSubstituted,
+      NodeCP child,
+      size_t numGroupingKeys) {
+    ExprVector finalExpressions;
+    finalExpressions.reserve(node->outputColumns().size());
+    appendAll(finalExpressions, input->outputColumns());
+    for (size_t i = 0; i < numGroupingKeys; ++i) {
+      finalExpressions.push_back(aggregate->outputColumns()[i]);
+    }
+    for (size_t i = 0; i < wraps.size(); ++i) {
+      ExprCP expression = wraps[i].finalExpression;
+      if (filterPostSubstituted != nullptr) {
+        ColumnCP originalOutput =
+            aggregate->outputColumns()[numGroupingKeys + i];
+        TypeCP type = originalOutput->value().type;
+        expression = exprFactory_.makeIf(
+            filterPostSubstituted, expression, builder().makeNull(type));
+      }
+      finalExpressions.push_back(expression);
+    }
+    // includeMarker is `true` for every output row: this level emits one
+    // row per outer (grouped by the per-outer id, or one match per outer
+    // from the join-back), so there are no pad rows to exclude.
+    finalExpressions.push_back(builder().makeBoolean(true));
+    return builder().make<Project>(Project::Key{
+        child,
+        std::move(finalExpressions),
+        node->outputColumns(),
+    });
+  }
+
+  // Builds the terminus shape from a fully-peeled Apply.
+  NodeCP terminus(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
+    switch (apply->kind()) {
+      case velox::core::JoinType::kLeft:
+        return terminusLeft(apply, input, body, filter);
+      case velox::core::JoinType::kLeftSemiProject:
+        return terminusSemi(apply, input, body, filter);
+      default:
+        VELOX_NYI("Decorrelate: unexpected Apply.kind {}", apply->kind());
+    }
+  }
+
+  // Adds `_include := true` to body. After LEFT JOIN it reads `true`
+  // on real body rows and NULL on pad rows.
+  // Wraps body in a Project exposing body cols absent from `excluded`
+  // plus `_include := true`. After LEFT JOIN above this, the marker
+  // reads `true` on real body rows and NULL on pad rows. Excluding
+  // input cols keeps the join's right side disjoint from its left.
+  NodeCP addIncludeMarkerToBody(
+      NodeCP body,
+      ColumnCP includeMarker,
+      const ColumnVector& excluded) {
+    PlanObjectSet excludedSet = PlanObjectSet::fromObjects(excluded);
+    ExprVector exprs;
+    ColumnVector outputColumns;
+    exprs.reserve(body->outputColumns().size() + 1);
+    outputColumns.reserve(body->outputColumns().size() + 1);
+    for (ColumnCP column : body->outputColumns()) {
+      if (!excludedSet.contains(column)) {
+        exprs.push_back(column);
+        outputColumns.push_back(column);
+      }
+    }
+    exprs.push_back(builder().makeBoolean(true));
+    outputColumns.push_back(includeMarker);
+
+    return builder().make<Project>(
+        Project::Key{body, std::move(exprs), std::move(outputColumns)});
+  }
+
+  NodeCP
+  terminusLeft(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
+    NodeCP markedBody = addIncludeMarkerToBody(
+        body, apply->includeMarker(), input->outputColumns());
+
+    if (!apply->enforceSingleRow()) {
+      // Plain LEFT JOIN terminus: no per-outer cardinality assertion.
+      JoinCondition::Split split = JoinCondition::splitEquiKeys(
+          filter,
+          PlanObjectSet::fromObjects(input->outputColumns()),
+          PlanObjectSet::fromObjects(markedBody->outputColumns()));
+      return builder().make<Join>(Join::Key{
+          input,
+          markedBody,
+          velox::core::JoinType::kLeft,
+          std::move(split.leftKeys),
+          std::move(split.rightKeys),
+          std::move(split.residual),
+          /*nullAware=*/false,
+          /*nullAsValue=*/false,
+          apply->outputColumns(),
+      });
+    }
+
+    // ESR=true: wrap LEFT JOIN in EnforceDistinct on the per-row id
+    // (from AssignUniqueId on input) so cardinality > 1 per outer
+    // raises at runtime. Final Project strips the id so the output
+    // matches Apply's contract.
+
+    // Tag input rows with a fresh BIGINT id column.
+    ColumnCP idColumn = makeIdColumn();
+    NodeCP taggedInput =
+        builder().make<AssignUniqueId>(AssignUniqueId::Key{input, idColumn});
+
+    // Build LEFT JOIN; output carries taggedInput.cols ++ markedBody.cols
+    // (i.e., input.cols + idColumn + body.cols + includeMarker).
+    ColumnVector joinOutput;
+    joinOutput.reserve(
+        taggedInput->outputColumns().size() +
+        markedBody->outputColumns().size());
+    appendAll(joinOutput, taggedInput->outputColumns());
+    appendAll(joinOutput, markedBody->outputColumns());
+
+    JoinCondition::Split split = JoinCondition::splitEquiKeys(
+        filter,
+        PlanObjectSet::fromObjects(taggedInput->outputColumns()),
+        PlanObjectSet::fromObjects(markedBody->outputColumns()));
+    NodeCP join = builder().make<Join>(Join::Key{
+        taggedInput,
+        markedBody,
+        velox::core::JoinType::kLeft,
+        std::move(split.leftKeys),
+        std::move(split.rightKeys),
+        std::move(split.residual),
+        /*nullAware=*/false,
+        /*nullAsValue=*/false,
+        std::move(joinOutput),
+    });
+
+    NodeCP enforced = enforceScalarSingleRow(join, idColumn);
+
+    // Strip the id column. Final outputColumns match Apply's contract
+    // (input.cols ++ body.cols ++ includeMarker). EnforceDistinct
+    // passes through (incl. the id col); the Project here is the
+    // column-prune that removes the id from the public output schema.
+    ExprVector finalExprs;
+    finalExprs.reserve(apply->outputColumns().size());
+    appendAll(finalExprs, apply->outputColumns());
+    return builder().make<Project>(Project::Key{
+        enforced,
+        std::move(finalExprs),
+        apply->outputColumns(),
+    });
+  }
+
+  // Aggregate peel for kLeftSemiProject:
+  //   - body aggregate elidable → drop it, recurse against its input
+  //   - inLhs != nullptr → Rule B-IN  (Cases 5b/6b/7b/8b)
+  //   - inLhs == nullptr → Rule B-EXISTS (Cases 5a/6a/7a/8a)
+  NodeCP aggregatePeelSemi(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    AggregateCP aggregate = body->as<Aggregate>();
+
+    if (aggregate->input()->is(NodeType::kGroupId)) {
+      VELOX_NYI(
+          "Decorrelate: Aggregate peel for kLeftSemiProject over GROUPING "
+          "SETS NYI");
+    }
+
+    if (canElideBodyAggregate(node, aggregate, accumulatedFilter)) {
+      return aggregatePeelSemiDropAggregate(
+          node, input, aggregate, accumulatedFilter);
+    }
+
+    if (node->inLhs() != nullptr) {
+      return aggregatePeelSemiIn(node, input, body, accumulatedFilter);
+    }
+    return aggregatePeelSemiExists(node, input, body, accumulatedFilter);
+  }
+
+  // Drops the body Aggregate and rewrites the Apply against its input.
+  // Caller must have verified via `canElideBodyAggregate` that no
+  // aggregate-result column is referenced.
+  NodeCP aggregatePeelSemiDropAggregate(
+      ApplyCP node,
+      NodeCP input,
+      AggregateCP aggregate,
+      ExprVector accumulatedFilter) {
+    ColumnVector substitutionSource =
+        prefix(aggregate->outputColumns(), aggregate->groupingKeys().size());
+
+    ExprVector newFilter = exprFactory_.substitute(
+        accumulatedFilter, substitutionSource, aggregate->groupingKeys());
+    ExprCP newInBodyKey = substituteOrNull(
+        exprFactory_,
+        node->inBodyKey(),
+        substitutionSource,
+        aggregate->groupingKeys());
+
+    NodeCP newBody = aggregate->input();
+    ColumnVector innerCorrelations =
+        recomputeCorrelations(newBody, input->outputColumns());
+
+    ColumnVector innerOutputColumns;
+    innerOutputColumns.reserve(input->outputColumns().size() + 1);
+    appendAll(innerOutputColumns, input->outputColumns());
+    innerOutputColumns.push_back(node->markColumn());
+
+    NodeCP newApply = builder().make<Apply>(Apply::Key{
+        input,
+        newBody,
+        std::move(innerCorrelations),
+        node->kind(),
+        std::move(newFilter),
+        node->enforceSingleRow(),
+        node->markColumn(),
+        node->inLhs(),
+        newInBodyKey,
+        /*includeMarker=*/nullptr,
+        std::move(innerOutputColumns),
+    });
+    return rewrite(newApply);
+  }
+
+  // Aggregate peel for kLeftSemiProject in the EXISTS branch (Rule
+  // B-EXISTS, Cases 5a/6a/7a/8a).
+  //
+  // Three branches, dispatched by (F_post presence, gby presence):
+  //
+  // - **Case 5a** (no F_post, empty gby): mark = TRUE per outer.
+  //   Body is elided — scalar aggregates always emit one row, so
+  //   EXISTS is unconditionally TRUE. Matches strict SQL; same
+  //   trade-off as Translate's EXISTS-over-scalar-agg fold, which
+  //   catches the common case earlier.
+  //
+  // - **Case 6a** (no F_post, non-empty gby): single Aggregate per
+  //   `[rn]` with `bool_or(_include)` collapsing across gby groups.
+  //   Drops the body's user aggregates (kSemi doesn't expose them).
+  //   For unmatched outer (pad-only): bool_or({NULL}) → NULL →
+  //   COALESCE → false. Matches strict SQL: gby on empty input → 0
+  //   groups → EXISTS = false.
+  //
+  // - **Cases 7a / 8a** (F_post present): unified Stage 1 / Stage 2
+  //   shape paralleling `aggregatePeelSemiIn`, with the equi-pair
+  //   dropped from `combined` and the mark CASE reduced to two-state
+  //   (no null-aware tri-state — EXISTS has no equi-pair to source
+  //   NULL from). The `combined` bit is `COALESCE(F_post_subst,
+  //   false)`. Path 1 (empty gby = 7a) emits one row per outer; mark
+  //   = combined. Path 2 (non-empty gby = 8a) collapses gby groups
+  //   per outer via `bool_or(combined) FILTER(_include)`.
+  NodeCP aggregatePeelSemiExists(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    AggregateCP aggregate = body->as<Aggregate>();
+    const size_t numGroupingKeys = aggregate->groupingKeys().size();
+
+    auto [filterPreConjuncts, filterPostConjuncts] =
+        splitFilterPreAndPost(accumulatedFilter, aggregate, numGroupingKeys);
+
+    // Case 5a: scalar agg with no HAVING. Per strict SQL, mark = TRUE
+    // for every outer regardless of body content (scalar aggs always
+    // emit one row → EXISTS sees that row → TRUE). The body is elided
+    // — same trade-off as Translate's EXISTS-over-scalar-agg fold,
+    // which catches the common case earlier. This handles the rare
+    // shapes Translate's fold misses (e.g., bodies with a Sort/Window
+    // operator above the Aggregate that breaks Translate's walker).
+    if (filterPostConjuncts.empty() && numGroupingKeys == 0) {
+      ExprVector finalExprs;
+      finalExprs.reserve(input->outputColumns().size() + 1);
+      appendAll(finalExprs, input->outputColumns());
+      finalExprs.push_back(builder().makeBoolean(true));
+      return builder().make<Project>(Project::Key{
+          input,
+          std::move(finalExprs),
+          node->outputColumns(),
+      });
+    }
+
+    AggregateRecovery recovery(builder(), exprFactory_);
+    auto innerApply = buildAggregateInnerApply(
+        input, aggregate, std::move(filterPreConjuncts));
+    NodeCP decorrelatedInner = rewrite(innerApply.apply);
+
+    // Case 6a: non-empty gby with no HAVING. Single Aggregate per
+    // [rn] with `bool_or(_include)` collapsing across gby groups.
+    // Drops the body's user aggregates entirely — kSemi doesn't
+    // expose them, and without F_post nothing else references them.
+    if (filterPostConjuncts.empty()) {
+      ColumnCP rawMark = Column::create(
+          node->markColumn()->name(), node->markColumn()->value());
+
+      AggregateCallVector aggregates;
+      aggregates.reserve(1 + input->outputColumns().size());
+      aggregates.push_back(recovery.makeBoolOr(innerApply.includeMarker));
+      for (ColumnCP outerColumn : input->outputColumns()) {
+        aggregates.push_back(makeArbitrary(outerColumn));
+      }
+
+      ColumnVector outputs;
+      outputs.reserve(2 + input->outputColumns().size());
+      outputs.push_back(innerApply.rowIdColumn);
+      outputs.push_back(rawMark);
+      appendAll(outputs, input->outputColumns());
+
+      NodeCP agg = builder().make<Aggregate>(Aggregate::Key{
+          decorrelatedInner,
+          ExprVector{innerApply.rowIdColumn},
+          std::move(aggregates),
+          std::move(outputs),
+      });
+
+      ExprCP markExpr =
+          exprFactory_.makeCoalesce(rawMark, builder().makeBoolean(false));
+
+      ExprVector finalExprs;
+      finalExprs.reserve(input->outputColumns().size() + 1);
+      appendAll(finalExprs, input->outputColumns());
+      finalExprs.push_back(markExpr);
+      return builder().make<Project>(Project::Key{
+          agg,
+          std::move(finalExprs),
+          node->outputColumns(),
+      });
+    }
+
+    // Cases 7a / 8a: F_post present. Stage 1 keeps user aggregates so
+    // F_post can reference them (via wraps substitution). The
+    // validator only applies here — 5a / 6a don't compute the user
+    // aggregates at all, so the pure-outer-args concern is moot.
+    AggregateRecovery::validateAggregateArgs(
+        aggregate->aggregates(), node->correlationColumns());
+
+    auto wraps = buildAggregateWraps(aggregate, numGroupingKeys);
+
+    AggregateCallVector stage1Aggregates = recovery.rewriteCountStar(
+        aggregate->aggregates(), innerApply.includeMarker);
+    stage1Aggregates =
+        recovery.addFilterCondition(stage1Aggregates, innerApply.includeMarker);
+    for (ColumnCP outerColumn : input->outputColumns()) {
+      stage1Aggregates.push_back(makeArbitrary(outerColumn));
+    }
+    ColumnCP padPresentColumn = nullptr;
+    if (numGroupingKeys > 0) {
+      padPresentColumn = Column::create(
+          innerApply.includeMarker->name(), innerApply.includeMarker->value());
+      stage1Aggregates.push_back(makeArbitrary(innerApply.includeMarker));
+    }
+
+    ExprVector stage1GroupingKeys;
+    stage1GroupingKeys.reserve(1 + numGroupingKeys);
+    stage1GroupingKeys.push_back(innerApply.rowIdColumn);
+    appendAll(stage1GroupingKeys, aggregate->groupingKeys());
+
+    ColumnVector stage1OutputColumns;
+    stage1OutputColumns.reserve(
+        1 + numGroupingKeys + wraps.size() + input->outputColumns().size() +
+        (padPresentColumn != nullptr ? 1 : 0));
+    stage1OutputColumns.push_back(innerApply.rowIdColumn);
+    for (size_t i = 0; i < numGroupingKeys; ++i) {
+      stage1OutputColumns.push_back(aggregate->outputColumns()[i]);
+    }
+    for (const auto& wrap : wraps) {
+      stage1OutputColumns.push_back(wrap.liftedOutput);
+    }
+    appendAll(stage1OutputColumns, input->outputColumns());
+    if (padPresentColumn != nullptr) {
+      stage1OutputColumns.push_back(padPresentColumn);
+    }
+
+    NodeCP stage1 = builder().make<Aggregate>(Aggregate::Key{
+        decorrelatedInner,
+        std::move(stage1GroupingKeys),
+        std::move(stage1Aggregates),
+        std::move(stage1OutputColumns),
+    });
+
+    const Literal* falseLiteral = builder().makeBoolean(false);
+
+    // combined: TRUE if no F_post, else COALESCE(F_post_subst, false).
+    ExprCP combinedExpr = builder().makeBoolean(true);
+    if (!filterPostConjuncts.empty()) {
+      ColumnVector substitutionSource;
+      ExprVector substitutionTarget;
+      substitutionSource.reserve(wraps.size());
+      substitutionTarget.reserve(wraps.size());
+      for (size_t i = 0; i < wraps.size(); ++i) {
+        substitutionSource.push_back(
+            aggregate->outputColumns()[numGroupingKeys + i]);
+        substitutionTarget.push_back(wraps[i].finalExpression);
+      }
+      ExprCP filterPostCombined = exprFactory_.andAll(filterPostConjuncts);
+      ExprCP filterPostSubst = exprFactory_.substitute(
+          filterPostCombined, substitutionSource, substitutionTarget);
+      combinedExpr = exprFactory_.makeCoalesce(filterPostSubst, falseLiteral);
+    }
+
+    NodeCP finalInput;
+    ExprCP markExpr;
+    if (numGroupingKeys == 0) {
+      // Path 1 — empty gby.
+      markExpr = combinedExpr;
+      finalInput = stage1;
+    } else {
+      // Path 2 — non-empty gby.
+      ColumnCP combinedColumn =
+          Column::create("_combined", combinedExpr->value());
+
+      ExprVector stage15Expressions;
+      ColumnVector stage15Outputs;
+      const size_t stage15Width = 3 + input->outputColumns().size();
+      stage15Expressions.reserve(stage15Width);
+      stage15Outputs.reserve(stage15Width);
+      stage15Expressions.push_back(innerApply.rowIdColumn);
+      stage15Outputs.push_back(innerApply.rowIdColumn);
+      stage15Expressions.push_back(padPresentColumn);
+      stage15Outputs.push_back(padPresentColumn);
+      for (ColumnCP outerColumn : input->outputColumns()) {
+        stage15Expressions.push_back(outerColumn);
+        stage15Outputs.push_back(outerColumn);
+      }
+      stage15Expressions.push_back(combinedExpr);
+      stage15Outputs.push_back(combinedColumn);
+
+      NodeCP stage15 = builder().make<Project>(Project::Key{
+          stage1,
+          std::move(stage15Expressions),
+          std::move(stage15Outputs),
+      });
+
+      ColumnCP hasTrueColumn = Column::createBoolean("_has_true");
+
+      AggregateCallVector boolOrs;
+      boolOrs.reserve(1);
+      boolOrs.push_back(recovery.makeBoolOr(combinedColumn));
+      boolOrs = recovery.addFilterCondition(boolOrs, padPresentColumn);
+
+      AggregateCallVector stage2Aggregates;
+      stage2Aggregates.reserve(1 + input->outputColumns().size());
+      appendAll(stage2Aggregates, boolOrs);
+      for (ColumnCP outerColumn : input->outputColumns()) {
+        stage2Aggregates.push_back(makeArbitrary(outerColumn));
+      }
+
+      ColumnVector stage2Outputs;
+      stage2Outputs.reserve(2 + input->outputColumns().size());
+      stage2Outputs.push_back(innerApply.rowIdColumn);
+      stage2Outputs.push_back(hasTrueColumn);
+      appendAll(stage2Outputs, input->outputColumns());
+
+      NodeCP stage2 = builder().make<Aggregate>(Aggregate::Key{
+          stage15,
+          ExprVector{innerApply.rowIdColumn},
+          std::move(stage2Aggregates),
+          std::move(stage2Outputs),
+      });
+
+      markExpr = exprFactory_.makeCoalesce(hasTrueColumn, falseLiteral);
+      finalInput = stage2;
+    }
+
+    ExprVector finalExpressions;
+    finalExpressions.reserve(input->outputColumns().size() + 1);
+    appendAll(finalExpressions, input->outputColumns());
+    finalExpressions.push_back(markExpr);
+
+    return builder().make<Project>(Project::Key{
+        finalInput,
+        std::move(finalExpressions),
+        node->outputColumns(),
+    });
+  }
+
+  // Aggregate peel for kLeftSemiProject in the IN-pair branch (Rule
+  // B-IN, Cases 5b/6b/7b/8b).
+  //
+  // Two paths, branched on `aggregate->groupingKeys().empty()`. Both
+  // share Stage 1 — a lifted Aggregate that runs the body's user aggs
+  // FILTER(_include) and carries the outer columns via arbitrary().
+  // The IN equi pair becomes a per-row `combined` bit:
+  //
+  //   combined := [if F_post present: COALESCE(F_post_subst, false) AND]
+  //               eq(inLhs, inBodyKey_subst)
+  //
+  // F_post coalesces to FALSE — a HAVING that fails or returns NULL
+  // means the row does not contribute to the IN match.
+  //
+  // Path 1 (empty gby): Stage 1 emits one row per outer. Mark is
+  // computed inline in the final Project from `combined` alone — no
+  // pad-row short-circuit needed, because Stage 1's FILTER(_include)
+  // makes user aggs evaluate over the empty set for unmatched outers,
+  // so `inBodyKey_subst` already carries the SQL "agg over empty"
+  // value (NULL for max, 0 for count, etc.) and the IN equi test runs
+  // against that.
+  //
+  // Path 2 (non-empty gby): Stage 1 emits multiple rows per outer
+  // (one per gby group). A Stage 1.5 Project computes `combined` per
+  // group. Stage 2 collapses across groups per outer using two
+  // bool_ors — `has_true = bool_or(combined)` and
+  // `has_null = bool_or(combined IS NULL)` — both with
+  // `FILTER(_include)` to discard the pad-row group. The mark CASE
+  // then maps (has_true, has_null) to the tri-state IN result.
+  //
+  // `nullAware = false`: wrap the final mark with `COALESCE(mark,
+  // false)` to collapse the NULL state to false.
+  NodeCP aggregatePeelSemiIn(
+      ApplyCP node,
+      NodeCP input,
+      NodeCP body,
+      ExprVector accumulatedFilter) {
+    AggregateCP aggregate = body->as<Aggregate>();
+    const size_t numGroupingKeys = aggregate->groupingKeys().size();
+
+    auto [filterPreConjuncts, filterPostConjuncts] =
+        splitFilterPreAndPost(accumulatedFilter, aggregate, numGroupingKeys);
+
+    // Validator (same as Rule A): pure-outer aggregates need
+    // outer-scope-collapse semantics not modeled here.
+    AggregateRecovery::validateAggregateArgs(
+        aggregate->aggregates(), node->correlationColumns());
+
+    auto wraps = buildAggregateWraps(aggregate, numGroupingKeys);
+
+    AggregateRecovery recovery(builder(), exprFactory_);
+    auto innerApply = buildAggregateInnerApply(
+        input, aggregate, std::move(filterPreConjuncts));
+    NodeCP decorrelatedInner = rewrite(innerApply.apply);
+
+    // Stage 1 Aggregate:
+    //   groupingKeys = [rowId, original gby...]
+    //   aggregates   = user aggs FILTER(_include)
+    //                + arbitrary(L.col) for each outer col
+    //                + arbitrary(_include) AS padPresent   [Path 2 only]
+    AggregateCallVector stage1Aggregates = recovery.rewriteCountStar(
+        aggregate->aggregates(), innerApply.includeMarker);
+    stage1Aggregates =
+        recovery.addFilterCondition(stage1Aggregates, innerApply.includeMarker);
+    for (ColumnCP outerColumn : input->outputColumns()) {
+      stage1Aggregates.push_back(makeArbitrary(outerColumn));
+    }
+    // Pad-present marker: needed only by Path 2's Stage 2 FILTER.
+    // For Path 1 the mark CASE consumes `inBodyKey_subst` directly,
+    // which already encodes the unmatched-outer case via FILTER(_include)
+    // on the user aggs.
+    ColumnCP padPresentColumn = nullptr;
+    if (numGroupingKeys > 0) {
+      padPresentColumn = Column::create(
+          innerApply.includeMarker->name(), innerApply.includeMarker->value());
+      stage1Aggregates.push_back(makeArbitrary(innerApply.includeMarker));
+    }
+
+    ExprVector stage1GroupingKeys;
+    stage1GroupingKeys.reserve(1 + numGroupingKeys);
+    stage1GroupingKeys.push_back(innerApply.rowIdColumn);
+    appendAll(stage1GroupingKeys, aggregate->groupingKeys());
+
+    ColumnVector stage1OutputColumns;
+    stage1OutputColumns.reserve(
+        1 + numGroupingKeys + wraps.size() + input->outputColumns().size() +
+        (padPresentColumn != nullptr ? 1 : 0));
+    stage1OutputColumns.push_back(innerApply.rowIdColumn);
+    for (size_t i = 0; i < numGroupingKeys; ++i) {
+      stage1OutputColumns.push_back(aggregate->outputColumns()[i]);
+    }
+    for (const auto& wrap : wraps) {
+      stage1OutputColumns.push_back(wrap.liftedOutput);
+    }
+    appendAll(stage1OutputColumns, input->outputColumns());
+    if (padPresentColumn != nullptr) {
+      stage1OutputColumns.push_back(padPresentColumn);
+    }
+
+    NodeCP stage1 = builder().make<Aggregate>(Aggregate::Key{
+        decorrelatedInner,
+        std::move(stage1GroupingKeys),
+        std::move(stage1Aggregates),
+        std::move(stage1OutputColumns),
+    });
+
+    // Substitute agg-result columns in `inBodyKey` and `F_post` with
+    // their post-COALESCE expressions so the mark evaluates over the
+    // SQL "agg over empty" values when applicable. Same mechanism as
+    // Rule A's F_post substitution.
+    ColumnVector substitutionSource;
+    ExprVector substitutionTarget;
+    substitutionSource.reserve(wraps.size());
+    substitutionTarget.reserve(wraps.size());
+    for (size_t i = 0; i < wraps.size(); ++i) {
+      substitutionSource.push_back(
+          aggregate->outputColumns()[numGroupingKeys + i]);
+      substitutionTarget.push_back(wraps[i].finalExpression);
+    }
+    ExprCP inBodyKeySubst = exprFactory_.substitute(
+        node->inBodyKey(), substitutionSource, substitutionTarget);
+
+    const Literal* falseLiteral = builder().makeBoolean(false);
+
+    ExprCP equiPair = exprFactory_.makeEq(node->inLhs(), inBodyKeySubst);
+    ExprCP combinedExpr = equiPair;
+    if (!filterPostConjuncts.empty()) {
+      ExprCP filterPostCombined = exprFactory_.andAll(filterPostConjuncts);
+      ExprCP filterPostSubst = exprFactory_.substitute(
+          filterPostCombined, substitutionSource, substitutionTarget);
+      ExprCP havingCoalesced =
+          exprFactory_.makeCoalesce(filterPostSubst, falseLiteral);
+      combinedExpr = exprFactory_.makeAnd(havingCoalesced, equiPair);
+    }
+
+    const Literal* trueLiteral = builder().makeBoolean(true);
+    const Literal* nullBoolLiteral =
+        builder().makeNull(toType(velox::BOOLEAN()));
+
+    NodeCP finalInput;
+    ExprCP markExpr;
+    if (numGroupingKeys == 0) {
+      // ===== Path 1 — empty gby =====
+      //
+      // Single Aggregate; mark inline:
+      //   IF(combined, true, IF(combined IS NULL, NULL, false))
+      ExprCP combinedIsNull = exprFactory_.makeIsNull(combinedExpr);
+      markExpr = exprFactory_.makeIf(
+          combinedExpr,
+          trueLiteral,
+          exprFactory_.makeIf(combinedIsNull, nullBoolLiteral, falseLiteral));
+      finalInput = stage1;
+    } else {
+      // ===== Path 2 — non-empty gby =====
+      //
+      // Stage 1.5 Project: per-(rn, gby) combined bit + carry-through
+      // (rowId, padPresent, L.cols). Stage 2 aggregates over [rowId].
+      ColumnCP combinedColumn =
+          Column::create("_combined", combinedExpr->value());
+
+      ExprVector stage15Expressions;
+      ColumnVector stage15Outputs;
+      const size_t stage15Width = 3 + input->outputColumns().size();
+      stage15Expressions.reserve(stage15Width);
+      stage15Outputs.reserve(stage15Width);
+
+      stage15Expressions.push_back(innerApply.rowIdColumn);
+      stage15Outputs.push_back(innerApply.rowIdColumn);
+      stage15Expressions.push_back(padPresentColumn);
+      stage15Outputs.push_back(padPresentColumn);
+      for (ColumnCP outerColumn : input->outputColumns()) {
+        stage15Expressions.push_back(outerColumn);
+        stage15Outputs.push_back(outerColumn);
+      }
+      stage15Expressions.push_back(combinedExpr);
+      stage15Outputs.push_back(combinedColumn);
+
+      NodeCP stage15 = builder().make<Project>(Project::Key{
+          stage1,
+          std::move(stage15Expressions),
+          std::move(stage15Outputs),
+      });
+
+      // Stage 2: bool_or(combined) and bool_or(combined IS NULL), both
+      // FILTER(_include); + arbitrary(L.cols).
+      ColumnCP hasTrueColumn = Column::createBoolean("_has_true");
+      ColumnCP hasNullColumn = Column::createBoolean("_has_null");
+
+      AggregateCallVector boolOrs;
+      boolOrs.reserve(2);
+      boolOrs.push_back(recovery.makeBoolOr(combinedColumn));
+      boolOrs.push_back(
+          recovery.makeBoolOr(exprFactory_.makeIsNull(combinedColumn)));
+      boolOrs = recovery.addFilterCondition(boolOrs, padPresentColumn);
+
+      AggregateCallVector stage2Aggregates;
+      stage2Aggregates.reserve(2 + input->outputColumns().size());
+      appendAll(stage2Aggregates, boolOrs);
+      for (ColumnCP outerColumn : input->outputColumns()) {
+        stage2Aggregates.push_back(makeArbitrary(outerColumn));
+      }
+
+      ColumnVector stage2Outputs;
+      stage2Outputs.reserve(3 + input->outputColumns().size());
+      stage2Outputs.push_back(innerApply.rowIdColumn);
+      stage2Outputs.push_back(hasTrueColumn);
+      stage2Outputs.push_back(hasNullColumn);
+      appendAll(stage2Outputs, input->outputColumns());
+
+      NodeCP stage2 = builder().make<Aggregate>(Aggregate::Key{
+          stage15,
+          ExprVector{innerApply.rowIdColumn},
+          std::move(stage2Aggregates),
+          std::move(stage2Outputs),
+      });
+
+      // Mark CASE: IF(COALESCE(has_true, false), true,
+      //               IF(has_null, NULL, false))
+      ExprCP hasTrueCoalesced =
+          exprFactory_.makeCoalesce(hasTrueColumn, falseLiteral);
+      markExpr = exprFactory_.makeIf(
+          hasTrueCoalesced,
+          trueLiteral,
+          exprFactory_.makeIf(hasNullColumn, nullBoolLiteral, falseLiteral));
+      finalInput = stage2;
+    }
+
+    // `nullAware = false`: collapse the NULL mark state to false.
+    if (!node->nullAware()) {
+      markExpr = exprFactory_.makeCoalesce(markExpr, falseLiteral);
+    }
+
+    // Final Project: input.cols ++ markColumn.
+    ExprVector finalExpressions;
+    finalExpressions.reserve(input->outputColumns().size() + 1);
+    appendAll(finalExpressions, input->outputColumns());
+    finalExpressions.push_back(markExpr);
+
+    return builder().make<Project>(Project::Key{
+        finalInput,
+        std::move(finalExpressions),
+        node->outputColumns(),
+    });
+  }
+
+  // Terminus for kLeftSemiProject. Builds a Join with
+  // joinType=kLeftSemiProject; the markColumn flows through Apply's
+  // outputColumns to the Join's outputColumns. For IN, the
+  // (inLhs, inBodyKey) pair seeds the Join's equi-keys; any equi
+  // conjuncts in `filter` that partition cleanly left/right become
+  // additional equi-keys, the rest stays in the Join's filter.
+  NodeCP
+  terminusSemi(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
+    ExprVector leftKeys;
+    ExprVector rightKeys;
+    if (apply->inLhs() != nullptr) {
+      // Equi-keys must each resolve on a single join side. When the
+      // body key references outer columns, demote the IN equality
+      // into the join filter; `nullAware=true` preserves null-aware
+      // semi-project semantics.
+      const bool bodyKeyHasOuter =
+          apply->inBodyKey()->columns().containsAny(input->outputColumns());
+      if (bodyKeyHasOuter) {
+        filter.push_back(
+            exprFactory_.makeEq(apply->inLhs(), apply->inBodyKey()));
+      } else {
+        leftKeys.push_back(apply->inLhs());
+        rightKeys.push_back(apply->inBodyKey());
+      }
+    }
+    JoinCondition::Split split = JoinCondition::splitEquiKeys(
+        filter,
+        PlanObjectSet::fromObjects(input->outputColumns()),
+        PlanObjectSet::fromObjects(body->outputColumns()));
+    // Null-aware semantics apply only to the IN equality. Keep
+    // correlation equi-conditions in the residual so they execute
+    // under standard `=`.
+    if (apply->nullAware()) {
+      for (size_t i = 0; i < split.leftKeys.size(); ++i) {
+        split.residual.push_back(
+            exprFactory_.makeEq(split.leftKeys[i], split.rightKeys[i]));
+      }
+    } else {
+      appendAll(leftKeys, split.leftKeys);
+      appendAll(rightKeys, split.rightKeys);
+    }
+    return builder().make<Join>(Join::Key{
+        input,
+        body,
+        velox::core::JoinType::kLeftSemiProject,
+        std::move(leftKeys),
+        std::move(rightKeys),
+        std::move(split.residual),
+        apply->nullAware(),
+        /*nullAsValue=*/false,
+        apply->outputColumns(),
+    });
+  }
+
+  // Creates a fresh BIGINT column intended to hold a per-row distinct
+  // value (AssignUniqueId output, Window row_number output, ...). NDV
+  // is set to max to convey "unique"; the planner treats this as
+  // each-row-distinct.
+  static ColumnCP makeIdColumn(std::string_view name = "__rownum") {
+    Value value(toType(velox::BIGINT()), std::numeric_limits<float>::max());
+    return Column::create(name, value);
+  }
+
+  // Creates a fresh `_include` BOOLEAN column for an Apply's
+  // includeMarker. See `Apply::Key::includeMarker`.
+  static ColumnCP makeIncludeColumn() {
+    return Column::createBoolean("_include");
+  }
+
+  // Wraps `input` in an `EnforceDistinct` that asserts at most one row
+  // per `perOuterId`, raising SQL's "scalar subquery returned multiple
+  // rows" error otherwise.
+  NodeCP enforceScalarSingleRow(NodeCP input, ColumnCP perOuterId) {
+    return builder().make<EnforceDistinct>(EnforceDistinct::Key{
+        input,
+        ExprVector{perOuterId},
+        toName("Scalar sub-query has returned multiple rows"),
+    });
+  }
+
+  // Constructs an `arbitrary(arg)` aggregate. Used for outer-column
+  // carry-through in the Aggregate peel: each outer column contributes
+  // a constant value within an `rowId` group (one row per outer), so
+  // `arbitrary` picks that value. Output type matches the argument's
+  // type; intermediate accumulator type same; output NDV (number of
+  // distinct values) inherits the argument's NDV — `arbitrary(x)`
+  // ranges over x's distinct values, not a single value.
+  const optimizer::Aggregate* makeArbitrary(ExprCP argument) {
+    const auto& arbitraryName = FunctionRegistry::instance()->arbitrary();
+    VELOX_USER_CHECK(
+        arbitraryName.has_value(),
+        "Decorrelate outer-column carry-through requires arbitrary "
+        "registered via FunctionRegistry::registerArbitrary");
+    const std::string& nameStr = *arbitraryName;
+
+    ExprVector arguments{argument};
+    Name aggregateName = toName(nameStr);
+    // Output value mirrors the argument: same type, same NDV.
+    Value value(argument->value().type, argument->value().cardinality);
+
+    const auto& metadata = velox::exec::getAggregateFunctionMetadata(nameStr);
+    FunctionSet functions = Call::unionArgFunctions(FunctionSet{}, arguments);
+    if (metadata.ignoreDuplicates) {
+      functions = functions | FunctionSet::kIgnoreDuplicatesAggregate;
+    }
+    if (metadata.orderSensitive) {
+      functions = functions | FunctionSet::kOrderSensitiveAggregate;
+    }
+    // For `arbitrary`, intermediate accumulator type equals the input
+    // type (it just holds one value).
+    TypeCP intermediateType = argument->value().type;
+
+    return builder().makeAggregate(
+        aggregateName,
+        value,
+        std::move(arguments),
+        functions,
+        /*isDistinct=*/false,
+        /*condition=*/nullptr,
+        intermediateType,
+        /*orderKeys=*/{},
+        /*orderTypes=*/{});
+  }
+
+  ExprFactory exprFactory_;
+};
+
+} // namespace
+
+NodeCP DecorrelatePass::run(NodeCP root, Builder& builder) {
+  Decorrelator rewriter(builder);
+  return rewriter.rewrite(root);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/DecorrelatePass.h
+++ b/axiom/optimizer/v2/DecorrelatePass.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Eliminates `Apply` nodes from the tree IR.
+class DecorrelatePass {
+ public:
+  /// Returns `root` with every `Apply` eliminated. Runs after `TranslatePass`
+  /// and before any phase that doesn't understand `Apply`. Per-Apply iterative
+  /// driver: peels body operators one at a time until terminus (correlation
+  /// columns empty), then converts Apply → Join (with optional ESR wrap). Built
+  /// up incrementally; out-of-scope sub-cases throw `VELOX_NYI` with a clear
+  /// message rather than silently producing wrong results.
+  static NodeCP run(NodeCP root, Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1,0 +1,1978 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/EmitPass.h"
+
+#include <folly/ScopeGuard.h>
+#include <limits>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/WriteStatsBuilder.h"
+#include "axiom/optimizer/v2/ExprEmitter.h"
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "velox/core/TableWriteTraits.h"
+#include "velox/exec/HashPartitionFunction.h"
+#include "velox/expression/ExprConstants.h"
+#include "velox/serializers/PrestoSerializer.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+velox::core::FieldAccessTypedExprPtr toFieldAccess(ColumnCP column) {
+  return std::make_shared<velox::core::FieldAccessTypedExpr>(
+      toTypePtr(column->value().type), column->outputName());
+}
+
+// Emits 'expr' as a `FieldAccessTypedExpr`, failing with a role-specific
+// error when it isn't a column reference. Velox `AggregationNode`,
+// `WindowNode`, and `OrderByNode` require key / FILTER / aggregate-arg
+// positions to be plain column references; non-column expressions must be
+// pre-projected.
+velox::core::FieldAccessTypedExprPtr toFieldAccess(
+    ExprCP expr,
+    std::string_view role) {
+  VELOX_USER_CHECK(
+      expr->is(PlanType::kColumnExpr), "{} must be a column reference", role);
+  return toFieldAccess(expr->as<Column>());
+}
+
+std::vector<velox::core::FieldAccessTypedExprPtr> toFieldAccessList(
+    const ColumnVector& columns) {
+  std::vector<velox::core::FieldAccessTypedExprPtr> out;
+  out.reserve(columns.size());
+  for (ColumnCP column : columns) {
+    out.push_back(toFieldAccess(column));
+  }
+  return out;
+}
+
+std::vector<velox::core::FieldAccessTypedExprPtr> toFieldAccessList(
+    const ExprVector& exprs,
+    std::string_view role) {
+  std::vector<velox::core::FieldAccessTypedExprPtr> out;
+  out.reserve(exprs.size());
+  for (ExprCP expr : exprs) {
+    out.push_back(toFieldAccess(expr, role));
+  }
+  return out;
+}
+
+// Decodes our `OrderType` into Velox's `(ascending, nullsFirst)` pair.
+velox::core::SortOrder toSortOrder(OrderType type) {
+  const bool ascending =
+      type == OrderType::kAscNullsFirst || type == OrderType::kAscNullsLast;
+  const bool nullsFirst =
+      type == OrderType::kAscNullsFirst || type == OrderType::kDescNullsFirst;
+  return velox::core::SortOrder{ascending, nullsFirst};
+}
+
+// Converts IR order keys / types into Velox sorting keys and orders. Shared by
+// Sort and TopN emission.
+std::pair<
+    std::vector<velox::core::FieldAccessTypedExprPtr>,
+    std::vector<velox::core::SortOrder>>
+toSortingKeys(
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes,
+    std::string_view role) {
+  std::vector<velox::core::SortOrder> sortingOrders;
+  sortingOrders.reserve(orderTypes.size());
+  for (OrderType type : orderTypes) {
+    sortingOrders.push_back(toSortOrder(type));
+  }
+  return {toFieldAccessList(orderKeys, role), std::move(sortingOrders)};
+}
+
+// Column indices in 'rowType' of the columns named by 'named' — each element
+// exposes '->name()', so this serves both field-access exprs and connector
+// Columns.
+template <typename Named>
+std::vector<velox::column_index_t> toChannels(
+    const velox::RowTypePtr& rowType,
+    const std::vector<Named>& named) {
+  std::vector<velox::column_index_t> channels;
+  channels.reserve(named.size());
+  for (const auto& element : named) {
+    channels.push_back(rowType->getChildIdx(element->name()));
+  }
+  return channels;
+}
+
+// Partition function spec for connector partitioning 'partitionType' over the
+// 'rowType' columns named by 'named'. 'isLocal' selects the within-worker
+// (LocalPartition) vs cross-worker (PartitionedOutput) variant.
+template <typename Named>
+velox::core::PartitionFunctionSpecPtr connectorPartitionSpec(
+    const connector::PartitionType& partitionType,
+    const velox::RowTypePtr& rowType,
+    const std::vector<Named>& named,
+    bool isLocal) {
+  return partitionType.makeSpec(
+      toChannels(rowType, named), /*constants=*/{}, isLocal);
+}
+
+// Builds a hash partition function spec over 'outputType' hashing the columns
+// named by 'keys'. Shared by remote (Exchange) and local (LocalPartition)
+// repartitioning.
+std::shared_ptr<velox::exec::HashPartitionFunctionSpec> makeHashPartitionSpec(
+    const velox::RowTypePtr& outputType,
+    const std::vector<velox::core::FieldAccessTypedExprPtr>& keys) {
+  return std::make_shared<velox::exec::HashPartitionFunctionSpec>(
+      outputType, toChannels(outputType, keys));
+}
+
+// True when 'values' pass 'input' through unchanged — each value is input
+// column i in order — so the table write can read 'input' directly. The write
+// node names its output columns itself, so a rename-only projection is
+// redundant: this lets the write reuse a source projection (e.g. the SELECT of
+// a CTAS, whose columns may be named `expr`/`expr_0`) instead of stacking one.
+bool writeInputIsIdentity(
+    const velox::RowTypePtr& inputType,
+    const std::vector<velox::core::TypedExprPtr>& values) {
+  if (values.size() != inputType->size()) {
+    return false;
+  }
+  for (size_t i = 0; i < values.size(); ++i) {
+    if (!values[i]->isFieldAccessKind()) {
+      return false;
+    }
+    const auto* field =
+        values[i]->asUnchecked<velox::core::FieldAccessTypedExpr>();
+    if (!field->isInputColumn() || field->name() != inputType->nameOf(i)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Walks the single-input chain down from 'node' and returns true if any node on
+// it requires single-threaded execution (a Values source, a gather). Returns
+// false at the first multi-input node (a join), which begins a separate
+// pipeline.
+bool isSingleThreadedPipeline(const velox::core::PlanNodePtr& node) {
+  for (auto current = node;;) {
+    if (current->requiresSingleThread()) {
+      return true;
+    }
+    if (current->sources().size() != 1) {
+      return false;
+    }
+    current = current->sources()[0];
+  }
+}
+
+class Emitter {
+ public:
+  Emitter(
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator,
+      ScanHandleCache& scanHandles,
+      const MultiFragmentPlan::Options& options)
+      : session_{session},
+        evaluator_{evaluator},
+        exprEmitter_{evaluator.pool()},
+        scanHandles_{scanHandles},
+        options_{options} {}
+
+  velox::core::PlanNodePtr emit(NodeCP node) {
+    switch (node->nodeType()) {
+      case NodeType::kScan:
+        return emitScan(*node->as<Scan>());
+      case NodeType::kFilter:
+        return emitFilter(*node->as<Filter>());
+      case NodeType::kProject:
+        return emitProject(*node->as<Project>());
+      case NodeType::kAggregate:
+        return emitAggregation(*node->as<Aggregate>());
+      case NodeType::kGroupId:
+        return emitGroupId(*node->as<GroupId>());
+      case NodeType::kMarkDistinct:
+        return emitMarkDistinct(*node->as<MarkDistinct>());
+      case NodeType::kJoin:
+        return emitJoin(*node->as<Join>());
+      case NodeType::kSort:
+        return emitSort(*node->as<Sort>());
+      case NodeType::kTopN:
+        return emitTopN(*node->as<TopN>());
+      case NodeType::kLimit:
+        return emitLimit(*node->as<Limit>());
+      case NodeType::kValues:
+        return emitValues(*node->as<Values>());
+      case NodeType::kWindow:
+        return emitWindow(*node->as<Window>());
+      case NodeType::kTopNRowNumber:
+        return emitTopNRowNumber(*node->as<TopNRowNumber>());
+      case NodeType::kUnnest:
+        return emitUnnest(*node->as<Unnest>());
+      case NodeType::kUnionAll:
+        return emitUnionAll(*node->as<UnionAll>());
+      case NodeType::kEnforceSingleRow:
+        return emitEnforceSingleRow(*node->as<EnforceSingleRow>());
+      case NodeType::kAssignUniqueId:
+        return emitAssignUniqueId(*node->as<AssignUniqueId>());
+      case NodeType::kEnforceDistinct:
+        return emitEnforceDistinct(*node->as<EnforceDistinct>());
+      case NodeType::kApply:
+        VELOX_NYI("Emit not implemented for {}", node->toString());
+      case NodeType::kTableWrite:
+        return emitTableWrite(*node->as<TableWrite>());
+      case NodeType::kExchange:
+        return emitExchange(*node->as<Exchange>());
+    }
+    VELOX_UNREACHABLE();
+  }
+
+  std::string nextId() {
+    return std::to_string(nextNodeId_++);
+  }
+
+  // Local exchange inserted below a final/single aggregation at numDrivers > 1
+  // so every row of a group is processed by one driver: a repartition on the
+  // grouping keys, or a gather to one driver when there are none.
+  velox::core::PlanNodePtr addLocalPartition(
+      velox::core::PlanNodePtr input,
+      const std::vector<velox::core::FieldAccessTypedExprPtr>& keys) {
+    if (keys.empty()) {
+      return velox::core::LocalPartitionNode::gather(
+          nextId(), {std::move(input)});
+    }
+
+    auto spec = makeHashPartitionSpec(input->outputType(), keys);
+    return std::make_shared<velox::core::LocalPartitionNode>(
+        nextId(),
+        velox::core::LocalPartitionNode::Type::kRepartition,
+        /*scaleWriter=*/false,
+        std::move(spec),
+        std::vector<velox::core::PlanNodePtr>{std::move(input)});
+  }
+
+  // Emits `node` as the plan root with output `outputColumns`
+  // aliased to `outputNames`.
+  velox::core::PlanNodePtr emitRoot(
+      NodeCP node,
+      const ColumnVector& outputColumns,
+      const std::vector<std::string>& outputNames);
+
+ private:
+  // Emits a Project root directly with the requested output layout,
+  // picking matching expressions from `project.exprs()`.
+  velox::core::PlanNodePtr emitRootProject(
+      const Project& project,
+      const ColumnVector& outputColumns,
+      const std::vector<std::string>& outputNames);
+
+  // Applies a Project root's output layout over an already-emitted `input`
+  // (e.g. a remote gather), instead of re-emitting `project.input()`.
+  velox::core::PlanNodePtr emitRootProjectOver(
+      velox::core::PlanNodePtr input,
+      const Project& project,
+      const ColumnVector& outputColumns,
+      const std::vector<std::string>& outputNames);
+
+  // Wraps `input` in a Project that selects `outputColumns` aliased
+  // to `outputNames`.
+  velox::core::PlanNodePtr wrapWithRenameProject(
+      velox::core::PlanNodePtr input,
+      const ColumnVector& outputColumns,
+      const std::vector<std::string>& outputNames);
+
+  velox::core::PlanNodePtr emitScan(const Scan& scan);
+  velox::core::PlanNodePtr emitFilter(const Filter& filter);
+  velox::core::PlanNodePtr emitProject(const Project& project);
+  velox::core::PlanNodePtr emitAggregation(const Aggregate& aggregate);
+  velox::core::PlanNodePtr emitSingleAggregation(const Aggregate& aggregate);
+  velox::core::PlanNodePtr emitPartialAggregation(const Aggregate& aggregate);
+  velox::core::PlanNodePtr emitFinalAggregation(const Aggregate& aggregate);
+  // Builds an AggregationNode, carrying the grouping-set default-row info
+  // (`globalGroupingSets`/`groupId`) from `aggregate` when present.
+  velox::core::PlanNodePtr makeAggregationNode(
+      velox::core::AggregationNode::Step step,
+      const Aggregate& aggregate,
+      std::vector<velox::core::FieldAccessTypedExprPtr> groupingKeys,
+      std::vector<velox::core::FieldAccessTypedExprPtr> preGroupedKeys,
+      std::vector<std::string> names,
+      std::vector<velox::core::AggregationNode::Aggregate> aggregates,
+      velox::core::PlanNodePtr input);
+  velox::core::PlanNodePtr emitGroupId(const GroupId& groupId);
+  velox::core::PlanNodePtr emitMarkDistinct(const MarkDistinct& markDistinct);
+  velox::core::PlanNodePtr emitJoin(const Join& join);
+  velox::core::PlanNodePtr emitSort(const Sort& sort);
+  velox::core::PlanNodePtr emitTopN(const TopN& topN);
+  velox::core::PlanNodePtr emitLimit(const Limit& limit);
+  velox::core::PlanNodePtr emitValues(const Values& values);
+  velox::core::PlanNodePtr emitWindow(const Window& window);
+  velox::core::PlanNodePtr emitTopNRowNumber(const TopNRowNumber& node);
+  velox::core::PlanNodePtr emitUnnest(const Unnest& unnest);
+  velox::core::PlanNodePtr emitUnionAll(const UnionAll& unionNode);
+  velox::core::PlanNodePtr emitEnforceSingleRow(const EnforceSingleRow& node);
+  velox::core::PlanNodePtr emitAssignUniqueId(const AssignUniqueId& node);
+  velox::core::PlanNodePtr emitEnforceDistinct(const EnforceDistinct& node);
+
+  // Lowers `Join(kAnti | kLeftSemiFilter)` with no equi-keys to
+  // `NestedLoopJoin(kLeftSemiProject) + Filter + Project`. See
+  // https://github.com/facebookincubator/velox/issues/17650.
+  velox::core::PlanNodePtr emitSemiAntiViaLeftSemiProject(
+      const Join& join,
+      velox::core::PlanNodePtr left,
+      velox::core::PlanNodePtr right,
+      velox::core::TypedExprPtr filter);
+
+  // Wraps 'input' in a `ProjectNode` that keeps only 'keepColumns'.
+  velox::core::PlanNodePtr projectToColumns(
+      const ColumnVector& keepColumns,
+      velox::core::PlanNodePtr input);
+
+  velox::RowTypePtr makeRowType(const ColumnVector& columns) const;
+
+  // Emits 'exchange's input as a producer fragment ending in a
+  // `PartitionedOutput`, and returns the consumer-side `ExchangeNode` for the
+  // current fragment, wiring the `InputStage` between them.
+  velox::core::PlanNodePtr emitExchange(const Exchange& exchange);
+  velox::core::PlanNodePtr emitTableWrite(const TableWrite& tableWrite);
+
+  // Builds the producer-side `PartitionedOutput` capping 'sourcePlan' for
+  // 'partitioning'. A connector-bucketed partitioning that scales to a single
+  // destination degrades to a single (gather) output.
+  velox::core::PlanNodePtr makeExchangeProducer(
+      const Partitioning& partitioning,
+      const velox::RowTypePtr& outputType,
+      const velox::core::PlanNodePtr& sourcePlan);
+
+  // Builds the consumer-side exchange node for 'partitioning' — a
+  // `MergeExchange` for an order-preserving gather, else a plain `Exchange`.
+  velox::core::PlanNodePtr makeExchangeConsumer(
+      const Partitioning& partitioning,
+      const velox::RowTypePtr& outputType);
+
+  // Emits 'node' as the root of child fragment 'fragment', isolating its
+  // grouped leaves and finalizing them onto 'fragment', then restores the
+  // enclosing fragment and its leaves. Returns the emitted plan. For a child
+  // fragment whose grouped leaves must be finalized after further building (a
+  // table write), do the save/restore inline instead.
+  velox::core::PlanNodePtr emitChildFragment(
+      NodeCP node,
+      ExecutableFragment& fragment);
+
+  // A fresh producer/consumer fragment with a unique task prefix.
+  ExecutableFragment newFragment() {
+    return ExecutableFragment{
+        .taskPrefix = fmt::format("fragment{}", fragmentCounter_++)};
+  }
+
+  const OptimizerSession& session_;
+  velox::core::ExpressionEvaluator& evaluator_;
+  ExprEmitter exprEmitter_;
+  ScanHandleCache& scanHandles_;
+  const MultiFragmentPlan::Options& options_;
+  int32_t nextNodeId_{0};
+
+  // The exchange serialization format for remote
+  // `PartitionedOutput`/`Exchange`.
+  const std::string exchangeSerdeKind_{
+      velox::serializer::presto::PrestoVectorSerde::name()};
+
+  // Producer fragments collected as `ir.Exchange`es are lowered; the root
+  // fragment is appended last by `emitFragments`.
+  std::vector<ExecutableFragment> stages_;
+  // The fragment currently being built; `emitExchange` records its input
+  // stages here. Set during the fragment-aware walk.
+  ExecutableFragment* currentFragment_{nullptr};
+  int32_t fragmentCounter_{0};
+
+  // A grouped leaf of the fragment currently being built: a source that runs
+  // per bucket-group under grouped execution. `partitionType` is the
+  // connector's (unscaled) partitioning for a bucketed scan, or null for a
+  // hash-partitioned consumer exchange that must route by group. Saved and
+  // restored around each child-fragment build so leaves don't leak across
+  // fragments.
+  struct PendingGroupedLeaf {
+    velox::core::PlanNodeId nodeId;
+    const connector::PartitionType* partitionType{nullptr};
+  };
+  std::vector<PendingGroupedLeaf> groupedLeaves_;
+
+  // Turns the accumulated `groupedLeaves_` into `fragment.groupedNodes` and,
+  // when any bucketed scan is present, makes the fragment `kFixed` at the
+  // folded bucket count. A fragment with no bucketed scan is left non-grouped.
+  void finalizeGroupedLeaves(ExecutableFragment& fragment);
+
+  // Set by emitTableWrite; moved out via takeFinishWrite so the runner can
+  // commit or abort the write. Empty (bool false) for read-only queries.
+  FinishWrite finishWrite_;
+
+ public:
+  // Lowers 'root' (plus the output rename to 'outputNames') into fragments,
+  // returning them with the root fragment last.
+  std::vector<ExecutableFragment> emitFragments(
+      NodeCP root,
+      const ColumnVector& outputColumns,
+      const std::vector<std::string>& outputNames);
+
+  // Transfers the write-finalization handle produced by a TableWrite emit, if
+  // any, to the caller. Empty for read-only queries.
+  FinishWrite takeFinishWrite() {
+    return std::move(finishWrite_);
+  }
+};
+
+velox::core::PlanNodePtr Emitter::projectToColumns(
+    const ColumnVector& keepColumns,
+    velox::core::PlanNodePtr input) {
+  std::vector<std::string> names;
+  std::vector<velox::core::TypedExprPtr> exprs;
+  names.reserve(keepColumns.size());
+  exprs.reserve(keepColumns.size());
+  for (ColumnCP column : keepColumns) {
+    names.emplace_back(column->outputName());
+    exprs.push_back(toFieldAccess(column));
+  }
+  return std::make_shared<velox::core::ProjectNode>(
+      nextId(), std::move(names), std::move(exprs), std::move(input));
+}
+
+velox::RowTypePtr Emitter::makeRowType(const ColumnVector& columns) const {
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(columns.size());
+  types.reserve(columns.size());
+  for (ColumnCP column : columns) {
+    names.push_back(column->outputName());
+    types.push_back(toTypePtr(column->value().type));
+  }
+  return velox::ROW(std::move(names), std::move(types));
+}
+
+// Collects names of every input-column `FieldAccessTypedExpr` reachable
+// from `expr`, excluding references bound by an enclosing lambda. Used
+// to compute the columns a rejected filter reads, so the scan's
+// projected schema can include them.
+//
+// `LambdaTypedExpr` stores its body outside `inputs()`; descend into it
+// explicitly so outer-column captures inside higher-order filters
+// (`array_filter`, `any_match`, ...) are picked up. The lambda's
+// signature parameters are removed before recursing so a field access
+// to a bound name (e.g. `x` in `array_filter(arr, x -> x > 0)`) isn't
+// mistaken for a scan-column reference.
+void collectInputColumnNamesImpl(
+    const velox::core::TypedExprPtr& expr,
+    folly::F14FastSet<std::string>& names,
+    const folly::F14FastSet<std::string>& boundNames) {
+  if (expr->isFieldAccessKind()) {
+    const auto* field = expr->asUnchecked<velox::core::FieldAccessTypedExpr>();
+    if (field->isInputColumn() && !boundNames.contains(field->name())) {
+      names.insert(field->name());
+    }
+  } else if (expr->isLambdaKind()) {
+    const auto* lambda = expr->asUnchecked<velox::core::LambdaTypedExpr>();
+    folly::F14FastSet<std::string> childBound = boundNames;
+    for (const auto& paramName : lambda->signature()->names()) {
+      childBound.insert(paramName);
+    }
+    collectInputColumnNamesImpl(lambda->body(), names, childBound);
+  }
+  for (const auto& input : expr->inputs()) {
+    collectInputColumnNamesImpl(input, names, boundNames);
+  }
+}
+
+void collectInputColumnNames(
+    const velox::core::TypedExprPtr& expr,
+    folly::F14FastSet<std::string>& names) {
+  collectInputColumnNamesImpl(expr, names, /*boundNames=*/{});
+}
+
+// The connector partitioning of a scan's table, or null when the table is not
+// bucketed. A property of the table layout, independent of which columns the
+// scan projects: a bucketed table runs grouped even when its bucket column is
+// pruned from the output.
+const connector::PartitionType* tablePartitionType(const Scan& scan) {
+  const auto* schemaTable = scan.baseTable()->schemaTable;
+  if (schemaTable == nullptr || schemaTable->columnGroups.empty()) {
+    return nullptr;
+  }
+  const connector::TableLayout* layout = schemaTable->columnGroups[0]->layout;
+  return layout != nullptr ? layout->partitionType().get() : nullptr;
+}
+
+velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
+  // The read schema is the consumer output columns followed by the filter-only
+  // columns, with columnHandles aligned to that order. Consumer columns keep
+  // their `outputName` (alias) in the scan's row type; the rename happens
+  // inside the scan via `assignments[outputName] = handle`. Filter-only
+  // columns keep their schema name.
+  const ScanHandle* cached = scanHandles_.find(scan);
+  ScanHandle built;
+  if (cached == nullptr) {
+    built = ScanHandle::build(scan, session_, evaluator_);
+  }
+  const ScanHandle& handle = cached != nullptr ? *cached : built;
+  const ColumnVector& consumerColumns = scan.outputColumns();
+  const ColumnVector& filterOnlyColumns = handle.filterOnlyColumns;
+  const auto& columnHandles = handle.columnHandles;
+  const auto& tableHandle = handle.tableHandle;
+  std::vector<velox::core::TypedExprPtr> rejectedFilters =
+      handle.rejectedFilters;
+
+  // Scan row type keeps consumer columns (named by outputName) plus
+  // any filter-only column actually referenced by a rejected filter.
+  // Columns referenced only by accepted filters were read by the
+  // connector but stay off the projected row.
+  folly::F14FastSet<std::string> rejectedFilterRefs;
+  for (const auto& rejected : rejectedFilters) {
+    collectInputColumnNames(rejected, rejectedFilterRefs);
+  }
+
+  std::vector<std::string> scanOutputNames;
+  std::vector<velox::TypePtr> scanOutputTypes;
+  velox::connector::ColumnHandleMap assignments;
+  scanOutputNames.reserve(consumerColumns.size() + filterOnlyColumns.size());
+  scanOutputTypes.reserve(consumerColumns.size() + filterOnlyColumns.size());
+  for (size_t i = 0; i < consumerColumns.size(); ++i) {
+    ColumnCP column = consumerColumns[i];
+    std::string outputName{column->outputName()};
+    scanOutputTypes.push_back(toTypePtr(column->value().type));
+    assignments[outputName] = columnHandles[i];
+    scanOutputNames.push_back(std::move(outputName));
+  }
+  for (size_t i = 0; i < filterOnlyColumns.size(); ++i) {
+    ColumnCP column = filterOnlyColumns[i];
+    std::string schemaName{column->name()};
+    if (!rejectedFilterRefs.contains(schemaName)) {
+      continue;
+    }
+    scanOutputTypes.push_back(toTypePtr(column->value().type));
+    assignments[schemaName] = columnHandles[consumerColumns.size() + i];
+    scanOutputNames.push_back(std::move(schemaName));
+  }
+
+  auto scanNode = std::make_shared<velox::core::TableScanNode>(
+      nextId(),
+      velox::ROW(std::move(scanOutputNames), std::move(scanOutputTypes)),
+      tableHandle,
+      std::move(assignments));
+
+  // A scan of a bucketed table is a grouped leaf: it runs per bucket-group
+  // under grouped execution, tagging the fragment as bucketed.
+  if (const auto* partitionType = tablePartitionType(scan)) {
+    groupedLeaves_.push_back({scanNode->id(), partitionType});
+  }
+
+  velox::core::PlanNodePtr result = std::move(scanNode);
+
+  if (!rejectedFilters.empty()) {
+    velox::core::TypedExprPtr predicate = rejectedFilters.size() == 1
+        ? rejectedFilters.front()
+        : std::make_shared<velox::core::CallTypedExpr>(
+              velox::BOOLEAN(),
+              std::move(rejectedFilters),
+              velox::expression::kAnd);
+
+    std::unordered_map<std::string, velox::core::TypedExprPtr> rejectedRename;
+    for (ColumnCP column : consumerColumns) {
+      if (column->name() != column->outputName()) {
+        rejectedRename.emplace(
+            std::string{column->name()}, toFieldAccess(column));
+      }
+    }
+
+    if (!rejectedRename.empty()) {
+      predicate = predicate->rewriteInputNames(rejectedRename);
+    }
+    result = std::make_shared<velox::core::FilterNode>(
+        nextId(), std::move(predicate), std::move(result));
+  }
+
+  return result;
+}
+
+velox::core::PlanNodePtr Emitter::emitFilter(const Filter& filter) {
+  velox::core::PlanNodePtr input = emit(filter.input());
+  return std::make_shared<velox::core::FilterNode>(
+      nextId(), exprEmitter_.makeAnd(filter.predicates()), std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitProject(const Project& project) {
+  velox::core::PlanNodePtr input = emit(project.input());
+  const auto& columns = project.outputColumns();
+  std::vector<std::string> names;
+  names.reserve(columns.size());
+  for (ColumnCP column : columns) {
+    names.push_back(column->outputName());
+  }
+  auto typedExprs = exprEmitter_.toTypedExprs(project.exprs());
+  return std::make_shared<velox::core::ProjectNode>(
+      nextId(), std::move(names), std::move(typedExprs), std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitRootProjectOver(
+    velox::core::PlanNodePtr input,
+    const Project& project,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames) {
+  const auto& projectColumns = project.outputColumns();
+  const auto& projectExprs = project.exprs();
+  std::vector<velox::core::TypedExprPtr> typedExprs;
+  typedExprs.reserve(outputColumns.size());
+  for (ColumnCP column : outputColumns) {
+    const auto it =
+        std::find(projectColumns.begin(), projectColumns.end(), column);
+    VELOX_CHECK(
+        it != projectColumns.end(),
+        "Output column not produced by root Project: {}",
+        column->outputName());
+    const size_t index = std::distance(projectColumns.begin(), it);
+    typedExprs.push_back(exprEmitter_.toTypedExpr(projectExprs[index]));
+  }
+  return std::make_shared<velox::core::ProjectNode>(
+      nextId(),
+      std::vector<std::string>{outputNames},
+      std::move(typedExprs),
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitRootProject(
+    const Project& project,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames) {
+  return emitRootProjectOver(
+      emit(project.input()), project, outputColumns, outputNames);
+}
+
+velox::core::PlanNodePtr Emitter::wrapWithRenameProject(
+    velox::core::PlanNodePtr input,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames) {
+  std::vector<velox::core::TypedExprPtr> projections;
+  projections.reserve(outputColumns.size());
+  for (ColumnCP column : outputColumns) {
+    projections.push_back(toFieldAccess(column));
+  }
+  return std::make_shared<velox::core::ProjectNode>(
+      nextId(),
+      std::vector<std::string>{outputNames},
+      std::move(projections),
+      std::move(input));
+}
+
+namespace {
+
+bool isIdentityLayout(
+    const Node& root,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames) {
+  const auto& rootColumns = root.outputColumns();
+  if (outputColumns.size() != rootColumns.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < outputColumns.size(); ++i) {
+    if (outputColumns[i] != rootColumns[i] ||
+        outputNames[i] != outputColumns[i]->outputName()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+} // namespace
+
+velox::core::PlanNodePtr Emitter::emitRoot(
+    NodeCP node,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames) {
+  if (isIdentityLayout(*node, outputColumns, outputNames)) {
+    return emit(node);
+  }
+  if (node->is(NodeType::kProject)) {
+    return emitRootProject(*node->as<Project>(), outputColumns, outputNames);
+  }
+  return wrapWithRenameProject(emit(node), outputColumns, outputNames);
+}
+
+namespace {
+
+// The types of an aggregate's raw (pre-accumulation) argument columns, which
+// Velox needs at every aggregation step.
+std::vector<velox::TypePtr> rawInputTypesOf(
+    const optimizer::Aggregate& aggregateExpr) {
+  std::vector<velox::TypePtr> types;
+  types.reserve(aggregateExpr.args().size());
+  for (ExprCP arg : aggregateExpr.args()) {
+    types.push_back(toTypePtr(arg->value().type));
+  }
+  return types;
+}
+
+// Lowers `aggregateExpr` to a Velox `Aggregate` whose call return
+// type is `resultType` (intermediate for kPartial; final otherwise).
+velox::core::AggregationNode::Aggregate toVeloxAggregate(
+    const optimizer::Aggregate& aggregateExpr,
+    const velox::TypePtr& resultType,
+    ExprEmitter& exprEmitter) {
+  std::vector<velox::core::TypedExprPtr> inputs;
+  inputs.reserve(aggregateExpr.args().size());
+  for (ExprCP arg : aggregateExpr.args()) {
+    inputs.push_back(exprEmitter.toTypedExpr(arg));
+  }
+
+  velox::core::AggregationNode::Aggregate out{};
+  out.call = std::make_shared<velox::core::CallTypedExpr>(
+      resultType, std::move(inputs), std::string{aggregateExpr.name()});
+  out.rawInputTypes = rawInputTypesOf(aggregateExpr);
+  out.distinct = aggregateExpr.isDistinct();
+  if (aggregateExpr.condition() != nullptr) {
+    out.mask = toFieldAccess(aggregateExpr.condition(), "Aggregate FILTER");
+  }
+  std::tie(out.sortingKeys, out.sortingOrders) = toSortingKeys(
+      aggregateExpr.orderKeys(),
+      aggregateExpr.orderTypes(),
+      "Aggregate ORDER BY key");
+  return out;
+}
+
+// Builds the kFinal-step `Aggregate` that consumes the intermediate
+// accumulator emitted by the Partial under `intermediateName`. mask, ORDER BY,
+// and distinct dedup were applied at the Partial; don't repeat them. Lambda
+// arguments (e.g. `reduce_agg`'s combiners) must be forwarded because Velox
+// binds them at every step. `rawInputTypes` are the Partial's raw inputs,
+// recomputed here from the expression's arguments (the Partial that produced
+// the intermediate may live in another fragment, so its Velox `Aggregate` is
+// not in hand).
+velox::core::AggregationNode::Aggregate toVeloxFinalAggregate(
+    const optimizer::Aggregate& aggregateExpr,
+    std::string_view intermediateName,
+    ExprEmitter& exprEmitter) {
+  std::vector<velox::core::TypedExprPtr> inputs;
+  inputs.push_back(
+      std::make_shared<velox::core::FieldAccessTypedExpr>(
+          toTypePtr(aggregateExpr.intermediateType()),
+          std::string{intermediateName}));
+  for (ExprCP arg : aggregateExpr.args()) {
+    if (arg->is(PlanType::kLambdaExpr)) {
+      inputs.push_back(exprEmitter.toTypedExpr(arg));
+    }
+  }
+  velox::core::AggregationNode::Aggregate out{};
+  out.call = std::make_shared<velox::core::CallTypedExpr>(
+      toTypePtr(aggregateExpr.value().type),
+      std::move(inputs),
+      std::string{aggregateExpr.name()});
+  out.rawInputTypes = rawInputTypesOf(aggregateExpr);
+  return out;
+}
+
+// Subset of `groupingKeys` that `local` guarantees are pre-grouped (equal-key
+// rows contiguous), so an aggregation over them can stream rather than build a
+// full hash table. The larger of: the leading `Sorted` run that are grouping
+// keys, and a `Grouped(S)` whose columns are all grouping keys (the whole `S`,
+// since rows are contiguous on the set jointly, not on a bare subset). Empty
+// when nothing is pre-grouped.
+ExprVector computePreGroupedKeys(
+    const LocalPropertyVector& local,
+    const ExprVector& groupingKeys) {
+  if (groupingKeys.empty()) {
+    return {};
+  }
+
+  const auto isGroupingKey = [&](ColumnCP column) {
+    for (ExprCP key : groupingKeys) {
+      if (column->sameOrEqual(*key)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  ExprVector best;
+  for (const LocalProperty& property : local) {
+    ExprVector candidate;
+    if (property.kind == LocalPropertyKind::kSorted) {
+      // Sorted on c1..cn implies grouped on any leading prefix; take the
+      // leading run of sort keys that are grouping keys.
+      for (ColumnCP column : property.columns) {
+        if (!isGroupingKey(column)) {
+          break;
+        }
+        candidate.push_back(column);
+      }
+    } else if (std::ranges::all_of(property.columns, isGroupingKey)) {
+      // Grouped on the whole set jointly; usable only if every member is a
+      // grouping key.
+      for (ColumnCP column : property.columns) {
+        candidate.push_back(column);
+      }
+    }
+    if (candidate.size() > best.size()) {
+      best = std::move(candidate);
+    }
+  }
+
+  return best;
+}
+
+// Builds the (output name, Velox Aggregate) lists for an AggregationNode. The
+// per-step call construction differs (single/partial output the result vs the
+// intermediate type; final reads its input accumulator column), so the caller
+// supplies 'makeAggregate' for aggregate i; the output name is always the i-th
+// non-key output column.
+std::pair<
+    std::vector<std::string>,
+    std::vector<velox::core::AggregationNode::Aggregate>>
+buildAggregates(
+    const Aggregate& aggregate,
+    const std::function<velox::core::AggregationNode::Aggregate(size_t)>&
+        makeAggregate) {
+  const auto& outputColumns = aggregate.outputColumns();
+  const size_t numKeys = aggregate.groupingKeys().size();
+  std::vector<std::string> names;
+  std::vector<velox::core::AggregationNode::Aggregate> aggregates;
+  names.reserve(aggregate.aggregates().size());
+  aggregates.reserve(aggregate.aggregates().size());
+  for (size_t i = 0; i < aggregate.aggregates().size(); ++i) {
+    aggregates.push_back(makeAggregate(i));
+    names.push_back(outputColumns[numKeys + i]->outputName());
+  }
+  return {std::move(names), std::move(aggregates)};
+}
+
+} // namespace
+
+velox::core::PlanNodePtr Emitter::emitAggregation(const Aggregate& aggregate) {
+  switch (aggregate.step()) {
+    case AggregateStep::kPartial:
+      return emitPartialAggregation(aggregate);
+    case AggregateStep::kFinal:
+      return emitFinalAggregation(aggregate);
+    case AggregateStep::kSingle:
+      return emitSingleAggregation(aggregate);
+    case AggregateStep::kIntermediate:
+      break;
+  }
+  VELOX_UNREACHABLE();
+}
+
+velox::core::PlanNodePtr Emitter::makeAggregationNode(
+    velox::core::AggregationNode::Step step,
+    const Aggregate& aggregate,
+    std::vector<velox::core::FieldAccessTypedExprPtr> groupingKeys,
+    std::vector<velox::core::FieldAccessTypedExprPtr> preGroupedKeys,
+    std::vector<std::string> names,
+    std::vector<velox::core::AggregationNode::Aggregate> aggregates,
+    velox::core::PlanNodePtr input) {
+  std::vector<velox::vector_size_t> globalGroupingSets(
+      aggregate.globalGroupingSets().begin(),
+      aggregate.globalGroupingSets().end());
+  std::optional<velox::core::FieldAccessTypedExprPtr> groupId;
+  if (aggregate.groupId() != nullptr) {
+    groupId = toFieldAccess(aggregate.groupId());
+  }
+  return std::make_shared<velox::core::AggregationNode>(
+      nextId(),
+      step,
+      std::move(groupingKeys),
+      std::move(preGroupedKeys),
+      std::move(names),
+      std::move(aggregates),
+      std::move(globalGroupingSets),
+      std::move(groupId),
+      /*ignoreNullKeys=*/false,
+      /*noGroupsSpanBatches=*/false,
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitSingleAggregation(
+    const Aggregate& aggregate) {
+  velox::core::PlanNodePtr input = emit(aggregate.input());
+
+  auto groupingKeys =
+      toFieldAccessList(aggregate.groupingKeys(), "Grouping key");
+
+  // An aggregation over input already grouped on (a prefix of) the keys streams
+  // instead of building a full hash table.
+  auto preGroupedKeys = toFieldAccessList(
+      computePreGroupedKeys(
+          aggregate.input()->physicalProperties().local,
+          aggregate.groupingKeys()),
+      "Pre-grouped key");
+
+  // At numDrivers > 1 a group's rows must all reach one driver. Skip the local
+  // exchange when the input is pre-grouped on the keys: a local grouping
+  // guarantees driver-confinement by contract (see `LocalProperty` in
+  // PhysicalProperties.h), so the aggregation streams correctly per driver.
+  if (options_.numDrivers > 1 && preGroupedKeys.empty()) {
+    input = addLocalPartition(std::move(input), groupingKeys);
+  }
+
+  auto [names, aggregates] = buildAggregates(aggregate, [&](size_t i) {
+    const auto* aggregateExpr = aggregate.aggregates()[i];
+    return toVeloxAggregate(
+        *aggregateExpr, toTypePtr(aggregateExpr->value().type), exprEmitter_);
+  });
+
+  return makeAggregationNode(
+      velox::core::AggregationNode::Step::kSingle,
+      aggregate,
+      std::move(groupingKeys),
+      std::move(preGroupedKeys),
+      std::move(names),
+      std::move(aggregates),
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitPartialAggregation(
+    const Aggregate& aggregate) {
+  velox::core::PlanNodePtr input = emit(aggregate.input());
+  auto groupingKeys =
+      toFieldAccessList(aggregate.groupingKeys(), "Grouping key");
+
+  // The Partial emits the intermediate accumulator, not the final result.
+  auto [names, aggregates] = buildAggregates(aggregate, [&](size_t i) {
+    const auto* aggregateExpr = aggregate.aggregates()[i];
+    return toVeloxAggregate(
+        *aggregateExpr,
+        toTypePtr(aggregateExpr->intermediateType()),
+        exprEmitter_);
+  });
+
+  return makeAggregationNode(
+      velox::core::AggregationNode::Step::kPartial,
+      aggregate,
+      std::move(groupingKeys),
+      /*preGroupedKeys=*/{},
+      std::move(names),
+      std::move(aggregates),
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitFinalAggregation(
+    const Aggregate& aggregate) {
+  velox::core::PlanNodePtr input = emit(aggregate.input());
+  auto groupingKeys =
+      toFieldAccessList(aggregate.groupingKeys(), "Grouping key");
+
+  // At numDrivers > 1 the Final's input rows are spread across drivers (read
+  // round-robin from a remote exchange, or straight from the Partial in a
+  // local-only split), so a local exchange co-partitions each group onto one
+  // driver before the merge.
+  if (options_.numDrivers > 1) {
+    input = addLocalPartition(std::move(input), groupingKeys);
+  }
+
+  // The Final's input is the (exchanged) Partial output: grouping keys followed
+  // by one intermediate accumulator per aggregate, so the i-th accumulator is
+  // at input column `numKeys + i`.
+  const auto& inputColumns = aggregate.input()->outputColumns();
+  const size_t numKeys = aggregate.groupingKeys().size();
+  auto [names, aggregates] = buildAggregates(aggregate, [&](size_t i) {
+    return toVeloxFinalAggregate(
+        *aggregate.aggregates()[i],
+        inputColumns[numKeys + i]->outputName(),
+        exprEmitter_);
+  });
+
+  return makeAggregationNode(
+      velox::core::AggregationNode::Step::kFinal,
+      aggregate,
+      std::move(groupingKeys),
+      /*preGroupedKeys=*/{},
+      std::move(names),
+      std::move(aggregates),
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitGroupId(const GroupId& groupId) {
+  velox::core::PlanNodePtr input = emit(groupId.input());
+
+  std::vector<velox::core::GroupIdNode::GroupingKeyInfo> groupingKeyInfos;
+  groupingKeyInfos.reserve(groupId.groupingKeyColumns().size());
+  for (size_t i = 0; i < groupId.groupingKeyColumns().size(); ++i) {
+    groupingKeyInfos.push_back({
+        .output = std::string{groupId.groupingKeyColumns()[i]->outputName()},
+        .input = toFieldAccess(groupId.groupingKeys()[i], "GroupId key"),
+    });
+  }
+
+  std::vector<std::vector<std::string>> groupingSets;
+  groupingSets.reserve(groupId.groupingSets().size());
+  for (const auto& set : groupId.groupingSets()) {
+    std::vector<std::string> names;
+    names.reserve(set.size());
+    for (auto keyIndex : set) {
+      VELOX_CHECK_LT(
+          keyIndex,
+          groupingKeyInfos.size(),
+          "GroupId grouping-set index out of range");
+      names.emplace_back(groupingKeyInfos[keyIndex].output);
+    }
+    groupingSets.emplace_back(std::move(names));
+  }
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> aggregationInputs =
+      toFieldAccessList(
+          groupId.aggregationInputs(), "GroupId aggregationInput");
+
+  return std::make_shared<velox::core::GroupIdNode>(
+      nextId(),
+      std::move(groupingSets),
+      std::move(groupingKeyInfos),
+      std::move(aggregationInputs),
+      std::string{groupId.groupId()->outputName()},
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitMarkDistinct(
+    const MarkDistinct& markDistinct) {
+  velox::core::PlanNodePtr input = emit(markDistinct.input());
+
+  std::vector<std::string> markerNames;
+  markerNames.reserve(markDistinct.markers().size());
+  for (ColumnCP marker : markDistinct.markers()) {
+    markerNames.emplace_back(marker->outputName());
+  }
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> distinctKeys =
+      toFieldAccessList(markDistinct.distinctKeys(), "MarkDistinct key");
+
+  // At numDrivers > 1 every row of a distinct-key tuple must reach one driver,
+  // else each driver marks the tuple as first-seen and the distinct count
+  // over-counts. Co-partition the input on the distinct keys.
+  if (options_.numDrivers > 1) {
+    input = addLocalPartition(std::move(input), distinctKeys);
+  }
+
+  return std::make_shared<velox::core::MarkDistinctNode>(
+      nextId(),
+      std::move(markerNames),
+      std::move(distinctKeys),
+      toFieldAccessList(markDistinct.masks()),
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitJoin(const Join& join) {
+  velox::core::PlanNodePtr left = emit(join.left());
+  velox::core::PlanNodePtr right = emit(join.right());
+
+  // PrecomputeProjections guarantees each key is a FieldAccess-shaped
+  // Column ref by this point.
+  velox::core::TypedExprPtr filter;
+  if (!join.filter().empty()) {
+    filter = exprEmitter_.makeAnd(join.filter());
+  }
+
+  if (!join.leftKeys().empty()) {
+    auto leftKeys = toFieldAccessList(join.leftKeys(), "Join leftKey");
+    auto rightKeys = toFieldAccessList(join.rightKeys(), "Join rightKey");
+
+    return std::make_shared<velox::core::HashJoinNode>(
+        nextId(),
+        join.joinType(),
+        join.nullAware(),
+        std::move(leftKeys),
+        std::move(rightKeys),
+        filter,
+        std::move(left),
+        std::move(right),
+        makeRowType(join.outputColumns()),
+        /*useHashTableCache=*/false,
+        join.nullAsValue());
+  }
+
+  const auto joinType = join.joinType();
+  if (joinType == velox::core::JoinType::kAnti ||
+      joinType == velox::core::JoinType::kLeftSemiFilter) {
+    // Velox NestedLoopJoinNode supports kLeftSemiProject but not kAnti
+    // or kLeftSemiFilter; lower via a kLeftSemiProject mark column plus
+    // a Filter on the mark, then project it away. Remove once Velox
+    // closes https://github.com/facebookincubator/velox/issues/17650.
+    VELOX_CHECK(
+        !join.nullAware(),
+        "Null-aware kAnti/kLeftSemiFilter without equi-keys is not supported");
+    return emitSemiAntiViaLeftSemiProject(
+        join, std::move(left), std::move(right), filter);
+  }
+
+  return std::make_shared<velox::core::NestedLoopJoinNode>(
+      nextId(),
+      joinType,
+      filter,
+      std::move(left),
+      std::move(right),
+      makeRowType(join.outputColumns()));
+}
+
+velox::core::PlanNodePtr Emitter::emitSemiAntiViaLeftSemiProject(
+    const Join& join,
+    velox::core::PlanNodePtr left,
+    velox::core::PlanNodePtr right,
+    velox::core::TypedExprPtr filter) {
+  const std::string markName = fmt::format("__nlj_mark_{}", nextNodeId_);
+  const auto& outputColumns = join.outputColumns();
+
+  auto outputType = [&]() {
+    std::vector<std::string> innerNames;
+    std::vector<velox::TypePtr> innerTypes;
+    innerNames.reserve(outputColumns.size() + 1);
+    innerTypes.reserve(outputColumns.size() + 1);
+    for (ColumnCP column : outputColumns) {
+      innerNames.emplace_back(column->outputName());
+      innerTypes.push_back(toTypePtr(column->value().type));
+    }
+    innerNames.push_back(markName);
+    innerTypes.push_back(velox::BOOLEAN());
+    return velox::ROW(std::move(innerNames), std::move(innerTypes));
+  }();
+
+  auto joinNode = std::make_shared<velox::core::NestedLoopJoinNode>(
+      nextId(),
+      velox::core::JoinType::kLeftSemiProject,
+      filter,
+      std::move(left),
+      std::move(right),
+      std::move(outputType));
+
+  auto markRef = std::make_shared<velox::core::FieldAccessTypedExpr>(
+      velox::BOOLEAN(), markName);
+  velox::core::TypedExprPtr markPredicate = markRef;
+  if (join.joinType() == velox::core::JoinType::kAnti) {
+    markPredicate = std::make_shared<velox::core::CallTypedExpr>(
+        velox::BOOLEAN(),
+        std::vector<velox::core::TypedExprPtr>{markRef},
+        std::string{queryCtx()->functionNames().negation});
+  }
+
+  auto filtered = std::make_shared<velox::core::FilterNode>(
+      nextId(), std::move(markPredicate), std::move(joinNode));
+
+  return projectToColumns(outputColumns, std::move(filtered));
+}
+
+velox::core::PlanNodePtr Emitter::emitSort(const Sort& sort) {
+  velox::core::PlanNodePtr input = emit(sort.input());
+  auto [sortingKeys, sortingOrders] =
+      toSortingKeys(sort.orderKeys(), sort.orderTypes(), "Sort key");
+  // With multiple drivers each driver sorts its rows (a partial sort) and a
+  // LocalMerge combines the per-driver runs into one sorted stream. With a
+  // single driver a plain final sort suffices.
+  const bool multiDriver = options_.numDrivers > 1;
+  auto ordered = std::make_shared<velox::core::OrderByNode>(
+      nextId(),
+      sortingKeys,
+      sortingOrders,
+      /*isPartial=*/multiDriver,
+      std::move(input));
+  if (!multiDriver) {
+    return ordered;
+  }
+  return std::make_shared<velox::core::LocalMergeNode>(
+      nextId(),
+      sortingKeys,
+      sortingOrders,
+      std::vector<velox::core::PlanNodePtr>{std::move(ordered)});
+}
+
+velox::core::PlanNodePtr Emitter::emitTopN(const TopN& topN) {
+  velox::core::PlanNodePtr input = emit(topN.input());
+  auto [sortingKeys, sortingOrders] =
+      toSortingKeys(topN.orderKeys(), topN.orderTypes(), "TopN key");
+  // The TopN keeps offset + count rows; a trailing Limit applies the offset.
+  const int64_t topNCount = topN.offset() + topN.count();
+  VELOX_CHECK_LE(
+      topNCount,
+      std::numeric_limits<int32_t>::max(),
+      "TopN offset + count exceeds the Velox TopNNode count limit");
+  // At numDrivers > 1 each driver keeps its own top rows (a partial top-n); a
+  // gather to one driver then re-applies the top-n across the merged outputs.
+  if (options_.numDrivers > 1) {
+    input = std::make_shared<velox::core::TopNNode>(
+        nextId(),
+        sortingKeys,
+        sortingOrders,
+        static_cast<int32_t>(topNCount),
+        /*isPartial=*/true,
+        std::move(input));
+    input =
+        velox::core::LocalPartitionNode::gather(nextId(), {std::move(input)});
+  }
+  velox::core::PlanNodePtr result = std::make_shared<velox::core::TopNNode>(
+      nextId(),
+      sortingKeys,
+      sortingOrders,
+      static_cast<int32_t>(topNCount),
+      /*isPartial=*/false,
+      std::move(input));
+  if (topN.offset() > 0) {
+    result = std::make_shared<velox::core::LimitNode>(
+        nextId(),
+        topN.offset(),
+        topN.count(),
+        /*isPartial=*/false,
+        std::move(result));
+  }
+  return result;
+}
+
+velox::core::PlanNodePtr Emitter::emitLimit(const Limit& limit) {
+  velox::core::PlanNodePtr input = emit(limit.input());
+  // At numDrivers > 1 each driver keeps its own top offset+count rows (a
+  // partial limit); a gather to one driver then applies the final offset/count
+  // so the limit is enforced across the task, not per driver.
+  if (options_.numDrivers > 1) {
+    input = std::make_shared<velox::core::LimitNode>(
+        nextId(),
+        /*offset=*/0,
+        limit.offset() + limit.count(),
+        /*isPartial=*/true,
+        std::move(input));
+    input =
+        velox::core::LocalPartitionNode::gather(nextId(), {std::move(input)});
+  }
+  return std::make_shared<velox::core::LimitNode>(
+      nextId(),
+      limit.offset(),
+      limit.count(),
+      /*isPartial=*/false,
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitValues(const Values& values) {
+  auto* pool = evaluator_.pool();
+  std::vector<velox::RowVectorPtr> rowVectors;
+
+  if (values.rows() != nullptr) {
+    const auto rowType = makeRowType(values.outputColumns());
+    rowVectors.emplace_back(
+        std::static_pointer_cast<velox::RowVector>(
+            velox::BaseVector::createFromVariants(
+                rowType, values.rows()->array(), pool)));
+    return std::make_shared<velox::core::ValuesNode>(
+        nextId(), std::move(rowVectors));
+  }
+
+  const auto* source = values.source();
+  if (source == nullptr) {
+    const auto rowType = makeRowType(values.outputColumns());
+    rowVectors.emplace_back(
+        velox::BaseVector::create<velox::RowVector>(rowType, /*size=*/0, pool));
+    return std::make_shared<velox::core::ValuesNode>(
+        nextId(), std::move(rowVectors));
+  }
+
+  const auto& sourceRowType = source->outputType();
+  const auto& data = source->data();
+  if (const auto* variants =
+          std::get_if<logical_plan::ValuesNode::Variants>(&data)) {
+    rowVectors.emplace_back(
+        std::static_pointer_cast<velox::RowVector>(
+            velox::BaseVector::createFromVariants(
+                sourceRowType, *variants, pool)));
+  } else if (
+      const auto* vectors =
+          std::get_if<logical_plan::ValuesNode::Vectors>(&data)) {
+    rowVectors = *vectors;
+  } else {
+    VELOX_NYI(
+        "ValuesNode::Exprs emit not yet supported (needs constant folding from normalize)");
+  }
+  return std::make_shared<velox::core::ValuesNode>(
+      nextId(), std::move(rowVectors));
+}
+
+velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
+  velox::core::PlanNodePtr input = emit(window.input());
+
+  auto partitionKeys =
+      toFieldAccessList(window.partitionKeys(), "Window partition key");
+
+  // At numDrivers > 1 each partition must be complete in one driver:
+  // repartition on the PARTITION BY keys, or gather when the window spans the
+  // whole input.
+  if (options_.numDrivers > 1) {
+    input = addLocalPartition(std::move(input), partitionKeys);
+  }
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> sortingKeys;
+  std::vector<velox::core::SortOrder> sortingOrders;
+  sortingKeys.reserve(window.orderKeys().size());
+  sortingOrders.reserve(window.orderTypes().size());
+  for (size_t i = 0; i < window.orderKeys().size(); ++i) {
+    sortingKeys.push_back(
+        toFieldAccess(window.orderKeys()[i], "Window sort key"));
+    sortingOrders.push_back(toSortOrder(window.orderTypes()[i]));
+  }
+
+  const auto& functions = window.functions();
+  const auto& outputColumns = window.outputColumns();
+  const size_t numInputColumns = window.input()->outputColumns().size();
+  std::vector<std::string> windowColumnNames;
+  std::vector<velox::core::WindowNode::Function> windowFunctions;
+  windowColumnNames.reserve(functions.size());
+  windowFunctions.reserve(functions.size());
+  for (size_t i = 0; i < functions.size(); ++i) {
+    auto typed = exprEmitter_.toTypedExpr(functions[i].call);
+    auto call =
+        std::dynamic_pointer_cast<const velox::core::CallTypedExpr>(typed);
+    VELOX_USER_CHECK_NOT_NULL(call, "Window function must be a call");
+    const auto& frame = functions[i].frame;
+    velox::core::WindowNode::Frame veloxFrame{
+        .type = static_cast<velox::core::WindowNode::WindowType>(frame.type),
+        .startType =
+            static_cast<velox::core::WindowNode::BoundType>(frame.startType),
+        .startValue = frame.startValue == nullptr
+            ? nullptr
+            : exprEmitter_.toTypedExpr(frame.startValue),
+        .endType =
+            static_cast<velox::core::WindowNode::BoundType>(frame.endType),
+        .endValue = frame.endValue == nullptr
+            ? nullptr
+            : exprEmitter_.toTypedExpr(frame.endValue),
+    };
+    windowFunctions.push_back({call, veloxFrame, functions[i].ignoreNulls});
+    windowColumnNames.push_back(
+        outputColumns[numInputColumns + i]->outputName());
+  }
+
+  return std::make_shared<velox::core::WindowNode>(
+      nextId(),
+      std::move(partitionKeys),
+      std::move(sortingKeys),
+      std::move(sortingOrders),
+      std::move(windowColumnNames),
+      std::move(windowFunctions),
+      /*inputsSorted=*/false,
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitTopNRowNumber(const TopNRowNumber& node) {
+  velox::core::PlanNodePtr input = emit(node.input());
+  auto partitionKeys =
+      toFieldAccessList(node.partitionKeys(), "TopNRowNumber partition key");
+  // At numDrivers > 1 each partition must be complete in one driver:
+  // repartition on the partition keys, or gather when there are none.
+  if (options_.numDrivers > 1) {
+    input = addLocalPartition(std::move(input), partitionKeys);
+  }
+  auto [sortingKeys, sortingOrders] = toSortingKeys(
+      node.orderKeys(), node.orderTypes(), "TopNRowNumber order key");
+  std::optional<std::string> rowNumberColumnName;
+  if (node.rankColumn() != nullptr) {
+    rowNumberColumnName = node.rankColumn()->outputName();
+  }
+  return std::make_shared<velox::core::TopNRowNumberNode>(
+      nextId(),
+      node.rankFunction(),
+      std::move(partitionKeys),
+      std::move(sortingKeys),
+      std::move(sortingOrders),
+      rowNumberColumnName,
+      node.limit(),
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitUnnest(const Unnest& unnest) {
+  velox::core::PlanNodePtr input = emit(unnest.input());
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> replicateVariables =
+      toFieldAccessList(unnest.replicatedColumns());
+
+  std::vector<velox::core::FieldAccessTypedExprPtr> unnestVariables =
+      toFieldAccessList(unnest.unnestExpressions(), "Unnest expression");
+
+  std::vector<std::string> unnestNames;
+  for (const auto& perExpr : unnest.unnestColumns()) {
+    for (ColumnCP column : perExpr) {
+      unnestNames.push_back(column->outputName());
+    }
+  }
+
+  std::optional<std::string> ordinalityName;
+  if (unnest.ordinalityColumn() != nullptr) {
+    ordinalityName = unnest.ordinalityColumn()->outputName();
+  }
+
+  return std::make_shared<velox::core::UnnestNode>(
+      nextId(),
+      std::move(replicateVariables),
+      std::move(unnestVariables),
+      std::move(unnestNames),
+      ordinalityName,
+      /*markerName=*/std::nullopt,
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitUnionAll(const UnionAll& unionNode) {
+  // `LocalPartitionNode` requires every source to share an identical output
+  // type. Each leg's IR `outputColumns` may be narrower than the union's
+  // width (legs collapse dup outputs independently), so always wrap each leg
+  // in a per-leg ProjectNode that selects via `legColumns[i][j]` (a Column*
+  // in the leg's outputColumns) and renames to the union's output names.
+  const auto& outputColumns = unionNode.outputColumns();
+  const auto& legColumns = unionNode.legColumns();
+  const auto numOutputs = outputColumns.size();
+  std::vector<velox::core::PlanNodePtr> sources;
+  sources.reserve(unionNode.inputs().size());
+  for (size_t legIdx = 0; legIdx < unionNode.inputs().size(); ++legIdx) {
+    NodeCP input = unionNode.inputs()[legIdx];
+    velox::core::PlanNodePtr emittedInput = emit(input);
+    const auto& legCols = legColumns[legIdx];
+    std::vector<std::string> names;
+    std::vector<velox::core::TypedExprPtr> exprs;
+    names.reserve(numOutputs);
+    exprs.reserve(numOutputs);
+    for (size_t j = 0; j < numOutputs; ++j) {
+      names.push_back(outputColumns[j]->outputName());
+      exprs.push_back(toFieldAccess(legCols[j]));
+    }
+    sources.push_back(
+        std::make_shared<velox::core::ProjectNode>(
+            nextId(),
+            std::move(names),
+            std::move(exprs),
+            std::move(emittedInput)));
+  }
+  return velox::core::LocalPartitionNode::gather(nextId(), std::move(sources));
+}
+
+velox::core::PlanNodePtr Emitter::emitEnforceSingleRow(
+    const EnforceSingleRow& node) {
+  velox::core::PlanNodePtr input = emit(node.input());
+  // Asserting at most one row is a global check; at numDrivers > 1 gather to
+  // one driver first so the count is across the whole task, not per driver.
+  if (options_.numDrivers > 1) {
+    input =
+        velox::core::LocalPartitionNode::gather(nextId(), {std::move(input)});
+  }
+  return std::make_shared<velox::core::EnforceSingleRowNode>(
+      nextId(), std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitAssignUniqueId(
+    const AssignUniqueId& node) {
+  return std::make_shared<velox::core::AssignUniqueIdNode>(
+      nextId(), node.idColumn()->outputName(), emit(node.input()));
+}
+
+velox::core::PlanNodePtr Emitter::emitEnforceDistinct(
+    const EnforceDistinct& node) {
+  velox::core::PlanNodePtr input = emit(node.input());
+  auto distinctKeys =
+      toFieldAccessList(node.distinctKeys(), "EnforceDistinct distinct key");
+  // Stream (no hash table) over input already grouped on a prefix of the
+  // distinct keys, mirroring how the aggregation derives its pre-grouped keys.
+  auto preGroupedKeys = toFieldAccessList(
+      computePreGroupedKeys(
+          node.input()->physicalProperties().local, node.distinctKeys()),
+      "EnforceDistinct pre-grouped key");
+  // At numDrivers > 1 each distinct-key group must be complete in one driver.
+  // Skip when the input is pre-grouped on the keys: a local grouping guarantees
+  // driver-confinement by contract (see `LocalProperty`).
+  if (options_.numDrivers > 1 && preGroupedKeys.empty()) {
+    input = addLocalPartition(std::move(input), distinctKeys);
+  }
+  return std::make_shared<velox::core::EnforceDistinctNode>(
+      nextId(),
+      std::move(distinctKeys),
+      std::move(preGroupedKeys),
+      node.errorMessage(),
+      std::move(input));
+}
+
+// Merges two fragment-type contributions: a kSource and a kFixed coexist as
+// kFixed (split-driven scans feeding a fixed-width stage); equal types merge to
+// themselves; nullopt is "no constraint".
+std::optional<FragmentType> mergeFragmentTypes(
+    std::optional<FragmentType> lhs,
+    std::optional<FragmentType> rhs) {
+  if (!lhs.has_value()) {
+    return rhs;
+  }
+  if (!rhs.has_value()) {
+    return lhs;
+  }
+  if (*lhs == *rhs) {
+    return lhs;
+  }
+  if ((*lhs == FragmentType::kSource && *rhs == FragmentType::kFixed) ||
+      (*lhs == FragmentType::kFixed && *rhs == FragmentType::kSource)) {
+    return FragmentType::kFixed;
+  }
+  VELOX_FAIL(
+      "Incompatible fragment-type contributions in one fragment: {} + {}",
+      *lhs,
+      *rhs);
+}
+
+// The fragment type the subtree at 'node' contributes, walking down to (not
+// across) inner exchanges. An exchange yields its consumer-side type
+// (partitioned → kFixed, gather → kSingle, broadcast/arbitrary → no
+// constraint); a scan yields kSource.
+std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
+  if (node->is(NodeType::kExchange)) {
+    switch (node->as<Exchange>()->partitioning().kind) {
+      case PartitionKind::kPartitioned:
+        return FragmentType::kFixed;
+      case PartitionKind::kGather:
+        return FragmentType::kSingle;
+      case PartitionKind::kBroadcast:
+      case PartitionKind::kArbitrary:
+      case PartitionKind::kUnspecified:
+        return std::nullopt;
+    }
+  }
+  switch (node->nodeType()) {
+    case NodeType::kScan:
+      return FragmentType::kSource;
+    case NodeType::kValues:
+      return FragmentType::kSingle;
+    default: {
+      std::optional<FragmentType> result;
+      for (NodeCP input : node->inputs()) {
+        result = mergeFragmentTypes(result, fragmentTypeContribution(input));
+      }
+      return result;
+    }
+  }
+}
+
+// Sets 'fragment.type' (and 'width' for kFixed) from the contents at 'node'. At
+// numWorkers == 1 all parallelism collapses to one task.
+void decideFragmentType(
+    NodeCP node,
+    int32_t numWorkers,
+    ExecutableFragment& fragment) {
+  if (numWorkers == 1) {
+    fragment.type = FragmentType::kSingle;
+    return;
+  }
+  fragment.type =
+      fragmentTypeContribution(node).value_or(FragmentType::kSource);
+  if (fragment.type == FragmentType::kFixed) {
+    fragment.width = numWorkers;
+  }
+}
+
+void Emitter::finalizeGroupedLeaves(ExecutableFragment& fragment) {
+  // Fold the bucketed scans' partitionings into one compatible type. `folded`
+  // owns the running copartition result so `base`, which points into it (or the
+  // first scan's layout-owned type before any fold), never dangles.
+  const connector::PartitionType* base = nullptr;
+  std::shared_ptr<connector::PartitionType> folded;
+  for (const auto& leaf : groupedLeaves_) {
+    if (leaf.partitionType == nullptr) {
+      continue;
+    }
+    if (base == nullptr) {
+      base = leaf.partitionType;
+      continue;
+    }
+    // Scans share a fragment without an intervening exchange only because the
+    // memo found them co-partitionable, so `copartition` must succeed.
+    folded = base->copartition(*leaf.partitionType);
+    VELOX_CHECK_NOT_NULL(
+        folded, "Co-fragmented bucketed scans must be copartitionable");
+    base = folded.get();
+  }
+
+  if (base == nullptr) {
+    return;
+  }
+
+  std::shared_ptr<connector::PartitionType> scaled =
+      base->scaleDown(options_.numWorkers);
+  for (const auto& leaf : groupedLeaves_) {
+    fragment.groupedNodes.emplace(
+        leaf.nodeId, leaf.partitionType != nullptr ? scaled : nullptr);
+  }
+  fragment.type = FragmentType::kFixed;
+  fragment.width = scaled->numPartitions();
+}
+
+velox::core::PlanNodePtr Emitter::emitChildFragment(
+    NodeCP node,
+    ExecutableFragment& fragment) {
+  ExecutableFragment* outer = currentFragment_;
+  auto outerGroupedLeaves = std::move(groupedLeaves_);
+  SCOPE_EXIT {
+    currentFragment_ = outer;
+    groupedLeaves_ = std::move(outerGroupedLeaves);
+  };
+  groupedLeaves_.clear();
+  currentFragment_ = &fragment;
+  velox::core::PlanNodePtr plan = emit(node);
+  finalizeGroupedLeaves(fragment);
+  return plan;
+}
+
+velox::core::PlanNodePtr Emitter::makeExchangeProducer(
+    const Partitioning& partitioning,
+    const velox::RowTypePtr& outputType,
+    const velox::core::PlanNodePtr& sourcePlan) {
+  switch (partitioning.kind) {
+    case PartitionKind::kBroadcast:
+      return velox::core::PartitionedOutputNode::broadcast(
+          nextId(),
+          /*numPartitions=*/1,
+          outputType,
+          exchangeSerdeKind_,
+          sourcePlan);
+    case PartitionKind::kGather:
+      return velox::core::PartitionedOutputNode::single(
+          nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+    case PartitionKind::kArbitrary:
+      return velox::core::PartitionedOutputNode::arbitrary(
+          nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+    case PartitionKind::kPartitioned: {
+      auto fields =
+          toFieldAccessList(partitioning.keys, "Exchange partition key");
+
+      // A partitionType aligns this shuffle to a bucketed side: use the
+      // connector's partition function (scaled to the worker count) so rows
+      // land in the same groups as the bucketed scan, matching the grouped
+      // fragment's width. Otherwise standard Velox hash over numWorkers
+      // partitions.
+      int32_t numPartitions = options_.numWorkers;
+      velox::core::PartitionFunctionSpecPtr spec;
+      if (partitioning.partitionType != nullptr) {
+        auto scaled =
+            partitioning.partitionType->scaleDown(options_.numWorkers);
+        numPartitions = scaled->numPartitions();
+        spec = connectorPartitionSpec(
+            *scaled, outputType, fields, /*isLocal=*/false);
+      } else {
+        spec = makeHashPartitionSpec(outputType, fields);
+      }
+
+      if (numPartitions == 1) {
+        // A connector partitioning that scales to one destination (e.g. a
+        // single-bucket table) needs no partition function: gather to one task.
+        return velox::core::PartitionedOutputNode::single(
+            nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+      }
+
+      std::vector<velox::core::TypedExprPtr> keys(fields.begin(), fields.end());
+      return std::make_shared<velox::core::PartitionedOutputNode>(
+          nextId(),
+          velox::core::PartitionedOutputNode::Kind::kPartitioned,
+          keys,
+          numPartitions,
+          partitioning.replicateNullsAndAny,
+          std::move(spec),
+          outputType,
+          exchangeSerdeKind_,
+          sourcePlan);
+    }
+    case PartitionKind::kUnspecified:
+      VELOX_UNREACHABLE("Exchange has no concrete partitioning to lower");
+  }
+}
+
+velox::core::PlanNodePtr Emitter::makeExchangeConsumer(
+    const Partitioning& partitioning,
+    const velox::RowTypePtr& outputType) {
+  if (partitioning.kind == PartitionKind::kGather &&
+      !partitioning.orderKeys.empty()) {
+    // Order-preserving gather: the consumer merges the sorted per-task streams.
+    auto [sortingKeys, sortingOrders] = toSortingKeys(
+        partitioning.orderKeys, partitioning.orderTypes, "Merge exchange key");
+    return std::make_shared<velox::core::MergeExchangeNode>(
+        nextId(), outputType, sortingKeys, sortingOrders, exchangeSerdeKind_);
+  }
+  return std::make_shared<velox::core::ExchangeNode>(
+      nextId(), outputType, exchangeSerdeKind_);
+}
+
+velox::core::PlanNodePtr Emitter::emitExchange(const Exchange& exchange) {
+  const auto& partitioning = exchange.partitioning();
+
+  // Producer fragment: the exchange's input, capped with a PartitionedOutput.
+  ExecutableFragment source = newFragment();
+  decideFragmentType(exchange.input(), options_.numWorkers, source);
+  velox::core::PlanNodePtr sourcePlan =
+      emitChildFragment(exchange.input(), source);
+  const auto outputType = sourcePlan->outputType();
+
+  source.fragment.planNode =
+      makeExchangeProducer(partitioning, outputType, sourcePlan);
+
+  velox::core::PlanNodePtr consumer =
+      makeExchangeConsumer(partitioning, outputType);
+  currentFragment_->inputStages.emplace_back(consumer->id(), source.taskPrefix);
+
+  // A partitioned exchange feeding the outer fragment is a group-routed leaf
+  // there: if that fragment turns out bucketed, the exchange delivers per
+  // group. Recorded as a null-typed leaf (the fragment's bucketed scan, if any,
+  // anchors the width); `finalizeGroupedLeaves` drops it when the fragment has
+  // none. A bucketed write, whose fragment has no scan, anchors this leaf
+  // explicitly — see emitTableWrite.
+  if (partitioning.kind == PartitionKind::kPartitioned) {
+    groupedLeaves_.push_back({consumer->id(), nullptr});
+  }
+
+  stages_.push_back(std::move(source));
+  return consumer;
+}
+
+velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
+  const auto& table = *tableWrite.table();
+  auto* layout = table.layouts().front();
+  const auto& connectorId = layout->connector()->connectorId();
+  auto metadata = connector::ConnectorMetadataRegistry::get(connectorId);
+  auto connectorSession = session_.toConnectorSession(connectorId);
+  auto handle = metadata->beginWrite(
+      connectorSession,
+      table.shared_from_this(),
+      tableWrite.kind(),
+      session_.options().explain);
+
+  // Parallelize writers only when the input is already distributed; gathering
+  // an already-single-task input would add a redundant exchange.
+  const bool distributed = options_.numWorkers > 1 &&
+      fragmentTypeContribution(tableWrite.input()) != FragmentType::kSingle;
+
+  ExecutableFragment* rootFragment = currentFragment_;
+  ExecutableFragment writerFragment;
+  std::vector<PendingGroupedLeaf> rootGroupedLeaves;
+  if (distributed) {
+    writerFragment = newFragment();
+    decideFragmentType(tableWrite.input(), options_.numWorkers, writerFragment);
+    rootGroupedLeaves = std::move(groupedLeaves_);
+    groupedLeaves_.clear();
+    currentFragment_ = &writerFragment;
+  }
+
+  velox::core::PlanNodePtr input = emit(tableWrite.input());
+
+  // A bucketed write's input is the remote bucket exchange (physical planning
+  // inserts it unless the source is already co-bucketed). The writer fragment
+  // has no bucketed scan to anchor grouped execution, so anchor it on that
+  // exchange: each of its bucket partitions becomes one writer group producing
+  // one bucket file, matching the exchange's partition count.
+  if (distributed && !layout->partitionColumns().empty() &&
+      tableWrite.input()->is(NodeType::kExchange)) {
+    for (auto& leaf : groupedLeaves_) {
+      if (leaf.nodeId == input->id()) {
+        leaf.partitionType = layout->partitionType().get();
+        break;
+      }
+    }
+  }
+
+  // Velox's TableWriteNode writes its input's columns, so materialize the write
+  // value expressions as a Project producing the target columns in schema
+  // order. Skip the projection when the input already produces exactly those
+  // columns — otherwise it would shadow a source projection and, for a bucketed
+  // write, land after the bucket exchange instead of before it.
+  auto values = exprEmitter_.toTypedExprs(tableWrite.columnExprs());
+  if (!writeInputIsIdentity(input->outputType(), values)) {
+    input = std::make_shared<velox::core::ProjectNode>(
+        nextId(), table.type()->names(), std::move(values), std::move(input));
+  }
+  const auto& inputType = input->outputType();
+
+  // A write to a bucketed/partitioned layout repartitions its input on the
+  // target's partition (bucket) columns so each partition's rows go to a single
+  // writer driver. The remote bucket exchange added in physical planning has
+  // already confined each partition to one worker; this is the within-worker
+  // split (only meaningful at numDrivers > 1).
+  const auto& partitionColumns = layout->partitionColumns();
+  if (options_.numDrivers > 1 && !partitionColumns.empty()) {
+    input = std::make_shared<velox::core::LocalPartitionNode>(
+        nextId(),
+        velox::core::LocalPartitionNode::Type::kRepartition,
+        /*scaleWriter=*/false,
+        connectorPartitionSpec(
+            *layout->partitionType(),
+            inputType,
+            partitionColumns,
+            /*isLocal=*/true),
+        std::vector<velox::core::PlanNodePtr>{std::move(input)});
+  }
+
+  // A single-fragment write over a single-threaded pipeline (e.g. a Values
+  // source) has one writer producing all rows, so the per-driver stats need no
+  // merge. Reporting one driver keeps the plan a bare TableWrite.
+  const int32_t numDrivers =
+      !distributed && isSingleThreadedPipeline(input) ? 1 : options_.numDrivers;
+  WriteStatsBuilder statsBuilder(
+      table,
+      inputType,
+      *handle,
+      numDrivers,
+      distributed ? options_.numWorkers : 1);
+  std::optional<velox::core::ColumnStatsSpec> writeStatsSpec;
+  if (statsBuilder.hasStats()) {
+    writeStatsSpec = statsBuilder.writeSpec();
+  }
+  auto writeOutputType = writeStatsSpec.has_value()
+      ? velox::core::TableWriteTraits::outputType(writeStatsSpec)
+      : handle->resultType();
+
+  VELOX_CHECK(!finishWrite_, "Only one TableWrite per query is supported");
+  auto insertTableHandle =
+      std::make_shared<const velox::core::InsertTableHandle>(
+          connectorId, handle->veloxHandle());
+  finishWrite_ = FinishWrite{
+      metadata,
+      std::move(connectorSession),
+      std::move(handle),
+      statsBuilder.statsMapping()};
+
+  velox::core::PlanNodePtr result =
+      std::make_shared<velox::core::TableWriteNode>(
+          nextId(),
+          inputType,
+          table.type()->names(),
+          std::move(writeStatsSpec),
+          std::move(insertTableHandle),
+          /*hasPartitioningScheme=*/false,
+          std::move(writeOutputType),
+          velox::connector::CommitStrategy::kNoCommit,
+          std::move(input));
+
+  // Combine the per-driver write stats within a worker.
+  if (statsBuilder.needsMerge()) {
+    result = velox::core::LocalPartitionNode::gather(
+        nextId(), std::vector<velox::core::PlanNodePtr>{result});
+    auto localMergeSpec = statsBuilder.localMergeSpec(result->outputType());
+    auto localMergeOutputType =
+        velox::core::TableWriteTraits::outputType(localMergeSpec);
+    result = std::make_shared<velox::core::TableWriteMergeNode>(
+        nextId(),
+        std::move(localMergeOutputType),
+        std::move(localMergeSpec),
+        std::move(result));
+  }
+
+  if (!distributed) {
+    return result;
+  }
+
+  // Gather each worker's intermediate stats to the single root fragment.
+  finalizeGroupedLeaves(writerFragment);
+  writerFragment.fragment.planNode = velox::core::PartitionedOutputNode::single(
+      nextId(), result->outputType(), exchangeSerdeKind_, result);
+  currentFragment_ = rootFragment;
+  groupedLeaves_ = std::move(rootGroupedLeaves);
+  auto gather = std::make_shared<velox::core::ExchangeNode>(
+      nextId(), result->outputType(), exchangeSerdeKind_);
+  rootFragment->inputStages.emplace_back(
+      gather->id(), writerFragment.taskPrefix);
+  stages_.push_back(std::move(writerFragment));
+
+  if (!statsBuilder.needsFinalMerge()) {
+    return gather;
+  }
+
+  // The coordinator merges the per-worker intermediates into final scalar
+  // stats.
+  auto finalMergeSpec = statsBuilder.finalMergeSpec(gather->outputType());
+  auto finalMergeOutputType =
+      velox::core::TableWriteTraits::outputType(finalMergeSpec);
+  return std::make_shared<velox::core::TableWriteMergeNode>(
+      nextId(),
+      std::move(finalMergeOutputType),
+      std::move(finalMergeSpec),
+      std::move(gather));
+}
+
+std::vector<ExecutableFragment> Emitter::emitFragments(
+    NodeCP root,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames) {
+  ExecutableFragment top = newFragment();
+  top.type = FragmentType::kSingle;
+
+  // A table write is a root sink: emit it (and its gathered input) directly as
+  // the single root fragment. Its output is the write-stats row the runner
+  // interprets via FinishWrite, not a user column layout, so it takes no
+  // output-rename projection.
+  if (root->is(NodeType::kTableWrite)) {
+    currentFragment_ = &top;
+    top.fragment.planNode = emit(root);
+    finalizeGroupedLeaves(top);
+    currentFragment_ = nullptr;
+    stages_.push_back(std::move(top));
+    return std::move(stages_);
+  }
+
+  // A root whose subtree already runs on one task (e.g. below a global ORDER BY
+  // or aggregate) needs no output gather and is emitted directly, like the
+  // single-node case. Only a multi-task root is gathered to a single task for
+  // the query output.
+  const Project* rootProject =
+      root->is(NodeType::kProject) ? root->as<Project>() : nullptr;
+  NodeCP sourceRoot = rootProject != nullptr ? rootProject->input() : root;
+  const bool gatherForOutput = options_.numWorkers > 1 &&
+      fragmentTypeContribution(sourceRoot) != FragmentType::kSingle;
+
+  if (gatherForOutput) {
+    // The distributed source gathers its output to the single-task root, which
+    // applies the output projection. Gathering below a root Project keeps the
+    // shuffle carrying only the projection's (distinct) input columns — a
+    // Project that renames or duplicates columns (e.g. `SELECT a, a`) does so
+    // at the single-task root, where the consistency checker also exempts the
+    // root projection from the unique-name rule.
+    ExecutableFragment source = newFragment();
+    decideFragmentType(sourceRoot, options_.numWorkers, source);
+    velox::core::PlanNodePtr sourcePlan = emitChildFragment(sourceRoot, source);
+    currentFragment_ = &top;
+
+    source.fragment.planNode = velox::core::PartitionedOutputNode::single(
+        nextId(), sourcePlan->outputType(), exchangeSerdeKind_, sourcePlan);
+    auto gather = std::make_shared<velox::core::ExchangeNode>(
+        nextId(), sourcePlan->outputType(), exchangeSerdeKind_);
+    top.inputStages.emplace_back(gather->id(), source.taskPrefix);
+    stages_.push_back(std::move(source));
+    // The gather already carries the query's output columns and names when the
+    // root layout is identity (`sourceRoot` is the root Project's input in the
+    // rootProject case), so no output-rename projection is needed.
+    if (isIdentityLayout(*sourceRoot, outputColumns, outputNames)) {
+      top.fragment.planNode = gather;
+    } else if (rootProject != nullptr) {
+      top.fragment.planNode =
+          emitRootProjectOver(gather, *rootProject, outputColumns, outputNames);
+    } else {
+      top.fragment.planNode =
+          wrapWithRenameProject(gather, outputColumns, outputNames);
+    }
+  } else {
+    currentFragment_ = &top;
+    top.fragment.planNode = emitRoot(root, outputColumns, outputNames);
+  }
+  finalizeGroupedLeaves(top);
+  currentFragment_ = nullptr;
+  stages_.push_back(std::move(top));
+  return std::move(stages_);
+}
+
+} // namespace
+
+EmitPass::Result EmitPass::run(
+    NodeCP root,
+    const ColumnVector& outputColumns,
+    const std::vector<std::string>& outputNames,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator,
+    ScanHandleCache& scanHandles,
+    const MultiFragmentPlan::Options& options) {
+  VELOX_CHECK_EQ(outputColumns.size(), outputNames.size());
+  Emitter emitter(session, evaluator, scanHandles, options);
+  auto fragments = emitter.emitFragments(root, outputColumns, outputNames);
+  return Result{std::move(fragments), emitter.takeFinishWrite()};
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
+#include "velox/core/Expressions.h"
+#include "velox/core/PlanNode.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Lowers a tree-IR into the fragments of a `MultiFragmentPlan`.
+class EmitPass {
+ public:
+  /// Output of `run`.
+  struct Result {
+    /// The plan's fragments, root fragment last.
+    std::vector<ExecutableFragment> fragments;
+    /// Set when the plan writes a table; empty otherwise.
+    FinishWrite finishWrite;
+  };
+
+  /// Lowers the tree-IR rooted at 'root' into fragments, projecting to the
+  /// user-visible layout described by 'outputColumns' and 'outputNames'
+  /// (aligned 1:1). Each `ir.Exchange` becomes a fragment boundary (a producer
+  /// fragment ending in `PartitionedOutput`, a consumer `Exchange`). For
+  /// `options.numWorkers > 1` a final gather collects the distributed output
+  /// into a single root fragment; for `numWorkers == 1` the result is one
+  /// fragment. 'session' supplies the connector session for Scan handles;
+  /// 'evaluator' folds filter constants; 'scanHandles' carries handles built by
+  /// `EstimateLeafStatsPass`. Throws VELOX_NYI for unsupported node or
+  /// expression types.
+  static Result run(
+      NodeCP root,
+      const ColumnVector& outputColumns,
+      const std::vector<std::string>& outputNames,
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator,
+      ScanHandleCache& scanHandles,
+      const MultiFragmentPlan::Options& options);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/EstimateLeafStatsPass.h"
+
+#include "folly/coro/BlockingWait.h"
+#include "folly/coro/Collect.h"
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/Filters.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/Schema.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// Collects the Scan nodes reachable from 'node'.
+void collectScans(NodeCP node, std::vector<ScanCP>& scans) {
+  if (node->is(NodeType::kScan)) {
+    scans.push_back(node->as<Scan>());
+    return;
+  }
+
+  for (NodeCP input : node->inputs()) {
+    collectScans(input, scans);
+  }
+}
+
+// Overwrites 'column''s Value with connector-provided per-column statistics.
+void applyColumnStats(
+    ColumnCP column,
+    const connector::ColumnStatistics& stats) {
+  const auto& existing = column->value();
+  // Propagate an absent NDV as unknown (nullopt) rather than fabricating 1;
+  // downstream fanout estimation treats unknown NDV as unknown selectivity.
+  const std::optional<float> numDistinct = stats.numDistinct.has_value()
+      ? std::optional<float>{std::max<float>(1, *stats.numDistinct)}
+      : std::nullopt;
+  Value value(existing.type, numDistinct);
+  value.min =
+      stats.min.has_value() ? registerVariant(stats.min.value()) : nullptr;
+  value.max =
+      stats.max.has_value() ? registerVariant(stats.max.value()) : nullptr;
+  value.nullFraction = stats.nullPct / 100.0f;
+  value.nullable = !stats.nonNull;
+  const_cast<Value&>(existing) = value;
+}
+
+// Applies one base table's connector stats result. Sets filteredCardinality to
+// the connector's post-filter row count, scaled by the optimizer's own
+// selectivity for any filters the connector rejected. A nullopt result (the
+// connector does not support stats) leaves filteredCardinality at 0 so
+// downstream estimation falls back to constraint-based selectivity. Rejected
+// filters scale only the row count; per-column constraints are re-derived
+// downstream.
+void applyFilteredStats(
+    const Scan& scan,
+    const std::vector<ColumnCP>& statColumns,
+    const std::optional<connector::FilteredTableStats>& stats) {
+  if (!stats.has_value()) {
+    return;
+  }
+
+  auto* baseTable = const_cast<BaseTable*>(scan.baseTable());
+
+  if (!stats->columnStats.empty()) {
+    VELOX_CHECK_EQ(stats->columnStats.size(), statColumns.size());
+    for (size_t i = 0; i < stats->columnStats.size(); ++i) {
+      applyColumnStats(statColumns[i], stats->columnStats[i]);
+    }
+  }
+
+  if (stats->rejectedFilterIndices.empty()) {
+    baseTable->filteredCardinality = std::max<float>(1, stats->numRows);
+    return;
+  }
+
+  ExprVector rejectedFilters;
+  rejectedFilters.reserve(stats->rejectedFilterIndices.size());
+  for (int32_t index : stats->rejectedFilterIndices) {
+    VELOX_CHECK_LT(index, scan.filters().size());
+    rejectedFilters.push_back(scan.filters()[index]);
+  }
+
+  ConstraintMap constraints;
+  const auto selectivity = conjunctsSelectivity(
+      constraints,
+      {rejectedFilters.data(), rejectedFilters.size()},
+      /*updateConstraints=*/false);
+  // When the rejected filters' selectivity is unknown, the post-filter row
+  // count is unknown too: leave `filteredCardinality` unset so downstream
+  // estimation propagates the unknown rather than fabricating a fraction.
+  if (!selectivity.has_value()) {
+    baseTable->filteredCardinality = std::nullopt;
+    return;
+  }
+  baseTable->filteredCardinality =
+      std::max<float>(1, stats->numRows * selectivity->trueFraction);
+}
+
+} // namespace
+
+void EstimateLeafStatsPass::run(
+    NodeCP root,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator,
+    ScanHandleCache& scanHandles) {
+  std::vector<ScanCP> scans;
+  collectScans(root, scans);
+
+  // One stats request per distinct base table.
+  struct TableTask {
+    ScanCP scan;
+    std::vector<ColumnCP> statColumns;
+  };
+  std::vector<TableTask> tasks;
+  std::vector<folly::coro::Task<std::optional<connector::FilteredTableStats>>>
+      requests;
+  folly::F14FastSet<int32_t> seen;
+
+  for (ScanCP scan : scans) {
+    const auto* baseTable = scan->baseTable();
+    if (!seen.insert(baseTable->id()).second) {
+      continue;
+    }
+    const ScanHandle& handle =
+        scanHandles.getOrBuild(*scan, session, evaluator);
+
+    const auto* layout = baseTable->schemaTable->columnGroups[0]->layout;
+    auto connectorSession =
+        session.toConnectorSession(layout->connector()->connectorId());
+
+    // Request stats for the top-level columns of the read schema. Subfield
+    // columns have no connector-level statistics.
+    std::vector<ColumnCP> statColumns;
+    std::vector<std::string> columnNames;
+    const auto addColumn = [&](ColumnCP column) {
+      if (column->topColumn() == nullptr) {
+        statColumns.push_back(column);
+        columnNames.emplace_back(column->name());
+      }
+    };
+    for (ColumnCP column : scan->outputColumns()) {
+      addColumn(column);
+    }
+    for (ColumnCP column : handle.filterOnlyColumns) {
+      addColumn(column);
+    }
+
+    tasks.push_back(TableTask{scan, std::move(statColumns)});
+    requests.push_back(layout->co_estimateStats(
+        std::move(connectorSession),
+        handle.tableHandle,
+        std::move(columnNames),
+        handle.filterConjuncts));
+  }
+
+  if (requests.empty()) {
+    return;
+  }
+
+  // No optimizer-time executor is available, so the requests run inline. They
+  // are still launched together so a connector that suspends on I/O can
+  // overlap them.
+  auto results = folly::coro::blockingWait(
+      folly::coro::collectAllRange(std::move(requests)));
+
+  for (size_t i = 0; i < tasks.size(); ++i) {
+    applyFilteredStats(*tasks[i].scan, tasks[i].statColumns, results[i]);
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.h
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/ScanHandle.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Annotates base tables with connector filtered-table statistics.
+class EstimateLeafStatsPass {
+ public:
+  /// For each base table reachable from 'root', builds (and caches in
+  /// 'scanHandles') the connector handle, calls
+  /// `TableLayout::co_estimateStats`, and writes the post-filter row count into
+  /// `BaseTable::filteredCardinality` and the per-column min/max/ndv into each
+  /// `Column::value()`, in place; join-order planning then reads these via
+  /// `EstimateProvider`. Runs after filter pushdown and before join-order
+  /// planning. The caller gates this on the `useFilteredTableStats` option;
+  /// when it does not run, or a connector returns no stats for a table, that
+  /// table's `filteredCardinality` stays 0 and `EstimateProvider` falls back to
+  /// constraint-based selectivity. 'session' supplies connector sessions;
+  /// 'evaluator' constant-folds filters during handle construction.
+  static void run(
+      NodeCP root,
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator,
+      ScanHandleCache& scanHandles);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/EstimateProvider.h"
+
+#include <algorithm>
+
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/Cost.h"
+#include "axiom/optimizer/v2/JoinFanout.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+constexpr float kDefaultLeafCardinality = 1;
+
+std::span<const ExprCP> toSpan(const ExprVector& exprs) {
+  return {exprs.data(), exprs.size()};
+}
+
+// Merges 'from' into 'into', keeping existing entries (the two sides of a
+// join have disjoint column-id spaces, so there is no real conflict).
+void mergeConstraints(const ConstraintMap& from, ConstraintMap& into) {
+  for (const auto& [id, value] : from) {
+    into.emplace(id, value);
+  }
+}
+
+} // namespace
+
+const Estimate& EstimateProvider::estimate(NodeCP node) {
+  auto it = byNode_.find(node);
+  if (it != byNode_.end()) {
+    return it->second;
+  }
+  Estimate result = compute(node);
+  return byNode_.emplace(node, std::move(result)).first->second;
+}
+
+Estimate EstimateProvider::compute(NodeCP node) {
+  switch (node->nodeType()) {
+    case NodeType::kScan: {
+      const auto* scan = node->as<Scan>();
+      const auto* baseTable = scan->baseTable();
+      Estimate result;
+      // Narrow per-column constraints from the scan filters; join propagation
+      // reads these regardless of the cardinality source. The filter
+      // selectivity is unknown when `conjunctsSelectivity` cannot estimate it;
+      // an unknown selectivity makes the constraint-derived cardinality
+      // unknown (no fabricated 1.0 fallback).
+      std::optional<float> selectivity{1.0f};
+      if (!scan->filters().empty()) {
+        const auto sel = conjunctsSelectivity(
+            result.constraints,
+            toSpan(scan->filters()),
+            /*updateConstraints=*/true);
+        selectivity = sel.has_value() ? std::optional<float>{sel->trueFraction}
+                                      : std::nullopt;
+      }
+      if (!baseTable->filteredCardinality.has_value()) {
+        // Filtered-stats pass ran but could not estimate the post-filter row
+        // count (a rejected filter's selectivity was unknown); propagate the
+        // unknown rather than falling back to a fabricated estimate.
+        result.cardinality = std::nullopt;
+      } else if (*baseTable->filteredCardinality > 0) {
+        // Connector filtered-stats pass populated the post-filter row count.
+        result.cardinality = std::max(1.0f, *baseTable->filteredCardinality);
+      } else if (baseTable->schemaTable != nullptr) {
+        // filteredCardinality == 0: no connector stats; fall back to base-table
+        // cardinality scaled by the optimizer's own selectivity.
+        result.cardinality =
+            maxOf(1.0f, mul(baseTable->schemaTable->cardinality, selectivity));
+      } else {
+        // No base-table statistics: cardinality is unknown.
+        result.cardinality = std::nullopt;
+      }
+      return result;
+    }
+
+    case NodeType::kFilter: {
+      const auto* filter = node->as<Filter>();
+      const auto& input = estimate(filter->input());
+      Estimate result;
+      result.constraints = input.constraints;
+      const auto sel = conjunctsSelectivity(
+          result.constraints,
+          toSpan(filter->predicates()),
+          /*updateConstraints=*/true);
+      // Unknown filter selectivity propagates: the output cardinality is
+      // unknown rather than the unfiltered input cardinality.
+      const std::optional<float> selectivity = sel.has_value()
+          ? std::optional<float>{sel->trueFraction}
+          : std::nullopt;
+      result.cardinality = maxOf(1.0f, mul(input.cardinality, selectivity));
+      return result;
+    }
+
+    case NodeType::kAggregate: {
+      const auto* aggregate = node->as<Aggregate>();
+      const auto& input = estimate(aggregate->input());
+      const auto& groupingKeys = aggregate->groupingKeys();
+      Estimate result;
+      if (groupingKeys.empty()) {
+        result.cardinality = 1;
+      } else {
+        // Product of per-key NDVs, capped at the input cardinality. Unknown
+        // propagates: if any grouping key's NDV (or the input cardinality) is
+        // unknown, the group count is unknown.
+        std::optional<float> product{1.0f};
+        for (ExprCP key : groupingKeys) {
+          product = mul(product, value(input.constraints, key).cardinality);
+        }
+        result.cardinality = maxOf(1.0f, minOf(input.cardinality, product));
+      }
+      // An aggregate emits one row per group, so each output column has at most
+      // `cardinality` distinct values. Derive the output-column NDVs so a
+      // consumer over the aggregate reads a real value rather than the unknown
+      // base NDV: grouping keys keep their input NDV clamped to the group
+      // count; aggregate results (which have no meaningful base NDV) take the
+      // group count. Output columns are the grouping keys, then the aggregates,
+      // positionally.
+      const std::optional<float> groupCount = result.cardinality;
+      const auto& outputColumns = aggregate->outputColumns();
+      for (size_t i = 0; i < outputColumns.size(); ++i) {
+        const std::optional<float> ndv = i < groupingKeys.size()
+            ? minOf(
+                  value(input.constraints, groupingKeys[i]).cardinality,
+                  groupCount)
+            : groupCount;
+        result.constraints.insert_or_assign(
+            outputColumns[i]->id(), Value(outputColumns[i]->value().type, ndv));
+      }
+      return result;
+    }
+
+    case NodeType::kLimit: {
+      const auto* limit = node->as<Limit>();
+      const auto& input = estimate(limit->input());
+      Estimate result;
+      result.constraints = input.constraints;
+      result.cardinality = minOf(
+          input.cardinality,
+          std::max(1.0f, static_cast<float>(limit->count())));
+      return result;
+    }
+
+    case NodeType::kTopN: {
+      const auto* topN = node->as<TopN>();
+      const auto& input = estimate(topN->input());
+      Estimate result;
+      result.constraints = input.constraints;
+      result.cardinality = minOf(
+          input.cardinality, std::max(1.0f, static_cast<float>(topN->count())));
+      return result;
+    }
+
+    case NodeType::kUnnest: {
+      const auto* unnest = node->as<Unnest>();
+      const auto& input = estimate(unnest->input());
+      Estimate result;
+      result.constraints = input.constraints;
+      result.cardinality =
+          maxOf(1.0f, mul(input.cardinality, kDefaultUnnestFanout));
+      return result;
+    }
+
+    case NodeType::kUnionAll: {
+      Estimate result;
+      // Sum of children. Unknown propagates: an unknown child cardinality
+      // makes the union cardinality unknown.
+      std::optional<float> total{0.0f};
+      for (NodeCP input : node->inputs()) {
+        total = add(total, estimate(input).cardinality);
+      }
+      result.cardinality = maxOf(1.0f, total);
+      return result;
+    }
+
+    case NodeType::kValues: {
+      const auto* values = node->as<Values>();
+      Estimate result;
+      if (values->rows() != nullptr) {
+        result.cardinality = std::max<float>(1, values->rows()->array().size());
+      } else {
+        result.cardinality = kDefaultLeafCardinality;
+      }
+      return result;
+    }
+
+    case NodeType::kJoin: {
+      const auto* join = node->as<Join>();
+      const auto& left = estimate(join->left());
+      const auto& right = estimate(join->right());
+      Estimate result;
+      mergeConstraints(left.constraints, result.constraints);
+      mergeConstraints(right.constraints, result.constraints);
+
+      // Matched-row count is unknown when any join-key NDV is unknown; that
+      // propagates through to the output cardinality.
+      const std::optional<float> matched = JoinFanout::estimateJoinCardinality(
+          left.cardinality,
+          right.cardinality,
+          join->leftKeys(),
+          join->rightKeys(),
+          result.constraints);
+      const std::optional<float> cardinality = JoinFanout::outputCardinality(
+          join->joinType(), left.cardinality, right.cardinality, matched);
+      result.cardinality = maxOf(1.0f, cardinality);
+      return result;
+    }
+
+    case NodeType::kTableWrite: {
+      // A table write emits a single row-count row.
+      Estimate result;
+      result.cardinality = 1;
+      return result;
+    }
+
+    // Cardinality-neutral operators: pass the input's estimate through.
+    case NodeType::kProject:
+    case NodeType::kSort:
+    case NodeType::kWindow:
+    case NodeType::kTopNRowNumber:
+    case NodeType::kGroupId:
+    case NodeType::kMarkDistinct:
+    case NodeType::kEnforceSingleRow:
+    case NodeType::kAssignUniqueId:
+    case NodeType::kEnforceDistinct:
+    case NodeType::kExchange:
+    case NodeType::kApply: {
+      const auto inputs = node->inputs();
+      if (inputs.empty()) {
+        return Estimate{};
+      }
+      const auto& input = estimate(inputs[0]);
+      Estimate result;
+      result.cardinality = input.cardinality;
+      result.constraints = input.constraints;
+      return result;
+    }
+  }
+  VELOX_UNREACHABLE("EstimateProvider::compute: unhandled NodeType");
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EstimateProvider.h
+++ b/axiom/optimizer/v2/EstimateProvider.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <optional>
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/optimizer/Filters.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Cardinality and per-column constraints of an IR subtree whose shape is
+/// fixed (a join-cluster leaf or barrier subtree, not a set reordered by
+/// DPhyp). `cardinality` is the estimated row count; `constraints` holds the
+/// refined per-column `Value` (ndv, min/max, null/true fraction) keyed by
+/// `expr->id()`, so a downstream join's fanout uses post-filter NDV rather
+/// than base-table NDV. Columns absent from `constraints` fall back to
+/// `Column::value()`.
+struct Estimate {
+  /// Estimated row count; nullopt when unknown. A missing input statistic
+  /// propagates rather than being replaced by a concrete fallback.
+  std::optional<float> cardinality;
+
+  /// Refined per-column `Value` (ndv, min/max, null/true fraction) keyed by
+  /// `expr->id()`. Columns absent here fall back to `Column::value()`.
+  ConstraintMap constraints;
+};
+
+/// Bottom-up cardinality + constraint estimator over the tree IR, memoized by
+/// node, using the shared `conjunctsSelectivity` / `JoinConstraints`
+/// primitives.
+///
+/// One instance is shared across all join clusters of a query (it is keyed
+/// by `NodeCP`, which is globally stable), so a leaf subtree — or a
+/// hash-consed duplicate — is estimated exactly once, and a barrier-subtree
+/// leaf reuses the estimates of the inner cluster it wraps.
+///
+/// Usage: `const Estimate& e = estimateProvider.estimate(node);`
+class EstimateProvider {
+ public:
+  /// Returns the memoized estimate for the subtree rooted at `node`,
+  /// computing it (and its inputs) on first request.
+  const Estimate& estimate(NodeCP node);
+
+ private:
+  // Computes the estimate for `node` from its inputs' estimates.
+  Estimate compute(NodeCP node);
+
+  // Node map for pointer-stable references across recursive insertion.
+  folly::F14NodeMap<NodeCP, Estimate> byNode_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExpandAggregatePass.cpp
+++ b/axiom/optimizer/v2/ExpandAggregatePass.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/optimizer/v2/ExpandAggregatePass.h"
+
+#include <span>
+
+#include <fmt/format.h>
+
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// Appends each non-literal column reference in 'args' to 'keys' if not
+// already present. Used to build a MarkDistinct key set as
+// `groupingKeys ∪ aggregate.args()`. Literals contribute nothing.
+ExprVector unionColumnArgs(const ExprVector& keys, const ExprVector& args) {
+  ExprVector merged = keys;
+  PlanObjectSet seen = PlanObjectSet::fromObjects(keys);
+  for (ExprCP arg : args) {
+    if (arg->is(PlanType::kLiteralExpr)) {
+      continue;
+    }
+    VELOX_CHECK(
+        arg->is(PlanType::kColumnExpr),
+        "Expected column or literal aggregate arg: {}",
+        arg->toString());
+    if (seen.contains(arg)) {
+      continue;
+    }
+    seen.add(arg);
+    merged.push_back(arg);
+  }
+  return merged;
+}
+
+// True when every aggregate shares a single distinct signature: all DISTINCT,
+// no FILTER, no ORDER BY, and the same column arguments. Velox then dedups them
+// in one native distinct aggregation pass (aggregates keep `distinct=true`).
+// Any other mix needs MarkDistinct.
+bool canUseNativeDistinct(const AggregateCallVector& aggregates) {
+  if (aggregates.empty()) {
+    return false;
+  }
+  std::optional<PlanObjectSet> commonArgs;
+  for (const auto* aggregate : aggregates) {
+    if (!aggregate->isDistinct() || aggregate->condition() != nullptr ||
+        !aggregate->orderKeys().empty()) {
+      return false;
+    }
+    PlanObjectSet columnArgs =
+        PlanObjectSet::fromObjects(unionColumnArgs({}, aggregate->args()));
+    if (!commonArgs.has_value()) {
+      commonArgs = std::move(columnArgs);
+    } else if (columnArgs != *commonArgs) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// One MarkDistinct group: all distinct aggregates whose key set
+// `(groupingKeys ∪ args)` equals 'keys'. Within a group, each unique FILTER
+// condition gets its own per-mask marker; aggregates with no FILTER share
+// `markers[0]` (the no-mask marker).
+struct MarkDistinctGroup {
+  ExprVector keys;
+  ColumnVector markers;
+  ColumnVector masks;
+  // Maps each FILTER condition to the marker that records first occurrence
+  // among rows where that condition is true. `nullptr` keys the no-mask
+  // marker (`markers[0]`).
+  folly::F14FastMap<ExprCP, ColumnCP> filterToMarker;
+};
+
+struct DistinctExpansion {
+  NodeCP input;
+  AggregateCallVector aggregates;
+};
+
+class AggregateExpander : public NodeRewriter<> {
+ public:
+  explicit AggregateExpander(Builder& builder) : NodeRewriter(builder) {}
+
+ protected:
+  NodeCP rewriteAggregate(const Aggregate* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+
+    // Grouping-set lowering already ran in translate, so the group-id column
+    // (if any) is one of the grouping keys and MarkDistinct dedup is per
+    // grouping set.
+    AggregateCallVector aggregates = node->aggregates();
+    DistinctExpansion distinct =
+        expandDistinct(newInput, node->groupingKeys(), aggregates);
+    newInput = distinct.input;
+    aggregates = std::move(distinct.aggregates);
+
+    if (newInput == node->input() && aggregates == node->aggregates()) {
+      return node;
+    }
+    return builder().make<Aggregate>(Aggregate::Key{
+        .input = newInput,
+        .groupingKeys = node->groupingKeys(),
+        .aggregates = std::move(aggregates),
+        .outputColumns = node->outputColumns(),
+        .step = node->step(),
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+  }
+
+ private:
+  // Lowers DISTINCT aggregates. When they share a single distinct signature
+  // (see `canUseNativeDistinct`) the aggregates are left as-is for Velox's
+  // native distinct aggregation. Otherwise each unique `(groupingKeys ∪ args)`
+  // set gets a `MarkDistinct` and its aggregates are rewritten as non-distinct
+  // with the marker as their FILTER. Distinct aggregates whose args ⊆
+  // `groupingKeys` are redundant (GROUP BY already dedups) and keep a native
+  // distinct flag without a marker.
+  DistinctExpansion expandDistinct(
+      NodeCP input,
+      const ExprVector& groupingKeys,
+      const AggregateCallVector& aggregates) {
+    if (canUseNativeDistinct(aggregates)) {
+      return {input, aggregates};
+    }
+
+    PlanObjectSet groupingKeySet = PlanObjectSet::fromObjects(groupingKeys);
+    folly::F14VectorMap<PlanObjectSet, MarkDistinctGroup> groups;
+    folly::F14FastMap<const optimizer::Aggregate*, ColumnCP> aggregateToMarker;
+
+    bool anyDistinct = false;
+    for (const auto* aggregate : aggregates) {
+      if (!aggregate->isDistinct()) {
+        continue;
+      }
+      anyDistinct = true;
+
+      ExprVector keys = unionColumnArgs(groupingKeys, aggregate->args());
+      PlanObjectSet keySet = PlanObjectSet::fromObjects(keys);
+      if (keySet == groupingKeySet) {
+        continue;
+      }
+
+      auto [groupIt, isNewGroup] = groups.try_emplace(keySet);
+      auto& group = groupIt->second;
+      if (isNewGroup) {
+        group.keys = std::move(keys);
+        group.markers.push_back(Column::createBoolean("mark"));
+        group.filterToMarker[nullptr] = group.markers.back();
+      }
+
+      ExprCP filter = aggregate->condition();
+      auto [filterIt, isNewFilter] =
+          group.filterToMarker.try_emplace(filter, nullptr);
+      if (isNewFilter) {
+        group.markers.push_back(Column::createBoolean("mark"));
+        filterIt->second = group.markers.back();
+
+        ColumnCP maskColumn = filter->as<Column>();
+        VELOX_CHECK_NOT_NULL(
+            maskColumn,
+            "MarkDistinct mask must be a Column reference; got: {}",
+            filter->toString());
+        group.masks.push_back(maskColumn);
+      }
+      aggregateToMarker[aggregate] = filterIt->second;
+    }
+
+    if (!anyDistinct) {
+      return {input, aggregates};
+    }
+
+    NodeCP currentInput = input;
+    // F14VectorMap iterates in LIFO; reverse to keep insertion order so the
+    // first encountered key set sits closest to the original input.
+    for (auto it = groups.rbegin(); it != groups.rend(); ++it) {
+      auto& group = it->second;
+      ColumnVector outputColumns;
+      outputColumns.reserve(
+          currentInput->outputColumns().size() + group.markers.size());
+      appendAll(outputColumns, currentInput->outputColumns());
+      appendAll(outputColumns, group.markers);
+
+      currentInput = builder().make<MarkDistinct>(MarkDistinct::Key{
+          currentInput,
+          group.markers,
+          group.keys,
+          group.masks,
+          std::move(outputColumns),
+      });
+    }
+
+    AggregateCallVector newAggregates;
+    newAggregates.reserve(aggregates.size());
+    for (const auto* aggregate : aggregates) {
+      if (auto it = aggregateToMarker.find(aggregate);
+          it != aggregateToMarker.end()) {
+        newAggregates.push_back(
+            aggregate->replaceDistinctAndFilterByMarker(it->second));
+      } else {
+        // Either non-distinct, or distinct whose args are all in
+        // `groupingKeys` (per-group dedup is implicit; Velox handles
+        // `distinct=true` natively for the trivial case).
+        newAggregates.push_back(aggregate);
+      }
+    }
+    return {currentInput, std::move(newAggregates)};
+  }
+};
+
+} // namespace
+
+NodeCP ExpandAggregatePass::run(NodeCP root, Builder& builder) {
+  AggregateExpander expander{builder};
+  return expander.rewrite(root);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExpandAggregatePass.h
+++ b/axiom/optimizer/v2/ExpandAggregatePass.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Lowers DISTINCT aggregates into a shape Velox can execute.
+class ExpandAggregatePass {
+ public:
+  /// Returns `root` with each DISTINCT aggregate lowered to
+  /// `Aggregate(MarkDistinct(input, ...))`, where `MarkDistinct` emits a
+  /// boolean marker per unique `(groupingKeys, args)` tuple and each
+  /// `agg(DISTINCT x)` is rewritten to `agg(x) FILTER (marker)`. Aggregates
+  /// that share one distinct signature keep native Velox distinct instead. The
+  /// group-id column of a grouping-set aggregate is already one of the grouping
+  /// keys (grouping sets are lowered to `GroupId` in translate), so distinct
+  /// dedup is per grouping set. Other node shapes pass through unchanged. Runs
+  /// after `PlanPhysicalPass` and `PrecomputeProjectionsPass`, before
+  /// `EmitPass`.
+  static NodeCP run(NodeCP root, Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprEmitter.cpp
+++ b/axiom/optimizer/v2/ExprEmitter.cpp
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ExprEmitter.h"
+
+#include <folly/container/F14Map.h>
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "velox/expression/ExprConstants.h"
+#include "velox/vector/BaseVector.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+const folly::F14FastMap<ColumnNaming, std::string_view>& columnNamingNames() {
+  static const folly::F14FastMap<ColumnNaming, std::string_view> kNames = {
+      {ColumnNaming::kOutputName, "OutputName"},
+      {ColumnNaming::kSchemaName, "SchemaName"},
+  };
+  return kNames;
+}
+
+velox::core::TypedExprPtr columnToTypedExpr(
+    ColumnCP column,
+    ColumnNaming naming) {
+  const std::string name = naming == ColumnNaming::kSchemaName
+      ? std::string{column->name()}
+      : column->outputName();
+  return std::make_shared<velox::core::FieldAccessTypedExpr>(
+      toTypePtr(column->value().type), name);
+}
+
+velox::core::TypedExprPtr literalToTypedExpr(LiteralCP literal) {
+  return std::make_shared<velox::core::ConstantTypedExpr>(
+      toTypePtr(literal->value().type), literal->literal());
+}
+
+// Emits a DEREFERENCE call (resolved at translate time to a numeric field
+// index) as Velox's `DereferenceTypedExpr`.
+velox::core::TypedExprPtr dereferenceToTypedExpr(
+    const Call* call,
+    const std::vector<velox::core::TypedExprPtr>& args) {
+  VELOX_CHECK_EQ(call->args().size(), 2);
+  const auto* index = call->args()[1]->as<Literal>();
+  VELOX_CHECK_NOT_NULL(index);
+  VELOX_CHECK_EQ(index->literal().kind(), velox::TypeKind::INTEGER);
+  return std::make_shared<velox::core::DereferenceTypedExpr>(
+      toTypePtr(call->value().type),
+      args[0],
+      static_cast<uint32_t>(
+          index->literal().value<velox::TypeKind::INTEGER>()));
+}
+
+// Folds an all-literal IN list into `in(col, ARRAY[...])` with one array
+// constant, so Velox binds the set/bitmask-based InPredicate instead of a
+// per-row variadic compare. Returns nullptr when any element is non-literal,
+// leaving the variadic call. Translate folds every single-element IN to
+// equality, so an IN reaching here has >= 2 elements. `column` is the
+// already-lowered first argument.
+velox::core::TypedExprPtr tryLowerConstantIn(
+    const Call* call,
+    const velox::core::TypedExprPtr& column,
+    velox::memory::MemoryPool* pool) {
+  const auto& args = call->args();
+  VELOX_CHECK_GE(args.size(), 3);
+  for (size_t i = 1; i < args.size(); ++i) {
+    if (!args[i]->is(PlanType::kLiteralExpr)) {
+      return nullptr;
+    }
+  }
+
+  const auto elementType = toTypePtr(args[0]->value().type);
+  std::vector<velox::Variant> elements;
+  elements.reserve(args.size() - 1);
+  for (size_t i = 1; i < args.size(); ++i) {
+    elements.push_back(args[i]->as<Literal>()->literal());
+  }
+
+  // Materialize the array through a constant vector, which supports complex
+  // element types.
+  return std::make_shared<velox::core::CallTypedExpr>(
+      velox::BOOLEAN(),
+      specialForm(logical_plan::SpecialForm::kIn),
+      column,
+      std::make_shared<velox::core::ConstantTypedExpr>(
+          velox::BaseVector::createConstant(
+              velox::ARRAY(elementType),
+              velox::Variant::array(elements),
+              1,
+              pool)));
+}
+
+velox::core::TypedExprPtr lambdaToTypedExpr(
+    const Lambda* lambda,
+    const velox::core::TypedExprPtr& body) {
+  std::vector<std::string> names;
+  std::vector<velox::TypePtr> types;
+  names.reserve(lambda->args().size());
+  types.reserve(lambda->args().size());
+  for (ColumnCP arg : lambda->args()) {
+    names.push_back(arg->outputName());
+    types.push_back(toTypePtr(arg->value().type));
+  }
+  return std::make_shared<velox::core::LambdaTypedExpr>(
+      velox::ROW(std::move(names), std::move(types)), body);
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(ColumnNaming, columnNamingNames);
+
+velox::core::TypedExprPtr ExprEmitter::callToTypedExpr(
+    const Call* call,
+    std::vector<velox::core::TypedExprPtr> args) {
+  auto resultType = toTypePtr(call->value().type);
+  if (auto form = SpecialFormCallNames::tryFromCallName(call->name())) {
+    if (form == logical_plan::SpecialForm::kCast) {
+      return std::make_shared<velox::core::CastTypedExpr>(
+          resultType, std::move(args), /*nullOnFailure=*/false);
+    }
+
+    if (form == logical_plan::SpecialForm::kTryCast) {
+      return std::make_shared<velox::core::CastTypedExpr>(
+          resultType, std::move(args), /*nullOnFailure=*/true);
+    }
+
+    if (form == logical_plan::SpecialForm::kDereference) {
+      return dereferenceToTypedExpr(call, args);
+    }
+
+    if (form == logical_plan::SpecialForm::kNullIf) {
+      // args[2] is a null literal whose type is the common comparison
+      // supertype.
+      VELOX_CHECK_EQ(args.size(), 3);
+      return std::make_shared<velox::core::NullIfTypedExpr>(
+          args[0], args[1], args[2]->type());
+    }
+
+    if (form == logical_plan::SpecialForm::kIn) {
+      // An all-literal IN list lowers to `in(col, ARRAY[...])`; a list with any
+      // non-literal element stays a variadic call.
+      if (auto lowered = tryLowerConstantIn(call, args[0], pool_)) {
+        return lowered;
+      }
+    }
+
+    return std::make_shared<velox::core::CallTypedExpr>(
+        resultType, std::move(args), specialForm(*form));
+  }
+
+  return std::make_shared<velox::core::CallTypedExpr>(
+      resultType, std::move(args), std::string{call->name()});
+}
+
+velox::core::TypedExprPtr ExprEmitter::toTypedExpr(
+    ExprCP expr,
+    ColumnNaming naming) {
+  switch (expr->type()) {
+    case PlanType::kColumnExpr:
+      return columnToTypedExpr(expr->as<Column>(), naming);
+    case PlanType::kLiteralExpr:
+      return literalToTypedExpr(expr->as<Literal>());
+    case PlanType::kCallExpr: {
+      const auto* call = expr->as<Call>();
+      std::vector<velox::core::TypedExprPtr> args;
+      args.reserve(call->args().size());
+      for (ExprCP arg : call->args()) {
+        args.push_back(toTypedExpr(arg, naming));
+      }
+      return callToTypedExpr(call, std::move(args));
+    }
+    case PlanType::kLambdaExpr: {
+      const auto* lambda = expr->as<Lambda>();
+      return lambdaToTypedExpr(lambda, toTypedExpr(lambda->body(), naming));
+    }
+    default:
+      VELOX_NYI("Unsupported expression type: {}", expr->typeName());
+  }
+}
+
+std::vector<velox::core::TypedExprPtr> ExprEmitter::toTypedExprs(
+    const ExprVector& exprs,
+    ColumnNaming naming) {
+  std::vector<velox::core::TypedExprPtr> result;
+  result.reserve(exprs.size());
+  for (ExprCP expr : exprs) {
+    result.push_back(toTypedExpr(expr, naming));
+  }
+  return result;
+}
+
+velox::core::TypedExprPtr ExprEmitter::makeAnd(
+    const ExprVector& predicates,
+    ColumnNaming naming) {
+  VELOX_DCHECK(!predicates.empty());
+  if (predicates.size() == 1) {
+    return toTypedExpr(predicates[0], naming);
+  }
+  return std::make_shared<velox::core::CallTypedExpr>(
+      velox::BOOLEAN(),
+      toTypedExprs(predicates, naming),
+      velox::expression::kAnd);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprEmitter.h
+++ b/axiom/optimizer/v2/ExprEmitter.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/common/Enums.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::velox::memory {
+class MemoryPool;
+}
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Selects the name a `Column` lowers to in a Velox `FieldAccessTypedExpr`.
+enum class ColumnNaming {
+  /// `Column::outputName()` (post-rename alias).
+  kOutputName,
+  /// `Column::name()` (underlying table column name).
+  kSchemaName,
+};
+
+AXIOM_DECLARE_ENUM_NAME(ColumnNaming);
+
+/// Converts tree-IR expressions (`ExprCP`) into Velox `core::TypedExpr`s.
+/// Used by Emit to lower expressions inside Filter, Project, and connector
+/// handle construction.
+class ExprEmitter {
+ public:
+  /// 'pool' backs constant vectors materialized during lowering (e.g. the
+  /// array constant of an IN list); it must outlive the emitted plan.
+  explicit ExprEmitter(velox::memory::MemoryPool* pool) : pool_{pool} {}
+
+  /// Lowers a single expression. Recursive; throws VELOX_NYI for expression
+  /// kinds not yet handled.
+  velox::core::TypedExprPtr toTypedExpr(
+      ExprCP expr,
+      ColumnNaming naming = ColumnNaming::kOutputName);
+
+  /// Lowers each expression to a Velox TypedExpr, preserving order.
+  std::vector<velox::core::TypedExprPtr> toTypedExprs(
+      const ExprVector& exprs,
+      ColumnNaming naming = ColumnNaming::kOutputName);
+
+  /// Returns the conjunction of 'predicates'. Calls toTypedExpr() on each
+  /// predicate, wraps with an `and` Velox call if more than one.
+  /// 'predicates' must be non-empty.
+  velox::core::TypedExprPtr makeAnd(
+      const ExprVector& predicates,
+      ColumnNaming naming = ColumnNaming::kOutputName);
+
+ private:
+  // Lowers a `Call`. 'args' are the already-lowered arguments.
+  velox::core::TypedExprPtr callToTypedExpr(
+      const Call* call,
+      std::vector<velox::core::TypedExprPtr> args);
+
+  velox::memory::MemoryPool* const pool_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ExprFactory.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+ExprCP ExprFactory::makeBooleanCall(
+    Name name,
+    ExprVector arguments,
+    bool specialForm) {
+  const Value value(toType(velox::BOOLEAN()), 2);
+  const FunctionSet functions =
+      Call::unionArgFunctions(functionBits(name, specialForm), arguments);
+  return builder_.makeCall(name, value, std::move(arguments), functions);
+}
+
+ExprCP ExprFactory::makeAnd(ExprCP lhs, ExprCP rhs) {
+  return makeBooleanCall(
+      SpecialFormCallNames::kAnd, {lhs, rhs}, /*specialForm=*/true);
+}
+
+namespace {
+
+// Recursively appends conjuncts/disjuncts of `expr` to `out` by
+// descending through calls named `targetName`.
+void flattenInto(ExprCP expr, Name targetName, ExprVector& out) {
+  if (expr->is(PlanType::kCallExpr) && expr->as<Call>()->name() == targetName) {
+    for (ExprCP arg : expr->as<Call>()->args()) {
+      flattenInto(arg, targetName, out);
+    }
+    return;
+  }
+  out.push_back(expr);
+}
+
+} // namespace
+
+ExprVector ExprFactory::flattenAnd(ExprCP expr) {
+  ExprVector conjuncts;
+  flattenInto(expr, SpecialFormCallNames::kAnd, conjuncts);
+  return conjuncts;
+}
+
+void ExprFactory::flattenAnd(ExprCP expr, ExprVector& conjuncts) {
+  flattenInto(expr, SpecialFormCallNames::kAnd, conjuncts);
+}
+
+ExprCP ExprFactory::makeOr(ExprCP lhs, ExprCP rhs) {
+  return makeBooleanCall(
+      SpecialFormCallNames::kOr, {lhs, rhs}, /*specialForm=*/true);
+}
+
+ExprVector ExprFactory::flattenOr(ExprCP expr) {
+  ExprVector disjuncts;
+  flattenInto(expr, SpecialFormCallNames::kOr, disjuncts);
+  return disjuncts;
+}
+
+void ExprFactory::flattenOr(ExprCP expr, ExprVector& disjuncts) {
+  flattenInto(expr, SpecialFormCallNames::kOr, disjuncts);
+}
+
+ExprCP ExprFactory::makeNot(ExprCP arg) {
+  const Name name = builder_.functionNames().negation;
+  VELOX_USER_CHECK_NOT_NULL(
+      name,
+      "ExprFactory::makeNot requires not registered via "
+      "FunctionRegistry::registerNegation; the active dialect did not "
+      "register it");
+  return makeBooleanCall(name, {arg}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeEq(ExprCP lhs, ExprCP rhs) {
+  return makeBooleanCall(
+      builder_.functionNames().equality, {lhs, rhs}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeLessThanOrEqual(ExprCP lhs, ExprCP rhs) {
+  const Name name = builder_.functionNames().lte;
+  VELOX_USER_CHECK_NOT_NULL(
+      name,
+      "ExprFactory::makeLessThanOrEqual requires lessThanOrEqual registered "
+      "via FunctionRegistry::registerLessThanOrEqual; the active dialect did "
+      "not register it");
+  return makeBooleanCall(name, {lhs, rhs}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeIsNull(ExprCP arg) {
+  const Name name = builder_.functionNames().isNull;
+  VELOX_USER_CHECK_NOT_NULL(
+      name,
+      "ExprFactory::makeIsNull requires is_null registered via "
+      "FunctionRegistry::registerIsNull; the active dialect did not "
+      "register it");
+  return makeBooleanCall(name, {arg}, /*specialForm=*/false);
+}
+
+ExprCP ExprFactory::makeCoalesce(ExprCP value, ExprCP fallback) {
+  ExprVector arguments{value, fallback};
+  const Name coalesceName = SpecialFormCallNames::kCoalesce;
+  const Value resultValue = value->value();
+  const FunctionSet functions = Call::unionArgFunctions(
+      functionBits(coalesceName, /*specialForm=*/true), arguments);
+  return builder_.makeCall(
+      coalesceName, resultValue, std::move(arguments), functions);
+}
+
+ExprCP ExprFactory::makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr) {
+  ExprVector arguments{condition, thenExpr, elseExpr};
+  const Name ifName = SpecialFormCallNames::kIf;
+  const Value resultValue = thenExpr->value();
+  const FunctionSet functions = Call::unionArgFunctions(
+      functionBits(ifName, /*specialForm=*/true), arguments);
+  return builder_.makeCall(
+      ifName, resultValue, std::move(arguments), functions);
+}
+
+namespace {
+
+// Rebuilds `call` with each argument substituted, sharing the original
+// when no argument changed. Substituted calls go through `Builder::makeCall`
+// so hash-consing stays canonical.
+ExprCP substituteCall(
+    ExprFactory& factory,
+    Builder& builder,
+    const Call* call,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ExprVector newArgs;
+  newArgs.reserve(call->args().size());
+
+  bool anyChange = false;
+  for (ExprCP arg : call->args()) {
+    ExprCP newArg = factory.substitute(arg, sources, targets);
+    anyChange |= newArg != arg;
+    newArgs.push_back(newArg);
+  }
+
+  if (!anyChange) {
+    return call;
+  }
+
+  const bool specialForm = SpecialFormCallNames::isSpecialForm(call->name());
+  const FunctionSet functions =
+      Call::unionArgFunctions(functionBits(call->name(), specialForm), newArgs);
+  return builder.makeCall(
+      call->name(), call->value(), std::move(newArgs), functions);
+}
+
+// Rebuilds `field` with its base substituted. Field is arena-allocated
+// (not hash-consed in Builder), so it goes through `make`,
+// which is safe in v2-only contexts.
+ExprCP substituteField(
+    ExprFactory& factory,
+    const Field* field,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ExprCP newBase = factory.substitute(field->base(), sources, targets);
+  if (newBase == field->base()) {
+    return field;
+  }
+  if (field->field() != nullptr) {
+    return make<Field>(field->value().type, newBase, field->field());
+  }
+  return make<Field>(field->value().type, newBase, field->index());
+}
+
+// Rebuilds `lambda` with its body substituted. The lambda's bound args
+// shadow any same-named outer column, so they are removed from the
+// source mapping before recursing — a caller's substitution set can't
+// rebind them.
+ExprCP substituteLambda(
+    ExprFactory& factory,
+    const Lambda* lambda,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ColumnVector filteredSources;
+  ExprVector filteredTargets;
+  filteredSources.reserve(sources.size());
+  filteredTargets.reserve(targets.size());
+  const auto& boundArgs = lambda->args();
+  for (size_t i = 0; i < sources.size(); ++i) {
+    bool isBound = false;
+    for (ColumnCP boundArg : boundArgs) {
+      if (boundArg == sources[i]) {
+        isBound = true;
+        break;
+      }
+    }
+    if (!isBound) {
+      filteredSources.push_back(sources[i]);
+      filteredTargets.push_back(targets[i]);
+    }
+  }
+  ExprCP newBody =
+      factory.substitute(lambda->body(), filteredSources, filteredTargets);
+  if (newBody == lambda->body()) {
+    return lambda;
+  }
+  return make<Lambda>(lambda->args(), lambda->value().type, newBody);
+}
+
+} // namespace
+
+ExprCP ExprFactory::substitute(
+    ExprCP expr,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  if (expr == nullptr) {
+    return nullptr;
+  }
+  switch (expr->type()) {
+    case PlanType::kColumnExpr: {
+      for (size_t i = 0; i < sources.size(); ++i) {
+        if (sources[i] == expr) {
+          return targets[i];
+        }
+      }
+      return expr;
+    }
+    case PlanType::kLiteralExpr:
+      return expr;
+    case PlanType::kCallExpr:
+      return substituteCall(
+          *this, builder_, expr->as<Call>(), sources, targets);
+    case PlanType::kFieldExpr:
+      return substituteField(*this, expr->as<Field>(), sources, targets);
+    case PlanType::kLambdaExpr:
+      return substituteLambda(*this, expr->as<Lambda>(), sources, targets);
+    default:
+      VELOX_NYI(
+          "ExprFactory::substitute: unsupported expression type {}",
+          expr->typeName());
+  }
+}
+
+ExprVector ExprFactory::substitute(
+    const ExprVector& exprs,
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  ExprVector substituted;
+  substituted.reserve(exprs.size());
+  for (ExprCP expr : exprs) {
+    substituted.push_back(substitute(expr, sources, targets));
+  }
+  return substituted;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Constructors for the recurring `Call` expression shapes that
+/// translate, decorrelate, and downstream rewrites need. Holds a
+/// `Builder&` so hash-cons construction goes through the right cache;
+/// construct one per logical "rewrite context" (typically once per
+/// pass / per `Translator`).
+///
+/// Column synthesis lives on the `Column` class itself
+/// (`Column::create(prefix, value)`) since `Column` is arena-allocated,
+/// not hash-consed via `Builder`.
+///
+/// New combinators belong here, not as free functions scattered across
+/// caller files. Each method enforces the shared invariants (correct
+/// `FunctionSet` propagation via `Call::unionArgFunctions`, function
+/// names sourced from `FunctionRegistry`, cardinality conventions for
+/// boolean results) so call sites can't get them wrong.
+///
+/// Combinators do not null-handle their operands; callers that pass
+/// optional predicates should null-check before delegating. Methods
+/// that source their function name from `FunctionRegistry` throw
+/// `VELOX_USER_CHECK` if the active dialect did not register that
+/// function.
+class ExprFactory {
+ public:
+  explicit ExprFactory(Builder& builder) : builder_(builder) {}
+
+  /// Flattens an AND tree into conjuncts. `expr` may be an AND call
+  /// (nested arbitrarily) or any other expression (appended as a
+  /// single conjunct).
+  static ExprVector flattenAnd(ExprCP expr);
+  static void flattenAnd(ExprCP expr, ExprVector& conjuncts);
+
+  /// Flattens an OR tree into disjuncts. `expr` may be an OR call
+  /// (nested arbitrarily) or any other expression (appended as a
+  /// single disjunct).
+  static ExprVector flattenOr(ExprCP expr);
+  static void flattenOr(ExprCP expr, ExprVector& disjuncts);
+
+  /// Builds `lhs AND rhs`.
+  ExprCP makeAnd(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `lhs OR rhs`.
+  ExprCP makeOr(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `not(arg)`. Preserves three-valued logic: `not(NULL)` is
+  /// NULL. Used to turn a semi-project mark into the antijoin predicate.
+  ExprCP makeNot(ExprCP arg);
+
+  /// Builds `lhs = rhs`.
+  ExprCP makeEq(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `lhs <= rhs`.
+  ExprCP makeLessThanOrEqual(ExprCP lhs, ExprCP rhs);
+
+  /// Builds `is_null(arg)`. Result is BOOLEAN and is never NULL —
+  /// returns `true` when 'arg' is NULL and `false` otherwise.
+  ExprCP makeIsNull(ExprCP arg);
+
+  /// Builds `coalesce(value, fallback)`. Both operands must be of the
+  /// same type per Velox's COALESCE rules; the factory does not verify.
+  ExprCP makeCoalesce(ExprCP value, ExprCP fallback);
+
+  /// Builds `if(condition, thenExpr, elseExpr)`. `thenExpr` and
+  /// `elseExpr` must be the same type per Velox's IF rules; the factory
+  /// does not verify.
+  ExprCP makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr);
+
+  /// Substitutes the i-th source `Column*` with the i-th `target`
+  /// Expr in `expr`, returning a rewritten Expr. Handles
+  /// Column/Literal/Call/Field/Lambda. Columns not in `sources` pass
+  /// through unchanged. `Call`s with at least one substituted child
+  /// are rebuilt through `Builder::makeCall` so hash-consing remains
+  /// canonical; Field/Lambda are rebuilt through `make`
+  /// (arena allocator, no dedup table). For Lambda, bound args are
+  /// removed from the source mapping before recursing into the body
+  /// — callers don't need to filter them out.
+  ///
+  /// `kAggregateExpr` substitution is not implemented (aggregates only
+  /// live inside `Aggregate` nodes, not embedded in scalar expressions
+  /// we substitute through); throws `VELOX_NYI` if encountered.
+  ExprCP substitute(
+      ExprCP expr,
+      const ColumnVector& sources,
+      const ExprVector& targets);
+
+  /// Applies `substitute` to each element of `exprs`, returning the
+  /// rewritten vector in the same order.
+  ExprVector substitute(
+      const ExprVector& exprs,
+      const ColumnVector& sources,
+      const ExprVector& targets);
+
+  /// Left-folds a non-empty sequence of boolean predicates with
+  /// `makeAnd`: `[p1, p2, p3]` → `AND(AND(p1, p2), p3)`. Single-element
+  /// input returns the predicate unchanged. The empty case is a
+  /// caller error (no neutral element is constructed).
+  template <typename Range>
+  ExprCP andAll(const Range& predicates) {
+    auto it = std::begin(predicates);
+    auto end = std::end(predicates);
+    VELOX_CHECK(it != end, "andAll requires a non-empty sequence");
+    ExprCP result = *it++;
+    for (; it != end; ++it) {
+      result = makeAnd(result, *it);
+    }
+    return result;
+  }
+
+  /// Left-folds a non-empty sequence of boolean predicates with
+  /// `makeOr`. Single-element input returns the predicate unchanged.
+  /// The empty case is a caller error.
+  template <typename Range>
+  ExprCP orAll(const Range& predicates) {
+    auto it = std::begin(predicates);
+    auto end = std::end(predicates);
+    VELOX_CHECK(it != end, "orAll requires a non-empty sequence");
+    ExprCP result = *it++;
+    for (; it != end; ++it) {
+      result = makeOr(result, *it);
+    }
+    return result;
+  }
+
+ private:
+  // Builds a BOOLEAN-typed (cardinality 2) call named `name` over
+  // `arguments`, seeding the `FunctionSet` from the function's own bits
+  // (`specialForm` selects special-form vs registered-function lookup)
+  // OR'd with each argument's.
+  ExprCP makeBooleanCall(Name name, ExprVector arguments, bool specialForm);
+
+  Builder& builder_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprSimplifier.cpp
+++ b/axiom/optimizer/v2/ExprSimplifier.cpp
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ExprSimplifier.h"
+
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/ExprEmitter.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "velox/expression/ConstantExpr.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// If `orExpr` is an OR call and its disjuncts share AND-conjuncts,
+// appends those common conjuncts to `common` and sets `*residual` to
+// the rewritten OR (or nullptr when a disjunct was fully subsumed and
+// the OR is trivially true once `common` holds). Returns true iff
+// any factoring was performed; on false, `common` and `*residual`
+// are unmodified.
+bool tryFactorOr(
+    Builder& builder,
+    ExprCP orExpr,
+    ExprVector& common,
+    ExprCP* residual) {
+  if (!orExpr->is(PlanType::kCallExpr) ||
+      orExpr->as<Call>()->name() != SpecialFormCallNames::kOr) {
+    return false;
+  }
+  ExprVector disjuncts = ExprFactory::flattenOr(orExpr);
+
+  // Dedup disjuncts. Hash-cons guarantees pointer equality for
+  // structurally identical exprs.
+  folly::F14FastSet<ExprCP> seen;
+  ExprVector uniqueDisjuncts;
+  uniqueDisjuncts.reserve(disjuncts.size());
+  for (ExprCP disjunct : disjuncts) {
+    if (seen.insert(disjunct).second) {
+      uniqueDisjuncts.push_back(disjunct);
+    }
+  }
+  if (uniqueDisjuncts.size() < 2) {
+    return false;
+  }
+
+  // Flatten each disjunct into its AND-conjuncts.
+  std::vector<ExprVector> perDisjunctConjuncts;
+  perDisjunctConjuncts.reserve(uniqueDisjuncts.size());
+  for (ExprCP disjunct : uniqueDisjuncts) {
+    perDisjunctConjuncts.push_back(ExprFactory::flattenAnd(disjunct));
+  }
+
+  // Intersect across all disjuncts.
+  folly::F14FastSet<ExprCP> commonSet(
+      perDisjunctConjuncts[0].begin(), perDisjunctConjuncts[0].end());
+  for (size_t i = 1; i < perDisjunctConjuncts.size(); ++i) {
+    folly::F14FastSet<ExprCP> next(
+        perDisjunctConjuncts[i].begin(), perDisjunctConjuncts[i].end());
+    folly::F14FastSet<ExprCP> intersected;
+    for (ExprCP conjunct : commonSet) {
+      if (next.contains(conjunct)) {
+        intersected.insert(conjunct);
+      }
+    }
+    commonSet = std::move(intersected);
+  }
+  if (commonSet.empty()) {
+    return false;
+  }
+
+  // Build residuals; any empty residual means that disjunct is fully
+  // subsumed by `common`, so the OR is trivially true given `common`.
+  ExprFactory factory(builder);
+  ExprVector residualDisjuncts;
+  residualDisjuncts.reserve(uniqueDisjuncts.size());
+  bool subsumed = false;
+  for (auto& conjuncts : perDisjunctConjuncts) {
+    ExprVector remaining;
+    remaining.reserve(conjuncts.size());
+    for (ExprCP conjunct : conjuncts) {
+      if (!commonSet.contains(conjunct)) {
+        remaining.push_back(conjunct);
+      }
+    }
+    if (remaining.empty()) {
+      subsumed = true;
+      break;
+    }
+    residualDisjuncts.push_back(factory.andAll(remaining));
+  }
+
+  // Append common in first-disjunct order to keep deterministic output.
+  for (ExprCP conjunct : perDisjunctConjuncts[0]) {
+    if (commonSet.contains(conjunct)) {
+      common.push_back(conjunct);
+    }
+  }
+  *residual = subsumed ? nullptr : factory.orAll(residualDisjuncts);
+  return true;
+}
+
+} // namespace
+
+ExprCP ExprSimplifier::simplify(ExprCP expr) {
+  return tryFoldConstant(expr);
+}
+
+bool ExprSimplifier::simplifyFilter(ExprCP predicate, ExprVector& into) {
+  ExprVector flattened = ExprFactory::flattenAnd(predicate);
+  ExprVector surviving;
+  surviving.reserve(flattened.size());
+  for (ExprCP conjunct : flattened) {
+    ExprCP simplified = simplify(conjunct);
+    if (simplified->is(PlanType::kLiteralExpr)) {
+      const auto& variant = simplified->as<Literal>()->literal();
+      VELOX_CHECK_EQ(
+          variant.kind(),
+          velox::TypeKind::BOOLEAN,
+          "Conjunct simplified to a non-boolean literal");
+      if (variant.isNull() || !variant.value<bool>()) {
+        return true;
+      }
+      // Literal `true` — drop.
+      continue;
+    }
+    ExprCP residual = nullptr;
+    if (tryFactorOr(builder_, simplified, surviving, &residual)) {
+      if (residual != nullptr) {
+        surviving.push_back(residual);
+      }
+      continue;
+    }
+    surviving.push_back(simplified);
+  }
+  appendAll(into, surviving);
+  return false;
+}
+
+ExprCP ExprSimplifier::tryFoldConstant(ExprCP expr) {
+  if (expr->is(PlanType::kLiteralExpr)) {
+    return expr;
+  }
+
+  if (!expr->columns().empty()) {
+    return expr;
+  }
+
+  try {
+    auto typedExpr = ExprEmitter{evaluator_.pool()}.toTypedExpr(expr);
+    auto exprSet = evaluator_.compile(typedExpr);
+    const auto& first = *exprSet->exprs().front();
+    if (!first.isConstant()) {
+      return expr;
+    }
+    const auto& constantExpr =
+        static_cast<const velox::exec::ConstantExpr&>(first);
+    auto variant = constantExpr.value()->variantAt(0);
+    Value value(toType(constantExpr.type()), 1);
+    auto* registered = queryCtx()->registerVariant(
+        std::make_unique<velox::Variant>(std::move(variant)));
+    return builder_.makeLiteral(value, registered);
+  } catch (const velox::VeloxException&) {
+    // Data-dependent evaluation failure on constant args (e.g.
+    // division-by-zero, invalid cast). Leave the call unchanged so the
+    // error surfaces at execution.
+    return expr;
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprSimplifier.h
+++ b/axiom/optimizer/v2/ExprSimplifier.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "velox/core/ExpressionEvaluator.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Reduces expressions to simpler equivalent forms — today constant
+/// folding of column-free expressions; algebraic and boolean identities
+/// (`a + 0 → a`, `true AND f → f`, …) plug in as the rule set grows.
+///
+/// `evaluator` must outlive this `ExprSimplifier` and any IR it
+/// produces: folded constants register `Variant`s in the
+/// `QueryGraphContext`, but vectors produced during compilation are
+/// allocated on the evaluator's pool and may be referenced by Velox
+/// plan nodes that emit later constructs from the same IR.
+class ExprSimplifier {
+ public:
+  ExprSimplifier(Builder& builder, velox::core::ExpressionEvaluator& evaluator)
+      : builder_(builder), evaluator_(evaluator) {}
+
+  /// Returns the simplified `expr`, or `expr` unchanged if no rule
+  /// applies.
+  ExprCP simplify(ExprCP expr);
+
+  /// Splits a filter `predicate` into conjuncts (AND-flattened),
+  /// simplifies each, and applies filter semantics: a literal `true`
+  /// conjunct is dropped; a literal `false` or `NULL` conjunct
+  /// short-circuits (filter passes only on `TRUE`, so `NULL` is
+  /// equivalent to `FALSE`).
+  ///
+  /// Returns true iff the filter is statically known to drop every
+  /// row; on true return `into` is unmodified. Returns false
+  /// otherwise and appends the surviving (flattened, simplified,
+  /// non-trivial) conjuncts to `into`. An empty `into` after a false
+  /// return means `predicate` is statically `true` and the filter can
+  /// be removed.
+  bool simplifyFilter(ExprCP predicate, ExprVector& into);
+
+ private:
+  // Folds `expr` to a `Literal` when it has no column refs and the
+  // evaluator produces a single constant value. Otherwise returns
+  // `expr` unchanged.
+  ExprCP tryFoldConstant(ExprCP expr);
+
+  Builder& builder_;
+  velox::core::ExpressionEvaluator& evaluator_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/HypergraphBuilder.cpp
+++ b/axiom/optimizer/v2/HypergraphBuilder.cpp
@@ -1,0 +1,594 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/HypergraphBuilder.h"
+
+#include <map>
+#include <set>
+
+#include <folly/container/F14Map.h>
+#include <folly/container/F14Set.h>
+
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/AlgebraicProperties.h"
+#include "axiom/optimizer/v2/Cost.h"
+#include "axiom/optimizer/v2/EstimateProvider.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// Cluster leaves whose columns `expression` references.
+RelationSet expressionRelations(
+    ExprCP expression,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf) {
+  RelationSet result;
+  expression->columns().forEach<Column>([&](ColumnCP column) {
+    const auto it = columnToLeaf.find(column);
+    VELOX_CHECK(
+        it != columnToLeaf.end(),
+        "Expression references a column not produced by any cluster leaf: {}",
+        column->toString());
+    result.add(it->second);
+  });
+  return result;
+}
+
+RelationSet unionExpressionRelations(
+    const ExprVector& expressions,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf) {
+  RelationSet result;
+  for (ExprCP expression : expressions) {
+    result.unionSet(expressionRelations(expression, columnToLeaf));
+  }
+  return result;
+}
+
+// Per-Join leaf covers of left and right operands, with the
+// kRight-to-kLeft normalization baked in: for an IR `kRight`
+// join, `left`/`right` are swapped and `joinType` is `kLeft`.
+// The rest of the pipeline never sees `kRight`.
+struct JoinLeaves {
+  RelationSet left;
+  RelationSet right;
+  velox::core::JoinType joinType;
+};
+
+// Returns the subtree leaves of `node`; populates `leaves[J]` for
+// every Join `J` reached during the walk. For an IR `kRight` join,
+// `leaves[J]` records the swapped operands and `joinType = kLeft`.
+// Unnest nodes are not in `leafIds`; descend into `input()`.
+RelationSet populateJoinLeaves(
+    NodeCP node,
+    const folly::F14FastMap<NodeCP, int8_t>& leafIds,
+    folly::F14FastMap<JoinCP, JoinLeaves>& leaves) {
+  const auto it = leafIds.find(node);
+  if (it != leafIds.end()) {
+    return RelationSet::singleton(it->second);
+  }
+  if (node->is(NodeType::kUnnest)) {
+    return populateJoinLeaves(node->as<Unnest>()->input(), leafIds, leaves);
+  }
+  const auto* join = node->as<Join>();
+  const RelationSet leftLeaves =
+      populateJoinLeaves(join->left(), leafIds, leaves);
+  const RelationSet rightLeaves =
+      populateJoinLeaves(join->right(), leafIds, leaves);
+  // Normalize right-form joins to their left form by swapping operands.
+  // kRight, kRightSemiFilter and kRightSemiProject each map to the
+  // matching left-form type; the rest of the pipeline never sees a
+  // right-form join.
+  switch (join->joinType()) {
+    case velox::core::JoinType::kRight:
+      leaves[join] = JoinLeaves{
+          .left = rightLeaves,
+          .right = leftLeaves,
+          .joinType = velox::core::JoinType::kLeft};
+      break;
+    case velox::core::JoinType::kRightSemiFilter:
+      leaves[join] = JoinLeaves{
+          .left = rightLeaves,
+          .right = leftLeaves,
+          .joinType = velox::core::JoinType::kLeftSemiFilter};
+      break;
+    case velox::core::JoinType::kRightSemiProject:
+      leaves[join] = JoinLeaves{
+          .left = rightLeaves,
+          .right = leftLeaves,
+          .joinType = velox::core::JoinType::kLeftSemiProject};
+      break;
+    default:
+      leaves[join] = JoinLeaves{
+          .left = leftLeaves,
+          .right = rightLeaves,
+          .joinType = join->joinType()};
+  }
+  RelationSet subtree{leftLeaves};
+  subtree.unionSet(rightLeaves);
+  return subtree;
+}
+
+// Returns the leaves an ancestor join must add to its TES to keep
+// unsound reshapes blocked over `node`'s descendant joins. `node`
+// is in the ancestor's LEFT subtree iff `leftSide` is true.
+// `parentType` is the (already-kRight-normalized) join type of
+// the ancestor.
+RelationSet tesExpansion(
+    NodeCP node,
+    velox::core::JoinType parentType,
+    const RelationSet& parentSes,
+    bool leftSide,
+    const folly::F14FastMap<NodeCP, int8_t>& leafIds,
+    const folly::F14FastMap<JoinCP, JoinLeaves>& leaves) {
+  if (leafIds.contains(node)) {
+    return RelationSet{};
+  }
+  if (node->is(NodeType::kUnnest)) {
+    return tesExpansion(
+        node->as<Unnest>()->input(),
+        parentType,
+        parentSes,
+        leftSide,
+        leafIds,
+        leaves);
+  }
+
+  const auto* childJoin = node->as<Join>();
+  const auto& childLeaves = leaves.at(childJoin);
+
+  // CD-A: for a LEFT-subtree descendant the M/N table is keyed
+  // `(child, parent)`. For a RIGHT-subtree descendant the roles
+  // flip to `(parent, child)`. `childLeaves.joinType` is already
+  // normalized (never kRight).
+  auto props = leftSide
+      ? AlgebraicProperties::derive(childLeaves.joinType, parentType)
+      : AlgebraicProperties::derive(parentType, childLeaves.joinType);
+
+  // When the parent's referenced relations overlap a child
+  // operand that the equivalence's syntactic precondition
+  // forbids, the equivalence breaks; downgrade that property.
+  // Skip for inner-over-inner where commutativity makes the
+  // equivalences hold regardless of predicate placement.
+  const bool involvesOuter =
+      childLeaves.joinType != velox::core::JoinType::kInner ||
+      parentType != velox::core::JoinType::kInner;
+  if (involvesOuter) {
+    if (leftSide) {
+      if (parentSes.hasIntersection(childLeaves.left)) {
+        props.associative = false;
+      }
+      if (parentSes.hasIntersection(childLeaves.right)) {
+        props.leftAsscom = false;
+      }
+    } else {
+      if (parentSes.hasIntersection(childLeaves.right)) {
+        props.associative = false;
+      }
+      if (parentSes.hasIntersection(childLeaves.left)) {
+        props.rightAsscom = false;
+      }
+    }
+  }
+
+  RelationSet expansion;
+  if (leftSide) {
+    if (!props.leftAsscom) {
+      expansion.unionSet(childLeaves.right);
+    }
+    if (!props.associative) {
+      expansion.unionSet(childLeaves.left);
+    }
+  } else {
+    if (!props.rightAsscom) {
+      expansion.unionSet(childLeaves.left);
+    }
+    if (!props.associative) {
+      expansion.unionSet(childLeaves.right);
+    }
+  }
+  expansion.unionSet(tesExpansion(
+      childJoin->left(), parentType, parentSes, leftSide, leafIds, leaves));
+  expansion.unionSet(tesExpansion(
+      childJoin->right(), parentType, parentSes, leftSide, leafIds, leaves));
+  return expansion;
+}
+
+std::pair<int8_t, int8_t> orderedPair(int8_t a, int8_t b) {
+  return a < b ? std::make_pair(a, b) : std::make_pair(b, a);
+}
+
+// Adds equi-join edges implied by transitivity of inner equality. Given a chain
+// of inner column equalities (a = b, b = c, ...), every pair (a = c) also
+// holds, so a derived edge connects relations the written predicates leave only
+// transitively linked. DPhyp can then attach a sub-join to either end of an
+// equality chain — e.g. the nation/region filter to customer rather than only
+// supplier in TPC-H q5 — instead of being forced through the single written
+// path. Only inner equalities participate; an outer join's null-padding breaks
+// the transitivity, and those keys are skipped.
+//
+// The equality classes are recorded on the shared `Column::equivalence`, so the
+// cost model can later read them back (via `Column::equivalence`) to count a
+// transitive equality's selectivity once across same-class edges at a join.
+void addTransitiveInnerEdges(
+    JoinHypergraph& graph,
+    const JoinCluster& cluster,
+    const folly::F14FastMap<ColumnCP, int8_t>& columnToLeaf) {
+  std::vector<ColumnCP> equatedColumns;
+  folly::F14FastSet<ColumnCP> seenColumns;
+  for (JoinCP join : cluster.joins) {
+    if (!join->isInner()) {
+      continue;
+    }
+    for (size_t i = 0; i < join->leftKeys().size(); ++i) {
+      ExprCP leftKey = join->leftKeys()[i];
+      ExprCP rightKey = join->rightKeys()[i];
+      if (leftKey->isColumn() && rightKey->isColumn()) {
+        const auto left = leftKey->as<Column>();
+        const auto right = rightKey->as<Column>();
+        if (seenColumns.insert(left).second) {
+          equatedColumns.push_back(left);
+        }
+        if (seenColumns.insert(right).second) {
+          equatedColumns.push_back(right);
+        }
+      }
+    }
+  }
+
+  // Relation pairs already joined by a single-relation inner equi-edge; a
+  // derived edge for such a pair would duplicate the equality and double-count
+  // its selectivity, so it is skipped.
+  std::set<std::pair<int8_t, int8_t>> connected;
+  for (const auto& edge : graph.edges()) {
+    if (edge.joinType() == velox::core::JoinType::kInner &&
+        edge.left().size() == 1 && edge.right().size() == 1) {
+      connected.insert(orderedPair(
+          static_cast<int8_t>(edge.left().min()),
+          static_cast<int8_t>(edge.right().min())));
+    }
+  }
+
+  // Group the equality classes, keeping one representative column per relation.
+  // `classOrder` records first-seen order (from the deterministic
+  // `equatedColumns`) so edges are added in a stable order: `classReps` is
+  // hashed on a pointer, whose iteration order is non-deterministic, and the
+  // edge-addition order fixes edge indices, which feed DPhyp's candidate
+  // tiebreak.
+  folly::F14FastMap<EquivalenceP, std::map<int8_t, ColumnCP>> classReps;
+  std::vector<EquivalenceP> classOrder;
+  for (ColumnCP column : equatedColumns) {
+    const auto leafIt = columnToLeaf.find(column);
+    if (leafIt != columnToLeaf.end()) {
+      auto [it, inserted] = classReps.try_emplace(column->equivalence());
+      if (inserted) {
+        classOrder.push_back(column->equivalence());
+      }
+      it->second.emplace(leafIt->second, column);
+    }
+  }
+
+  // Connect every relation pair within each class that is not already joined.
+  for (EquivalenceP root : classOrder) {
+    const std::map<int8_t, ColumnCP>& repByRelation = classReps.at(root);
+    for (auto a = repByRelation.begin(); a != repByRelation.end(); ++a) {
+      for (auto b = std::next(a); b != repByRelation.end(); ++b) {
+        if (!connected.insert(orderedPair(a->first, b->first)).second) {
+          continue;
+        }
+        const RelationSet leftSet = RelationSet::singleton(a->first);
+        const RelationSet rightSet = RelationSet::singleton(b->first);
+        const ExprVector leftKeys{a->second};
+        const ExprVector rightKeys{b->second};
+        RelationSet tes{leftSet};
+        tes.unionSet(rightSet);
+        graph.addEdge(
+            JoinEdge{
+                leftSet,
+                rightSet,
+                leftKeys,
+                rightKeys,
+                ExprVector{},
+                velox::core::JoinType::kInner,
+                /*nullAware=*/false,
+                /*nullAsValue=*/false},
+            tes);
+      }
+    }
+  }
+}
+
+} // namespace
+
+JoinHypergraph HypergraphBuilder::build(
+    const JoinCluster& cluster,
+    const std::vector<NodeCP>& rewrittenLeaves,
+    EstimateProvider& estimateProvider) {
+  VELOX_CHECK_LE(
+      cluster.leaves.size(),
+      RelationSet::kMaxRelations,
+      "Cluster has more leaves than RelationSet can represent");
+  VELOX_CHECK_EQ(
+      cluster.leaves.size(),
+      rewrittenLeaves.size(),
+      "rewrittenLeaves must align 1:1 with cluster.leaves");
+
+  JoinHypergraph graph;
+  folly::F14FastMap<ColumnCP, int8_t> columnToLeaf;
+  folly::F14FastMap<NodeCP, int8_t> leafIds;
+  for (size_t i = 0; i < cluster.leaves.size(); ++i) {
+    NodeCP original = cluster.leaves[i];
+    NodeCP rewritten = rewrittenLeaves[i];
+    PlanObjectSet columns;
+    for (const auto* column : rewritten->outputColumns()) {
+      columns.add(column);
+    }
+    const int8_t id = graph.addRelation(
+        rewritten,
+        estimateProvider.estimate(rewritten).cardinality,
+        std::move(columns));
+    VELOX_CHECK(leafIds.emplace(original, id).second, "Duplicate cluster leaf");
+    if (rewritten != original) {
+      VELOX_CHECK(
+          leafIds.emplace(rewritten, id).second,
+          "Duplicate rewritten cluster leaf");
+    }
+    for (const auto* column : rewritten->outputColumns()) {
+      columnToLeaf.emplace(column, id);
+    }
+  }
+
+  // Admit Unnest relations and extend the column-resolution map so the
+  // Unnest's produced columns resolve to the Unnest's relation id.
+  // Innermost first, so a dependent Unnest sees the Unnest feeding its
+  // input already registered.
+  folly::F14FastMap<UnnestCP, int8_t> unnestIds;
+  for (UnnestCP unnest : cluster.unnests) {
+    PlanObjectSet producedColumns;
+    for (const auto& columnsForExpr : unnest->unnestColumns()) {
+      for (const auto* column : columnsForExpr) {
+        producedColumns.add(column);
+      }
+    }
+    if (unnest->ordinalityColumn() != nullptr) {
+      producedColumns.add(unnest->ordinalityColumn());
+    }
+    const std::optional<float> cardinality =
+        mul(estimateProvider.estimate(unnest->input()).cardinality,
+            kDefaultUnnestFanout);
+    const int8_t id =
+        graph.addUnnestRelation(unnest, cardinality, producedColumns);
+    unnestIds.emplace(unnest, id);
+    for (const auto& columnsForExpr : unnest->unnestColumns()) {
+      for (const auto* column : columnsForExpr) {
+        columnToLeaf.emplace(column, id);
+      }
+    }
+    if (unnest->ordinalityColumn() != nullptr) {
+      columnToLeaf.emplace(unnest->ordinalityColumn(), id);
+    }
+  }
+
+  // Build the directed cross-join-unnest edge for each Unnest, and record
+  // its input relations (the relation ids its input subtree contributes,
+  // resolved via the now-complete columnToLeaf) for the outer-join barrier
+  // applied in the cluster-join loop.
+  folly::F14FastMap<int8_t, RelationSet> unnestInputRelations;
+  for (UnnestCP unnest : cluster.unnests) {
+    const int8_t id = unnestIds.at(unnest);
+    RelationSet inputRelations;
+    for (const auto* column : unnest->input()->outputColumns()) {
+      const auto it = columnToLeaf.find(column);
+      if (it != columnToLeaf.end()) {
+        inputRelations.add(it->second);
+      }
+    }
+    VELOX_CHECK(
+        !inputRelations.empty(),
+        "Unnest input subtree must contribute at least one cluster relation");
+    unnestInputRelations.emplace(id, inputRelations);
+
+    RelationSet tes{inputRelations};
+    tes.add(id);
+    graph.addEdge(
+        JoinEdge{
+            inputRelations,
+            RelationSet::singleton(id),
+            unnest->unnestExpressions()},
+        tes);
+  }
+
+  folly::F14FastMap<JoinCP, JoinLeaves> joinLeaves;
+  populateJoinLeaves(cluster.root, leafIds, joinLeaves);
+
+  for (JoinCP join : cluster.joins) {
+    const auto& leaves = joinLeaves.at(join);
+    if (join->isInner()) {
+      // Group keys by endpoint relation-pair and emit one edge per group.
+      // Keys sharing an endpoint (a composite key) stay on one edge so
+      // their combined selectivity is preserved; keys with different
+      // endpoints become separate edges, so two relations are not forced
+      // co-located by a single hyperedge.
+      std::map<std::pair<uint64_t, uint64_t>, std::vector<size_t>>
+          keysByEndpoint;
+      for (size_t i = 0; i < join->leftKeys().size(); ++i) {
+        const RelationSet leftKeyRelations{
+            expressionRelations(join->leftKeys()[i], columnToLeaf)};
+        const RelationSet rightKeyRelations{
+            expressionRelations(join->rightKeys()[i], columnToLeaf)};
+        keysByEndpoint[{leftKeyRelations.bits(), rightKeyRelations.bits()}]
+            .push_back(i);
+      }
+
+      for (const auto& [endpoint, keyIndices] : keysByEndpoint) {
+        ExprVector leftKeys;
+        ExprVector rightKeys;
+        for (size_t i : keyIndices) {
+          leftKeys.push_back(join->leftKeys()[i]);
+          rightKeys.push_back(join->rightKeys()[i]);
+        }
+        const RelationSet leftSet{
+            unionExpressionRelations(leftKeys, columnToLeaf)};
+        const RelationSet rightSet{
+            unionExpressionRelations(rightKeys, columnToLeaf)};
+        RelationSet ses{leftSet};
+        ses.unionSet(rightSet);
+        RelationSet tes{ses};
+        tes.unionSet(tesExpansion(
+            join->left(),
+            join->joinType(),
+            ses,
+            /*leftSide=*/true,
+            leafIds,
+            joinLeaves));
+        tes.unionSet(tesExpansion(
+            join->right(),
+            join->joinType(),
+            ses,
+            /*leftSide=*/false,
+            leafIds,
+            joinLeaves));
+
+        // Consumer edges that reference an Unnest produced column must
+        // wait until the Unnest's input relations are in cover, so the
+        // cross-join-unnest fires before any consumer joins Unnest with
+        // its other side.
+        for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
+          if (ses.contains(unnestId)) {
+            tes.unionSet(inputRelations);
+          }
+        }
+
+        graph.addEdge(
+            JoinEdge{
+                leftSet,
+                rightSet,
+                leftKeys,
+                rightKeys,
+                ExprVector{},
+                join->joinType(),
+                /*nullAware=*/false,
+                /*nullAsValue=*/false},
+            tes);
+      }
+
+      for (ExprCP conjunct : join->filter()) {
+        graph.addFilterConjunct(
+            {conjunct, expressionRelations(conjunct, columnToLeaf)});
+      }
+    } else {
+      // Swap keys when the IR join is a right-form join so the edge's
+      // leftKeys reference `leaves.left` (already right-normalized to the
+      // matching left form in populateJoinLeaves).
+      const bool flip = join->joinType() == velox::core::JoinType::kRight ||
+          join->joinType() == velox::core::JoinType::kRightSemiFilter ||
+          join->joinType() == velox::core::JoinType::kRightSemiProject;
+      const ExprVector& edgeLeftKeys =
+          flip ? join->rightKeys() : join->leftKeys();
+      const ExprVector& edgeRightKeys =
+          flip ? join->leftKeys() : join->rightKeys();
+      NodeCP normalizedLeftChild = flip ? join->right() : join->left();
+      NodeCP normalizedRightChild = flip ? join->left() : join->right();
+
+      const RelationSet leftSet{
+          unionExpressionRelations(edgeLeftKeys, columnToLeaf)};
+      const RelationSet rightSet{
+          unionExpressionRelations(edgeRightKeys, columnToLeaf)};
+      RelationSet ses{leftSet};
+      ses.unionSet(rightSet);
+      for (ExprCP conjunct : join->filter()) {
+        ses.unionSet(expressionRelations(conjunct, columnToLeaf));
+      }
+      RelationSet tes{ses};
+      tes.unionSet(tesExpansion(
+          normalizedLeftChild,
+          leaves.joinType,
+          ses,
+          /*leftSide=*/true,
+          leafIds,
+          joinLeaves));
+      tes.unionSet(tesExpansion(
+          normalizedRightChild,
+          leaves.joinType,
+          ses,
+          /*leftSide=*/false,
+          leafIds,
+          joinLeaves));
+
+      // Unnest barrier: if an Unnest's input subtree contributes a
+      // relation on this outer join's null-padded side, the
+      // cross-join-unnest must fire before the outer join. Otherwise
+      // null-padding flows into UNNEST and rows drop. Expand TES to
+      // include the Unnest relation id so DPhyp pins the order.
+      RelationSet joinRelations{leaves.left};
+      joinRelations.unionSet(leaves.right);
+      for (const auto& [unnestId, inputRelations] : unnestInputRelations) {
+        // An outer join inside the Unnest's input subtree is already
+        // ordered before the Unnest by the directed cross-join-unnest
+        // edge. The barrier would demand the reverse order, which no
+        // plan can satisfy when this join is the only edge co-locating
+        // the input relations.
+        if (joinRelations.isSubset(inputRelations)) {
+          continue;
+        }
+        RelationSet nullPaddedSide;
+        if (leaves.joinType == velox::core::JoinType::kLeft) {
+          nullPaddedSide = leaves.right;
+        } else if (leaves.joinType == velox::core::JoinType::kFull) {
+          nullPaddedSide = leaves.left;
+          nullPaddedSide.unionSet(leaves.right);
+        }
+        if (nullPaddedSide.hasIntersection(inputRelations)) {
+          tes.add(unnestId);
+        }
+      }
+
+      // kLeftSemiProject preserves the left side and appends a mark; the
+      // Join (and its Apply origin) build outputColumns as
+      // `left.outputColumns ++ mark`, so the mark is the last output
+      // column. Emit reads it back via JoinEdge::markColumn to thread the
+      // mark through reordering. The filtering forms (kLeftSemiFilter /
+      // kAnti) carry no mark.
+      ColumnCP markColumn = nullptr;
+      if (leaves.joinType == velox::core::JoinType::kLeftSemiProject) {
+        VELOX_CHECK(
+            !join->outputColumns().empty(),
+            "kLeftSemiProject join must output its mark column");
+        markColumn = join->outputColumns().back();
+      }
+
+      graph.addEdge(
+          JoinEdge{
+              leftSet,
+              rightSet,
+              edgeLeftKeys,
+              edgeRightKeys,
+              join->filter(),
+              leaves.joinType,
+              join->nullAware(),
+              join->nullAsValue(),
+              markColumn},
+          tes);
+    }
+  }
+
+  addTransitiveInnerEdges(graph, cluster, columnToLeaf);
+
+  return graph;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/HypergraphBuilder.h
+++ b/axiom/optimizer/v2/HypergraphBuilder.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/JoinCluster.h"
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+class EstimateProvider;
+
+/// Converts a `JoinCluster` into the `JoinHypergraph` consumed by
+/// `DPhyp`: one `Relation` per cluster leaf, one `JoinEdge` per
+/// cluster Join.
+class HypergraphBuilder {
+ public:
+  /// `cluster.leaves` carries the original pointers found in
+  /// `cluster.root`'s tree (used to walk the cluster topology);
+  /// `rewrittenLeaves` carries the corresponding post-rewrite leaf
+  /// pointers (used to populate hypergraph relations so the emitted
+  /// plan reflects sub-cluster rewrites). `rewrittenLeaves[i]` must
+  /// align 1:1 with `cluster.leaves[i]` and output the same logical
+  /// columns.
+  ///
+  /// Throws if the cluster has more leaves than
+  /// `RelationSet::kMaxRelations`, or if any cluster Join references
+  /// a join key that does not resolve to a leaf column.
+  static JoinHypergraph build(
+      const JoinCluster& cluster,
+      const std::vector<NodeCP>& rewrittenLeaves,
+      EstimateProvider& estimateProvider);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinCluster.h
+++ b/axiom/optimizer/v2/JoinCluster.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// A maximal subtree of reorderable equi-Joins discovered in the IR.
+///
+/// `root` is the topmost Join. `leaves` are the non-Join input nodes
+/// at the cluster's frontier; their pointer identity is preserved so
+/// downstream emit can stitch the rewritten join tree back together
+/// with surrounding IR. `joins` lists every Join in the cluster,
+/// `root` included.
+///
+/// `unnests` records Unnest IR nodes the cluster collection
+/// descended through. Each becomes its own relation in the
+/// hypergraph, connected to the leaves contributed by its input
+/// subtree via a directed cross-join-unnest edge. Order is descent
+/// order (innermost first) so dependent chains (`UNNEST(u1.x) u2`)
+/// have `u1`'s cardinality computed before `u2`'s.
+struct JoinCluster {
+  JoinCP root;
+  std::vector<NodeCP> leaves;
+  std::vector<JoinCP> joins;
+  std::vector<UnnestCP> unnests;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinCondition.cpp
+++ b/axiom/optimizer/v2/JoinCondition.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/JoinCondition.h"
+
+#include "axiom/optimizer/FunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+JoinCondition::Split JoinCondition::splitEquiKeys(
+    const ExprVector& conjuncts,
+    const PlanObjectSet& leftColumns,
+    const PlanObjectSet& rightColumns) {
+  Split result;
+  const Name equalityName = toName(FunctionRegistry::instance()->equality());
+  for (ExprCP conjunct : conjuncts) {
+    if (!conjunct->is(PlanType::kCallExpr)) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
+    const auto* call = conjunct->as<Call>();
+    if (call->name() != equalityName || call->args().size() != 2) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
+    ExprCP lhs = call->args()[0];
+    ExprCP rhs = call->args()[1];
+    const auto& lhsCols = lhs->columns();
+    const auto& rhsCols = rhs->columns();
+    if (lhsCols.empty() || rhsCols.empty()) {
+      result.residual.push_back(conjunct);
+      continue;
+    }
+    if (lhsCols.isSubset(leftColumns) && rhsCols.isSubset(rightColumns)) {
+      result.leftKeys.push_back(lhs);
+      result.rightKeys.push_back(rhs);
+      continue;
+    }
+    if (lhsCols.isSubset(rightColumns) && rhsCols.isSubset(leftColumns)) {
+      result.leftKeys.push_back(rhs);
+      result.rightKeys.push_back(lhs);
+      continue;
+    }
+    result.residual.push_back(conjunct);
+  }
+  return result;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinCondition.h
+++ b/axiom/optimizer/v2/JoinCondition.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/QueryGraph.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Normalizes raw join-condition conjuncts into the Join IR's split
+/// form. The invariant `Join` callers rely on: any `eq(leftExpr,
+/// rightExpr)` conjunct whose sides partition cleanly into one side
+/// each lives in `leftKeys` / `rightKeys`, never in `filter`.
+class JoinCondition {
+ public:
+  /// Output of `splitEquiKeys`: paired equi-keys plus the residual
+  /// non-equi conjuncts.
+  struct Split {
+    ExprVector leftKeys;
+    ExprVector rightKeys;
+    ExprVector residual;
+  };
+
+  /// Walks `conjuncts` (typically the flattened AND-conjuncts of a join
+  /// condition). For each `eq(lhs, rhs)` whose `lhs` references only
+  /// `leftColumns` and `rhs` only `rightColumns` (or vice versa, with
+  /// the pair swapped to canonical left/right order), records it as a
+  /// `(leftKey, rightKey)` pair. Anything not matching that pattern
+  /// stays in `residual`.
+  static Split splitEquiKeys(
+      const ExprVector& conjuncts,
+      const PlanObjectSet& leftColumns,
+      const PlanObjectSet& rightColumns);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinEdge.h
+++ b/axiom/optimizer/v2/JoinEdge.h
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <utility>
+
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/v2/RelationSet.h"
+#include "velox/common/base/Exceptions.h"
+#include "velox/core/PlanNode.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Whether the build (right) side of a join with `joinType` may be broadcast.
+///
+/// A side may be broadcast only if it is not *preserved* by the join — i.e. its
+/// rows are emitted only on a match, never on their own account. Broadcasting
+/// replicates a side to every task while the other side stays partitioned, so a
+/// preserved side must be the partitioned one or its rows would be emitted on
+/// every task. The right side is preserved by RIGHT / FULL outer joins and by
+/// right semi joins; for those the build cannot be broadcast, and the mirror
+/// orientation broadcasts the other side instead.
+inline bool canBroadcastBuild(velox::core::JoinType joinType) {
+  using velox::core::JoinType;
+  return joinType == JoinType::kInner || joinType == JoinType::kLeft ||
+      joinType == JoinType::kLeftSemiFilter ||
+      joinType == JoinType::kLeftSemiProject || joinType == JoinType::kAnti;
+}
+
+/// A hyperedge in a join cluster's hypergraph. Three flavors:
+///
+///   - Inner equi-join. `filter` is empty; non-equi conjuncts live in
+///     `JoinHypergraph::filterConjuncts` so DPhyp can place them at
+///     the lowest eligible join. `nullAware` and `nullAsValue` are
+///     unused.
+///   - Outer equi-join (LEFT / RIGHT / FULL). `filter` carries the
+///     ON-clause non-equi conjuncts bound to this edge — moving them
+///     above would let null-padded rows pass through, changing
+///     semantics. `nullAware` and `nullAsValue` carry Velox null
+///     semantics.
+///   - Directed cross-join-unnest. Built by the unnest constructor
+///     overload. `left` covers the relations whose subtree feeds the
+///     Unnest; `right` is the single Unnest relation. `unnestExprs`
+///     carries the ARRAY/MAP expressions to unnest. No equi-keys, no
+///     filter. `isUnnest()` discriminates.
+///
+/// Invariants:
+///   - `left` and `right` are non-empty and disjoint.
+///   - Equi-join flavors: `leftKeys.size() == rightKeys.size()` and
+///     is non-empty.
+///   - Unnest flavor: `unnestExprs` non-empty; `leftKeys` /
+///     `rightKeys` / `filter` empty; `joinType == kInner`.
+class JoinEdge {
+ public:
+  JoinEdge(
+      RelationSet left,
+      RelationSet right,
+      ExprVector leftKeys,
+      ExprVector rightKeys,
+      ExprVector filter,
+      velox::core::JoinType joinType,
+      bool nullAware,
+      bool nullAsValue,
+      ColumnCP markColumn = nullptr)
+      : left_{std::move(left)},
+        right_{std::move(right)},
+        leftKeys_{std::move(leftKeys)},
+        rightKeys_{std::move(rightKeys)},
+        filter_{std::move(filter)},
+        joinType_{joinType},
+        nullAware_{nullAware},
+        nullAsValue_{nullAsValue},
+        markColumn_{markColumn} {
+    VELOX_CHECK(!left_.empty());
+    VELOX_CHECK(!right_.empty());
+    VELOX_CHECK(!left_.hasIntersection(right_));
+    VELOX_CHECK_EQ(leftKeys_.size(), rightKeys_.size());
+    VELOX_CHECK(
+        !leftKeys_.empty(), "Equi-join edge must carry at least one key pair");
+    VELOX_CHECK(
+        filter_.empty() || joinType_ != velox::core::JoinType::kInner,
+        "Inner-join edges must have empty filter; conjuncts live in the hypergraph's filter pool: {}",
+        velox::core::JoinTypeName::toName(joinType_));
+    VELOX_CHECK(
+        (!nullAware_ && !nullAsValue_) ||
+            joinType_ != velox::core::JoinType::kInner,
+        "Inner-join edges must not carry nullAware or nullAsValue: {}",
+        velox::core::JoinTypeName::toName(joinType_));
+  }
+
+  /// Constructs a directed cross-join-unnest edge: input relations on
+  /// `left`, the Unnest relation on `right`, the ARRAY/MAP expressions
+  /// to unnest in `unnestExprs`. Equi-key invariants don't apply; see
+  /// the class doc.
+  JoinEdge(RelationSet left, RelationSet right, ExprVector unnestExprs)
+      : left_{std::move(left)},
+        right_{std::move(right)},
+        joinType_{velox::core::JoinType::kInner},
+        unnestExprs_{std::move(unnestExprs)} {
+    VELOX_CHECK(!left_.empty());
+    VELOX_CHECK(!right_.empty());
+    VELOX_CHECK(!left_.hasIntersection(right_));
+    VELOX_CHECK(
+        !unnestExprs_.empty(),
+        "Cross-join-unnest edge must carry at least one unnest expression");
+  }
+
+  const RelationSet& left() const {
+    return left_;
+  }
+
+  const RelationSet& right() const {
+    return right_;
+  }
+
+  /// Equi-join keys aligned by position with `rightKeys()`.
+  const ExprVector& leftKeys() const {
+    return leftKeys_;
+  }
+
+  const ExprVector& rightKeys() const {
+    return rightKeys_;
+  }
+
+  /// Bound non-equi conjuncts for outer-join edges. Empty for inner.
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  /// ARRAY/MAP expressions to unnest. Non-empty iff this is a
+  /// cross-join-unnest edge.
+  const ExprVector& unnestExprs() const {
+    return unnestExprs_;
+  }
+
+  /// True iff this is a directed cross-join-unnest edge.
+  bool isUnnest() const {
+    return !unnestExprs_.empty();
+  }
+
+  velox::core::JoinType joinType() const {
+    return joinType_;
+  }
+
+  bool nullAware() const {
+    return nullAware_;
+  }
+
+  bool nullAsValue() const {
+    return nullAsValue_;
+  }
+
+  /// The mark/exists column produced by a `kLeftSemiProject` join;
+  /// `nullptr` for all other join types. Populated in Phase 2 when
+  /// semi-project joins are admitted to clusters.
+  ColumnCP markColumn() const {
+    return markColumn_;
+  }
+
+ private:
+  RelationSet left_;
+  RelationSet right_;
+  ExprVector leftKeys_;
+  ExprVector rightKeys_;
+  ExprVector filter_;
+  velox::core::JoinType joinType_;
+  bool nullAware_{false};
+  bool nullAsValue_{false};
+  // The mark/exists column produced by a kLeftSemiProject join;
+  // nullptr otherwise. Populated in Phase 2.
+  ColumnCP markColumn_{nullptr};
+  ExprVector unnestExprs_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinFanout.cpp
+++ b/axiom/optimizer/v2/JoinFanout.cpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/JoinFanout.h"
+
+#include <algorithm>
+#include <cstddef>
+
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/Filters.h"
+#include "axiom/optimizer/QueryGraph.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+std::optional<float> JoinFanout::estimateJoinCardinality(
+    std::optional<float> leftCardinality,
+    std::optional<float> rightCardinality,
+    const ExprVector& leftKeys,
+    const ExprVector& rightKeys,
+    const ConstraintMap& constraints) {
+  const auto ndv = [&](ExprCP key) {
+    return value(constraints, key).cardinality;
+  };
+
+  if (!leftCardinality.has_value() || !rightCardinality.has_value()) {
+    return std::nullopt;
+  }
+
+  float jointNdvLeft{1};
+  float jointNdvRight{1};
+  for (size_t i = 0; i < leftKeys.size(); ++i) {
+    const auto leftNdv = ndv(leftKeys[i]);
+    const auto rightNdv = ndv(rightKeys[i]);
+    // An unknown join-key NDV makes the cardinality unknown.
+    if (!leftNdv.has_value() || !rightNdv.has_value()) {
+      return std::nullopt;
+    }
+    // A zero-NDV key means an empty side, hence an empty join.
+    if (*leftNdv == 0 || *rightNdv == 0) {
+      return 0;
+    }
+    jointNdvLeft *= *leftNdv;
+    jointNdvRight *= *rightNdv;
+  }
+  jointNdvLeft = std::min(jointNdvLeft, *leftCardinality);
+  jointNdvRight = std::min(jointNdvRight, *rightCardinality);
+  return *leftCardinality * *rightCardinality /
+      std::max(jointNdvLeft, jointNdvRight);
+}
+
+std::optional<float> JoinFanout::outputCardinality(
+    velox::core::JoinType joinType,
+    std::optional<float> leftCardinality,
+    std::optional<float> rightCardinality,
+    std::optional<float> matched) {
+  switch (joinType) {
+    case velox::core::JoinType::kLeft:
+      return maxOf(matched, leftCardinality);
+    case velox::core::JoinType::kRight:
+      return maxOf(matched, rightCardinality);
+    case velox::core::JoinType::kFull:
+      return subtract(add(leftCardinality, rightCardinality), matched);
+    case velox::core::JoinType::kLeftSemiFilter:
+      return minOf(leftCardinality, matched);
+    case velox::core::JoinType::kRightSemiFilter:
+      return minOf(rightCardinality, matched);
+    case velox::core::JoinType::kLeftSemiProject:
+      // Mark-preserving: every left row is output with a boolean mark.
+      return leftCardinality;
+    case velox::core::JoinType::kRightSemiProject:
+      return rightCardinality;
+    case velox::core::JoinType::kAnti:
+      return maxOf(
+          0.0f, subtract(leftCardinality, minOf(leftCardinality, matched)));
+    default:
+      return matched;
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinFanout.h
+++ b/axiom/optimizer/v2/JoinFanout.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/Filters.h"
+#include "velox/core/PlanNode.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Cardinality estimator for equi-joins.
+class JoinFanout {
+ public:
+  /// Returns the estimated number of rows produced by the equi-join
+  /// `leftKeys == rightKeys` of 'leftCardinality' left rows against
+  /// 'rightCardinality' right rows. Each side's joint key NDV is the product
+  /// of its per-key NDVs, capped at that side's row count (a side cannot have
+  /// more distinct key tuples than rows); the larger of the two joint NDVs
+  /// determines selectivity. Orientation-invariant: swapping the two sides
+  /// yields the same result. 'leftKeys' and 'rightKeys' are aligned by
+  /// position. Each key's NDV is read from 'constraints' (falling back to
+  /// `expr->value()` for keys absent from the map), so propagated post-filter /
+  /// post-join statistics drive the estimate instead of base-table NDV. Returns
+  /// nullopt if any cardinality or key NDV is unknown, 0 if any key NDV is 0.
+  static std::optional<float> estimateJoinCardinality(
+      std::optional<float> leftCardinality,
+      std::optional<float> rightCardinality,
+      const ExprVector& leftKeys,
+      const ExprVector& rightKeys,
+      const ConstraintMap& constraints);
+
+  /// Shapes an inner-join match count 'matched' into a join's output
+  /// cardinality according to 'joinType'. 'leftCardinality' /
+  /// 'rightCardinality' are the join's left / right operand cardinalities.
+  ///   - inner: matched.
+  ///   - left / right: at least every preserved-side row (max with matched).
+  ///   - full: both sides minus the matched overlap.
+  ///   - left/right semi filter: preserved side bounded by matched.
+  ///   - left/right semi project: every preserved-side row (a mark is added).
+  ///   - anti: preserved-side rows with no match.
+  /// Unknown inputs propagate to nullopt.
+  static std::optional<float> outputCardinality(
+      velox::core::JoinType joinType,
+      std::optional<float> leftCardinality,
+      std::optional<float> rightCardinality,
+      std::optional<float> matched);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinHypergraph.cpp
+++ b/axiom/optimizer/v2/JoinHypergraph.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+
+#include <utility>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+int8_t JoinHypergraph::addRelation(
+    NodeCP node,
+    std::optional<float> cardinality,
+    PlanObjectSet columns) {
+  VELOX_CHECK_LT(
+      relations_.size(),
+      RelationSet::kMaxRelations,
+      "Hypergraph cluster exceeds the per-hypergraph relation cap");
+  const int8_t id{static_cast<int8_t>(relations_.size())};
+  relations_.emplace_back(id, node, cardinality, std::move(columns));
+  relationIds_.add(id);
+  invalidateCoverCaches();
+  return id;
+}
+
+void JoinHypergraph::setTargetColumns(PlanObjectSet targetColumns) {
+  targetColumns_ = std::move(targetColumns);
+  invalidateCoverCaches();
+}
+
+void JoinHypergraph::invalidateCoverCaches() {
+  coverOutputColumnsCache_.clear();
+}
+
+int8_t JoinHypergraph::addUnnestRelation(
+    NodeCP node,
+    std::optional<float> cardinality,
+    PlanObjectSet columns) {
+  VELOX_CHECK_NOT_NULL(node);
+  VELOX_CHECK(
+      node->nodeType() == NodeType::kUnnest,
+      "addUnnestRelation requires an Unnest node");
+  const int8_t id = addRelation(node, cardinality, std::move(columns));
+  unnestRelationIds_.add(id);
+  return id;
+}
+
+RelationSet JoinHypergraph::connectedComponent(
+    RelationSet seed,
+    RelationSet bound) const {
+  RelationSet reached{seed};
+  bool changed{true};
+  while (changed) {
+    changed = false;
+    for (const auto& edge : edges_) {
+      RelationSet endpoints{edge.left()};
+      endpoints.unionSet(edge.right());
+      if (!endpoints.isSubset(bound)) {
+        continue;
+      }
+      if (endpoints.hasIntersection(reached) && !endpoints.isSubset(reached)) {
+        reached.unionSet(endpoints);
+        changed = true;
+      }
+    }
+  }
+  return reached;
+}
+
+void JoinHypergraph::checkConsistency() const {
+  if (relations_.empty()) {
+    return;
+  }
+  const RelationSet reached =
+      connectedComponent(RelationSet::singleton(0), relationIds_);
+  VELOX_CHECK_EQ(
+      reached.size(), relations_.size(), "Hypergraph is not connected");
+
+  // Every Unnest relation must be reachable through its cross-join-unnest
+  // edge; otherwise the directed-edge connectivity was never built.
+  unnestRelationIds_.forEach([&](int32_t id) {
+    bool found = false;
+    for (const auto& edge : edges_) {
+      if (edge.isUnnest() && edge.right().contains(id)) {
+        found = true;
+        break;
+      }
+    }
+    VELOX_CHECK(found, "Unnest relation has no cross-join-unnest edge: {}", id);
+  });
+}
+
+void JoinHypergraph::addFilterConjunct(FilterConjunct conjunct) {
+  VELOX_CHECK_NOT_NULL(conjunct.expr);
+  VELOX_CHECK(
+      conjunct.relations.isSubset(relationIds_),
+      "Filter conjunct references unknown relations");
+  filterConjuncts_.push_back(std::move(conjunct));
+  invalidateCoverCaches();
+}
+
+PlanObjectSet JoinHypergraph::coverColumns(const RelationSet& cover) const {
+  PlanObjectSet columns;
+  cover.forEach([&](int32_t id) { columns.unionSet(relation(id).columns()); });
+  return columns;
+}
+
+folly::F14FastMap<ColumnCP, ColumnCP> JoinHypergraph::coverColumnReps(
+    const RelationSet& cover) const {
+  folly::F14FastMap<ColumnCP, ColumnCP> parent;
+  coverColumns(cover).forEach<Column>(
+      [&](ColumnCP column) { parent[column] = column; });
+
+  auto find = [&](ColumnCP column) {
+    while (parent[column] != column) {
+      parent[column] = parent[parent[column]];
+      column = parent[column];
+    }
+    return column;
+  };
+
+  auto asColumn = [](ExprCP expr) -> ColumnCP {
+    return expr->is(PlanType::kColumnExpr) ? expr->as<Column>() : nullptr;
+  };
+
+  // A target column is the better representative (its name must reach the
+  // cluster root); ties break on column name, then id. Name is used rather than
+  // id alone because column ids come from a process-global counter, so id order
+  // within an equivalence class depends on allocation history — using it would
+  // make the surviving column (and thus the plan) non-reproducible across runs
+  // and query forms.
+  auto betterRep = [&](ColumnCP a, ColumnCP b) {
+    const bool aTarget = targetColumns_.contains(a);
+    const bool bTarget = targetColumns_.contains(b);
+    if (aTarget != bTarget) {
+      return aTarget;
+    }
+    const std::string_view aName{a->name()};
+    const std::string_view bName{b->name()};
+    if (aName != bName) {
+      return aName < bName;
+    }
+    return a->id() < b->id();
+  };
+
+  for (const auto& edge : edges_) {
+    // Only an inner join makes its key columns equal in the output: across an
+    // outer join the null-padded side's key is NULL, not equal to the
+    // preserved side, so those columns must not be collapsed.
+    if (edge.joinType() != velox::core::JoinType::kInner) {
+      continue;
+    }
+    RelationSet endpoints{edge.left()};
+    endpoints.unionSet(edge.right());
+    if (!endpoints.isSubset(cover)) {
+      continue;
+    }
+    const auto& leftKeys = edge.leftKeys();
+    const auto& rightKeys = edge.rightKeys();
+    for (size_t i = 0; i < leftKeys.size() && i < rightKeys.size(); ++i) {
+      ColumnCP left = asColumn(leftKeys[i]);
+      ColumnCP right = asColumn(rightKeys[i]);
+      if (left == nullptr || right == nullptr || !parent.contains(left) ||
+          !parent.contains(right)) {
+        continue;
+      }
+      ColumnCP rootLeft = find(left);
+      ColumnCP rootRight = find(right);
+      if (rootLeft == rootRight) {
+        continue;
+      }
+      if (betterRep(rootRight, rootLeft)) {
+        std::swap(rootLeft, rootRight);
+      }
+      parent[rootRight] = rootLeft;
+    }
+  }
+
+  folly::F14FastMap<ColumnCP, ColumnCP> reps;
+  reps.reserve(parent.size());
+  for (const auto& [column, _] : parent) {
+    reps[column] = find(column);
+  }
+  return reps;
+}
+
+PlanObjectSet JoinHypergraph::coverOutputColumns(
+    const RelationSet& cover) const {
+  if (auto it = coverOutputColumnsCache_.find(cover);
+      it != coverOutputColumnsCache_.end()) {
+    return it->second;
+  }
+  PlanObjectSet neededAbove = targetColumns_;
+  for (const auto& edge : edges_) {
+    RelationSet endpoints{edge.left()};
+    endpoints.unionSet(edge.right());
+    if (!endpoints.isSubset(cover)) {
+      neededAbove.unionColumns(edge.leftKeys());
+      neededAbove.unionColumns(edge.rightKeys());
+      neededAbove.unionColumns(edge.filter());
+      neededAbove.unionColumns(edge.unnestExprs());
+    }
+  }
+  for (const auto& conjunct : filterConjuncts_) {
+    if (!conjunct.relations.isSubset(cover)) {
+      neededAbove.unionColumns(conjunct.expr);
+    }
+  }
+  PlanObjectSet demand = coverColumns(cover);
+  demand.intersect(neededAbove);
+
+  // Collapse each demanded column to its equivalence representative, so a group
+  // of provably-equal columns contributes a single output column.
+  const auto reps = coverColumnReps(cover);
+  PlanObjectSet columns;
+  demand.forEach<Column>([&](ColumnCP column) {
+    const auto it = reps.find(column);
+    columns.add(it != reps.end() ? it->second : column);
+  });
+  return coverOutputColumnsCache_.emplace(cover, std::move(columns))
+      .first->second;
+}
+
+void JoinHypergraph::addEdge(JoinEdge edge, RelationSet tes) {
+  RelationSet touched{edge.left()};
+  touched.unionSet(edge.right());
+  VELOX_CHECK(touched.isSubset(tes), "Edge endpoints must be a subset of TES");
+  VELOX_CHECK(
+      tes.isSubset(relationIds_),
+      "TES must reference only relations already added");
+  edges_.push_back(std::move(edge));
+  tes_.push_back(tes);
+  invalidateCoverCaches();
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinHypergraph.h
+++ b/axiom/optimizer/v2/JoinHypergraph.h
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/v2/JoinEdge.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/Relation.h"
+#include "axiom/optimizer/v2/RelationSet.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// A single boolean predicate that must be evaluated somewhere in
+/// the chosen join tree. `relations` is the set of cluster leaves
+/// whose columns the predicate references; the emitter places the
+/// conjunct at the lowest join whose cover ⊇ `relations`. `expr` is
+/// required at construction; default-null is only the
+/// aggregate-init placeholder. Only free (inner-join / WHERE) conjuncts
+/// live here; outer-join ON-clause conjuncts are edge-pinned via
+/// `JoinEdge::filter` instead.
+struct FilterConjunct {
+  ExprCP expr{nullptr};
+  RelationSet relations;
+};
+
+/// The hypergraph DPhyp enumerates over: a set of relations
+/// (atomic join inputs) connected by hyperedges (predicates).
+///
+/// Each edge carries a Total Eligibility Set (TES) — the relations that
+/// must already be in the joined set before the edge can fire.
+///
+/// Typical use: call `addRelation` once for each base input, then
+/// `addEdge` once for each predicate, then pass the result to
+/// DPhyp for plan enumeration. Edges and their TES are stored in
+/// parallel: `tes()[i]` is the TES of `edges()[i]`.
+///
+/// Invariants (maintained across construction):
+///   - `relations()[i].id() == i`.
+///   - Every relation id referenced by an edge is in
+///     `[0, relations().size())`.
+///   - `tes()[i]` is a superset of
+///     `edges()[i].left() ∪ edges()[i].right()`.
+class JoinHypergraph {
+ public:
+  /// Constructs a Relation with the next assigned id and adds it
+  /// to the hypergraph. Returns the assigned id.
+  int8_t addRelation(
+      NodeCP node,
+      std::optional<float> cardinality,
+      PlanObjectSet columns);
+
+  /// Registers an Unnest IR node as its own relation and tracks its id
+  /// for connectivity checks. `node` must be an Unnest. Returns the
+  /// assigned id.
+  int8_t addUnnestRelation(
+      NodeCP node,
+      std::optional<float> cardinality,
+      PlanObjectSet columns);
+
+  /// Relation ids registered via `addUnnestRelation`.
+  const RelationSet& unnestRelationIds() const {
+    return unnestRelationIds_;
+  }
+
+  /// Appends an edge with its TES. `tes` must be a superset of
+  /// `edge.left() ∪ edge.right()`, and every relation referenced
+  /// by `edge` or `tes` must already be in `relations()`.
+  void addEdge(JoinEdge edge, RelationSet tes);
+
+  /// Appends a filter conjunct. `conjunct.relations` must be
+  /// a subset of the relations already in `relations()`.
+  void addFilterConjunct(FilterConjunct conjunct);
+
+  const std::vector<FilterConjunct>& filterConjuncts() const {
+    return filterConjuncts_;
+  }
+
+  /// Columns the cluster's plan must output (the cluster root's output
+  /// columns). Used to decide which of a subplan's columns survive past it: a
+  /// cover's output columns are its columns that are either targets or
+  /// referenced by a not-yet-applied edge / filter.
+  void setTargetColumns(PlanObjectSet targetColumns);
+
+  const PlanObjectSet& targetColumns() const {
+    return targetColumns_;
+  }
+
+  /// Union of the output columns of every relation in `cover` — the columns a
+  /// subplan over `cover` can supply.
+  PlanObjectSet coverColumns(const RelationSet& cover) const;
+
+  /// Maps each column of `cover` to the representative of its equivalence group
+  /// under the equi-join keys of the INNER-join edges lying entirely within
+  /// `cover` — only an inner join makes its keys equal in the output (an outer
+  /// join's null-padded key is not). Columns equated to nothing map to
+  /// themselves. The representative is the group's target column if any, else
+  /// the column with the smallest name, with id breaking final ties; name
+  /// rather than id because ids come from a process-global counter, which would
+  /// make the choice non-reproducible across runs and query forms. The order is
+  /// total, so `best(A∪B) = best(best A, best B)`: a join's representative is
+  /// always one of its children's representatives, hence present in a child's
+  /// output, independent of join order. Used to collapse provably-equal columns
+  /// to one, consistently for costing (row width) and emission (output columns
+  /// and key/filter references).
+  folly::F14FastMap<ColumnCP, ColumnCP> coverColumnReps(
+      const RelationSet& cover) const;
+
+  /// The columns a subplan over `cover` must output: its `coverColumns` that
+  /// are either target columns or referenced by an edge / filter conjunct
+  /// crossing the cover boundary. This demand depends only on `cover`'s
+  /// boundary, not on the internal join order, so it is the precise output
+  /// set both for costing a candidate (row width) and for setting the emitted
+  /// join's output columns.
+  PlanObjectSet coverOutputColumns(const RelationSet& cover) const;
+
+  const std::vector<Relation>& relations() const {
+    return relations_;
+  }
+
+  /// Looks up a relation by id.
+  const Relation& relation(int32_t id) const {
+    return relations_[id];
+  }
+
+  const std::vector<JoinEdge>& edges() const {
+    return edges_;
+  }
+
+  /// Per-edge Total Eligibility Sets, aligned with `edges()`:
+  /// `tes()[i]` is the TES of `edges()[i]`.
+  const std::vector<RelationSet>& tes() const {
+    return tes_;
+  }
+
+  /// Returns the set of relations reachable from `seed` by repeatedly
+  /// following edges whose endpoints are entirely within `bound`.
+  RelationSet connectedComponent(RelationSet seed, RelationSet bound) const;
+
+  /// Checks that all relations are connected to each other via
+  /// edges. DPhyp's main enumeration loop requires a connected
+  /// hypergraph.
+  void checkConsistency() const;
+
+ private:
+  // Empties the cover-derived memo caches. Called by every builder mutation so
+  // the caches never outlive the graph state they were computed from.
+  void invalidateCoverCaches();
+
+  // Indexed by relation id.
+  std::vector<Relation> relations_;
+  std::vector<JoinEdge> edges_;
+  // Parallel to `edges_`: `tes_[i]` is the TES of `edges_[i]`.
+  std::vector<RelationSet> tes_;
+  std::vector<FilterConjunct> filterConjuncts_;
+  // Bitset of every relation id currently in the hypergraph.
+  RelationSet relationIds_;
+  // Bitset of relations registered via `addUnnestRelation`.
+  RelationSet unnestRelationIds_;
+  // Columns the cluster's plan must output. See setTargetColumns().
+  PlanObjectSet targetColumns_;
+
+  // Memoized coverOutputColumns() results, keyed by cover. coverOutputColumns
+  // is a pure function of the frozen graph but the cost model queries it once
+  // per join candidate during enumeration; caching collapses the per-candidate
+  // recomputation (a union-find over all inner edges) that otherwise dominates
+  // planning a many-relation same-key join. Invalidated by
+  // invalidateCoverCaches(). Assumes single-threaded planning (the mutable
+  // cache makes the const method non-thread-safe).
+  mutable folly::F14FastMap<RelationSet, PlanObjectSet>
+      coverOutputColumnsCache_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -1,0 +1,552 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/JoinTreeEmitter.h"
+
+#include <algorithm>
+#include <numeric>
+#include <optional>
+
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// An intermediate join emits the columns a consumer above `cover` demands —
+// `graph.coverOutputColumns(cover)`, which collapses each within-cover
+// equi-group to one representative — exactly the set the cost model charges
+// for, so the executed plan matches its estimated width. Left-then-right order
+// is preserved. A column produced by no relation in `cover` (e.g. a semijoin
+// mark synthesized below) is outside the demand universe and is always kept.
+ColumnVector coverNarrowedColumns(
+    const JoinHypergraph& graph,
+    const RelationSet& cover,
+    NodeCP left,
+    NodeCP right) {
+  const PlanObjectSet needed = graph.coverOutputColumns(cover);
+  const PlanObjectSet coverColumns = graph.coverColumns(cover);
+  ColumnVector columns;
+  for (NodeCP side : {left, right}) {
+    for (ColumnCP column : side->outputColumns()) {
+      if (!coverColumns.contains(column) || needed.contains(column)) {
+        columns.push_back(column);
+      }
+    }
+  }
+  return columns;
+}
+
+// Returns each not-yet-placed conjunct whose required relations are
+// a subset of `cover`. Marks the returned conjuncts in `fired`.
+ExprVector takeReadyConjuncts(
+    const JoinHypergraph& graph,
+    RelationSet cover,
+    std::vector<bool>& fired) {
+  ExprVector ready;
+  const auto& conjuncts = graph.filterConjuncts();
+  for (size_t i = 0; i < conjuncts.size(); ++i) {
+    if (fired[i]) {
+      continue;
+    }
+    if (conjuncts[i].relations.isSubset(cover)) {
+      ready.push_back(conjuncts[i].expr);
+      fired[i] = true;
+    }
+  }
+  return ready;
+}
+
+struct EmitState {
+  const JoinHypergraph& graph;
+  Builder& builder;
+  ExprFactory exprs;
+  std::vector<bool> fired;
+};
+
+NodeCP emitOp(MemoOpCP op, EmitState& state);
+
+// A join's children each emit one representative per equivalence group, so a
+// column equated and collapsed in a child is gone from that child's output.
+// `mergedChildReps` maps every such column to the surviving representative
+// across both child covers; `remapToReps` rewrites key/filter expressions to
+// reference the survivor, keeping the emitted node's column references valid.
+folly::F14FastMap<ColumnCP, ColumnCP> mergedChildReps(
+    const JoinOp* join,
+    EmitState& state) {
+  auto reps = state.graph.coverColumnReps(join->left->cover());
+  auto right = state.graph.coverColumnReps(join->right->cover());
+  reps.insert(right.begin(), right.end());
+  return reps;
+}
+
+ExprVector remapToReps(
+    const ExprVector& exprs,
+    const folly::F14FastMap<ColumnCP, ColumnCP>& reps,
+    EmitState& state) {
+  ColumnVector sources;
+  ExprVector targets;
+  for (const auto& [column, rep] : reps) {
+    if (rep != column) {
+      sources.push_back(column);
+      targets.push_back(rep);
+    }
+  }
+  if (sources.empty()) {
+    return exprs;
+  }
+  return state.exprs.substitute(exprs, sources, targets);
+}
+
+NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
+  return state.graph.relation(leaf->relationId).node();
+}
+
+// Builds a new `Unnest` IR node from a JoinOp wrapping a directed
+// cross-join-unnest edge. DPhyp's orientation enforcement guarantees
+// `join->left` is the input-side plan and `join->right` is the
+// singleton Unnest leaf. `unnestExpressions`, `unnestColumns`, and
+// `ordinalityColumn` come from the original Unnest IR node stored on
+// the Unnest relation. `replicatedColumns` conservatively forwards
+// every input column.
+NodeCP buildUnnest(const JoinOp* join, NodeCP leftNode, EmitState& state) {
+  const auto& edge = state.graph.edges()[join->edgeIndex];
+  const int8_t unnestRelId = edge.right().min();
+  const auto* origUnnest =
+      state.graph.relation(unnestRelId).node()->as<Unnest>();
+
+  ColumnVector replicatedColumns{leftNode->outputColumns()};
+
+  ColumnVector outputColumns{replicatedColumns};
+  for (const auto& perExpr : origUnnest->unnestColumns()) {
+    for (const auto* column : perExpr) {
+      outputColumns.push_back(column);
+    }
+  }
+  if (origUnnest->ordinalityColumn() != nullptr) {
+    outputColumns.push_back(origUnnest->ordinalityColumn());
+  }
+
+  // A column collapsed in the input is gone from `leftNode`'s output; point the
+  // unnest arguments at its surviving representative.
+  ExprVector unnestExpressions = remapToReps(
+      origUnnest->unnestExpressions(),
+      state.graph.coverColumnReps(join->left->cover()),
+      state);
+
+  return state.builder.make<Unnest>(Unnest::Key{
+      leftNode,
+      std::move(unnestExpressions),
+      std::move(replicatedColumns),
+      origUnnest->unnestColumns(),
+      origUnnest->ordinalityColumn(),
+      std::move(outputColumns)});
+}
+
+// Narrows `outputColumns` for semi/anti joins, which emit only the semi'd
+// side's columns (plus the mark for the project forms); inner/outer emit both
+// sides. Keys off the orientation-resolved `joinType`, so a left-form and its
+// build-side-flipped right form (operands swapped) yield identical output
+// columns. Returns std::nullopt for inner/outer (caller's columns are correct).
+std::optional<ColumnVector> narrowSemiAntiOutput(
+    velox::core::JoinType joinType,
+    NodeCP leftNode,
+    NodeCP rightNode,
+    ColumnCP markColumn) {
+  using velox::core::JoinType;
+  switch (joinType) {
+    case JoinType::kLeftSemiFilter:
+    case JoinType::kAnti:
+      // Semi'd side is the probe (left) input.
+      return ColumnVector{leftNode->outputColumns()};
+    case JoinType::kRightSemiFilter:
+      // Flipped semijoin: semi'd side is the build (right) input.
+      return ColumnVector{rightNode->outputColumns()};
+    case JoinType::kLeftSemiProject: {
+      ColumnVector columns{leftNode->outputColumns()};
+      if (markColumn != nullptr) {
+        columns.push_back(markColumn);
+      }
+      return columns;
+    }
+    case JoinType::kRightSemiProject: {
+      ColumnVector columns{rightNode->outputColumns()};
+      if (markColumn != nullptr) {
+        columns.push_back(markColumn);
+      }
+      return columns;
+    }
+    default:
+      return std::nullopt;
+  }
+}
+
+NodeCP buildJoin(
+    const JoinOp* join,
+    NodeCP leftNode,
+    NodeCP rightNode,
+    ColumnVector outputColumns,
+    EmitState& state) {
+  const auto& edge = state.graph.edges()[join->edgeIndex];
+  const bool isInner = edge.joinType() == velox::core::JoinType::kInner;
+
+  if (auto narrowed = narrowSemiAntiOutput(
+          join->joinType, leftNode, rightNode, edge.markColumn())) {
+    outputColumns = std::move(*narrowed);
+  }
+
+  // If DPhyp chose the swapped orientation, edge.left() covers
+  // join->right; swap keys.
+  ExprVector leftKeys{edge.leftKeys()};
+  ExprVector rightKeys{edge.rightKeys()};
+  if (edge.left().isSubset(join->right->cover())) {
+    std::swap(leftKeys, rightKeys);
+  }
+
+  // Conjoin the keys of any additional inner edges this join applies (a
+  // cyclic join graph can have several edges crossing one partition). Each
+  // is orientation-corrected independently. Inner edges carry no filter
+  // (their non-equi conjuncts live in the hypergraph's filter pool).
+  for (size_t extraIndex : join->extraEdges) {
+    const auto& extra = state.graph.edges()[extraIndex];
+    ExprVector extraLeftKeys{extra.leftKeys()};
+    ExprVector extraRightKeys{extra.rightKeys()};
+    if (extra.left().isSubset(join->right->cover())) {
+      std::swap(extraLeftKeys, extraRightKeys);
+    }
+    appendAll(leftKeys, extraLeftKeys);
+    appendAll(rightKeys, extraRightKeys);
+  }
+
+  ExprVector filter;
+  if (isInner) {
+    filter = takeReadyConjuncts(state.graph, join->cover(), state.fired);
+  } else {
+    filter = ExprVector{edge.filter()};
+  }
+
+  // A key/filter may reference a column a child collapsed into its
+  // representative; rewrite it to the survivor present in the child's output.
+  const auto reps = mergedChildReps(join, state);
+  leftKeys = remapToReps(leftKeys, reps, state);
+  rightKeys = remapToReps(rightKeys, reps, state);
+  filter = remapToReps(filter, reps, state);
+
+  return state.builder.make<Join>(Join::Key{
+      leftNode,
+      rightNode,
+      join->joinType,
+      std::move(leftKeys),
+      std::move(rightKeys),
+      std::move(filter),
+      edge.nullAware(),
+      edge.nullAsValue(),
+      std::move(outputColumns)});
+}
+
+// Lowers an antijoin played in its reversed (build-on-the-preserved-side)
+// orientation. There is no `kAnti` build-side flip in Velox, so synthesize
+// it: a kRightSemiProject (probe = `probeNode`, the edge's right side; build
+// = `buildNode`, the preserved left side) emits each build row plus a mark
+// for a probe match; `Filter(not mark)` keeps the unmatched rows (the
+// antijoin result); a Project drops the mark, restoring the antijoin schema.
+// The mark is fresh and never escapes this subtree.
+//
+// TODO: Replace this synthesis (and the reversedAnti orientation marker)
+// with a plain kRightAnti relabel once Velox adds that join type:
+// https://github.com/facebookincubator/velox/issues/17815.
+NodeCP buildReversedAnti(
+    const JoinOp* join,
+    NodeCP probeNode,
+    NodeCP buildNode,
+    EmitState& state) {
+  const auto& edge = state.graph.edges()[join->edgeIndex];
+
+  const ColumnVector antiOutput{buildNode->outputColumns()};
+  ColumnCP mark = Column::createBoolean("mark");
+  ColumnVector joinOutput{antiOutput};
+  joinOutput.push_back(mark);
+
+  // edge.leftKeys reference the preserved (build) side, rightKeys the probe
+  // side. The IR Join's leftKeys must reference its left (probe) input. A key
+  // referencing a column collapsed in a child is rewritten to the survivor.
+  const auto reps = mergedChildReps(join, state);
+  NodeCP rightSemiProject = state.builder.make<Join>(Join::Key{
+      probeNode,
+      buildNode,
+      velox::core::JoinType::kRightSemiProject,
+      remapToReps(ExprVector{edge.rightKeys()}, reps, state),
+      remapToReps(ExprVector{edge.leftKeys()}, reps, state),
+      remapToReps(ExprVector{edge.filter()}, reps, state),
+      edge.nullAware(),
+      edge.nullAsValue(),
+      std::move(joinOutput)});
+
+  ExprFactory exprFactory{state.builder};
+  NodeCP filtered = state.builder.make<Filter>(
+      Filter::Key{rightSemiProject, ExprVector{exprFactory.makeNot(mark)}});
+
+  // Project away the mark, restoring the antijoin's output schema. Every
+  // entry is a pass-through of the preserved-side column.
+  ExprVector projectExprs;
+  projectExprs.reserve(antiOutput.size());
+  for (ColumnCP column : antiOutput) {
+    projectExprs.push_back(column);
+  }
+  return state.builder.make<Project>(
+      Project::Key{filtered, std::move(projectExprs), antiOutput});
+}
+
+NodeCP emitOp(MemoOpCP op, EmitState& state) {
+  switch (op->kind()) {
+    case MemoOpKind::kLeaf:
+      return emitLeaf(op->as<LeafOp>(), state);
+    case MemoOpKind::kJoin: {
+      const auto* join = op->as<JoinOp>();
+      const auto& edge = state.graph.edges()[join->edgeIndex];
+      NodeCP leftNode = emitOp(join->left, state);
+      if (edge.isUnnest()) {
+        return buildUnnest(join, leftNode, state);
+      }
+      NodeCP rightNode = emitOp(join->right, state);
+      if (join->reversedAnti) {
+        return buildReversedAnti(join, leftNode, rightNode, state);
+      }
+      return buildJoin(
+          join,
+          leftNode,
+          rightNode,
+          coverNarrowedColumns(state.graph, join->cover(), leftNode, rightNode),
+          state);
+    }
+    case MemoOpKind::kExchange: {
+      const auto* exchange = op->as<ExchangeOp>();
+      NodeCP inputNode = emitOp(exchange->input, state);
+      return state.builder.make<Exchange>(
+          Exchange::Key{inputNode, exchange->outputPartitioning()});
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Emits the cluster root. The root join carries exactly `rootOutputColumns`
+// unless an equivalence collapse dropped a target column in favor of its
+// representative; then the join emits representatives and a Project
+// re-materializes each target name (and restores output order).
+NodeCP buildRoot(
+    const JoinOp* join,
+    NodeCP leftNode,
+    NodeCP rightNode,
+    const ColumnVector& rootOutputColumns,
+    EmitState& state) {
+  const auto rootReps = state.graph.coverColumnReps(join->cover());
+  bool collapsed = false;
+  for (ColumnCP target : rootOutputColumns) {
+    const auto it = rootReps.find(target);
+    if (it != rootReps.end() && it->second != target) {
+      collapsed = true;
+      break;
+    }
+  }
+  if (!collapsed) {
+    return buildJoin(
+        join, leftNode, rightNode, ColumnVector{rootOutputColumns}, state);
+  }
+
+  NodeCP joinNode = buildJoin(
+      join,
+      leftNode,
+      rightNode,
+      coverNarrowedColumns(state.graph, join->cover(), leftNode, rightNode),
+      state);
+  ExprVector exprs;
+  exprs.reserve(rootOutputColumns.size());
+  for (ColumnCP target : rootOutputColumns) {
+    const auto it = rootReps.find(target);
+    exprs.push_back(it != rootReps.end() ? it->second : target);
+  }
+  return state.builder.make<Project>(Project::Key{
+      joinNode, std::move(exprs), ColumnVector{rootOutputColumns}});
+}
+
+} // namespace
+
+NodeCP JoinTreeEmitter::emit(
+    MemoOpCP root,
+    const JoinHypergraph& graph,
+    const ColumnVector& rootOutputColumns,
+    Builder& builder) {
+  VELOX_CHECK_NOT_NULL(root);
+  EmitState state{
+      graph,
+      builder,
+      ExprFactory{builder},
+      std::vector<bool>(graph.filterConjuncts().size(), false)};
+  NodeCP result{nullptr};
+  switch (root->kind()) {
+    case MemoOpKind::kLeaf:
+      result = emitLeaf(root->as<LeafOp>(), state);
+      break;
+    case MemoOpKind::kJoin: {
+      const auto* join = root->as<JoinOp>();
+      const auto& edge = state.graph.edges()[join->edgeIndex];
+      NodeCP leftNode = emitOp(join->left, state);
+      if (edge.isUnnest()) {
+        result = buildUnnest(join, leftNode, state);
+      } else {
+        NodeCP rightNode = emitOp(join->right, state);
+        if (join->reversedAnti) {
+          result = buildReversedAnti(join, leftNode, rightNode, state);
+        } else {
+          result =
+              buildRoot(join, leftNode, rightNode, rootOutputColumns, state);
+        }
+      }
+      break;
+    }
+    case MemoOpKind::kExchange:
+      // The chosen join-tree root is never an exchange: a final gather is added
+      // by the fragment splitter, not enumerated into the memo.
+      VELOX_UNREACHABLE("Join-tree root cannot be an exchange");
+  }
+  VELOX_CHECK_NOT_NULL(result);
+  const size_t unplaced =
+      std::count(state.fired.begin(), state.fired.end(), false);
+  VELOX_CHECK_EQ(
+      unplaced,
+      0,
+      "Filter conjuncts were not all placed; required relations exceed the root cover");
+  return result;
+}
+
+NodeCP JoinTreeEmitter::emitComponents(
+    const std::vector<MemoOpCP>& componentRoots,
+    const JoinHypergraph& graph,
+    const ColumnVector& rootOutputColumns,
+    Builder& builder,
+    int32_t numWorkers) {
+  VELOX_CHECK_GE(
+      componentRoots.size(),
+      2,
+      "emitComponents requires at least two components");
+  EmitState state{
+      graph,
+      builder,
+      ExprFactory{builder},
+      std::vector<bool>(graph.filterConjuncts().size(), false)};
+
+  // Emit each component subtree first, sharing one `fired` vector so a
+  // cross-component conjunct is placed once, at a fold below.
+  std::vector<NodeCP> nodes;
+  nodes.reserve(componentRoots.size());
+  for (MemoOpCP root : componentRoots) {
+    nodes.push_back(emitOp(root, state));
+  }
+
+  // Largest component drives as the bottom-left probe; the rest join as
+  // builds in ascending cardinality.
+  std::vector<size_t> order(componentRoots.size());
+  std::iota(order.begin(), order.end(), 0);
+  std::sort(order.begin(), order.end(), [&](size_t lhs, size_t rhs) {
+    // Descending by cardinality. A known cardinality sorts before an unknown
+    // one (an unknown is never the larger); ties — including two unknowns —
+    // break deterministically on the component index.
+    const std::optional<float> lhsCard = componentRoots[lhs]->cost.cardinality;
+    const std::optional<float> rhsCard = componentRoots[rhs]->cost.cardinality;
+    if (lessThan(rhsCard, lhsCard)) {
+      return true;
+    }
+    if (lessThan(lhsCard, rhsCard)) {
+      return false;
+    }
+    if (lhsCard.has_value() != rhsCard.has_value()) {
+      return lhsCard.has_value();
+    }
+    return lhs < rhs;
+  });
+
+  // A target collapsed to a representative within a component must be
+  // re-materialized by name; the final fold then emits representatives and a
+  // Project restores the target names. With no such collapse the final fold
+  // emits `rootOutputColumns` directly and no Project is needed.
+  RelationSet fullCover;
+  for (MemoOpCP root : componentRoots) {
+    fullCover.unionSet(root->cover());
+  }
+  const auto rootReps = graph.coverColumnReps(fullCover);
+  bool collapsed = false;
+  for (ColumnCP target : rootOutputColumns) {
+    const auto it = rootReps.find(target);
+    if (it != rootReps.end() && it->second != target) {
+      collapsed = true;
+      break;
+    }
+  }
+
+  NodeCP result = nodes[order[0]];
+  RelationSet cover{componentRoots[order[0]]->cover()};
+  for (size_t i = 1; i < order.size(); ++i) {
+    NodeCP build = nodes[order[i]];
+    // A cross product is keyless: broadcast the build so the probe keeps its
+    // partitioning and a single-task (Values / global-aggregate) or scan build
+    // is isolated in its own fragment instead of co-locating with the probe.
+    if (numWorkers > 1) {
+      build = builder.make<Exchange>(
+          Exchange::Key{build, Partitioning::globalBroadcast()});
+    }
+    cover.unionSet(componentRoots[order[i]]->cover());
+    const bool isLast = (i + 1 == order.size());
+    ColumnVector columns = (isLast && !collapsed)
+        ? ColumnVector{rootOutputColumns}
+        : coverNarrowedColumns(state.graph, cover, result, build);
+    const auto reps = graph.coverColumnReps(cover);
+    result = builder.make<Join>(Join::Key{
+        result,
+        build,
+        velox::core::JoinType::kInner,
+        /*leftKeys=*/ExprVector{},
+        /*rightKeys=*/ExprVector{},
+        remapToReps(
+            takeReadyConjuncts(state.graph, cover, state.fired), reps, state),
+        /*nullAware=*/false,
+        /*nullAsValue=*/false,
+        std::move(columns)});
+  }
+
+  if (collapsed) {
+    ExprVector projectExprs;
+    projectExprs.reserve(rootOutputColumns.size());
+    for (ColumnCP target : rootOutputColumns) {
+      const auto it = rootReps.find(target);
+      projectExprs.push_back(it != rootReps.end() ? it->second : target);
+    }
+    result = builder.make<Project>(Project::Key{
+        result, std::move(projectExprs), ColumnVector{rootOutputColumns}});
+  }
+
+  const size_t unplaced =
+      std::count(state.fired.begin(), state.fired.end(), false);
+  VELOX_CHECK_EQ(
+      unplaced,
+      0,
+      "Filter conjuncts were not all placed across cross-product components");
+  return result;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinTreeEmitter.h
+++ b/axiom/optimizer/v2/JoinTreeEmitter.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <vector>
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/DPhyp.h"
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Translates the `MemoOp` tree DPhyp produced back into an IR
+/// `Join` tree by walking bottom-up: each `LeafOp` resolves to the
+/// relation's IR node; each `JoinOp` calls `Builder::make<Join>` with
+/// the edge's keys/filter and the chosen child plans.
+///
+/// Intermediate Joins carry the lossless union of their children's
+/// columns. The root Join carries exactly `rootOutputColumns` so
+/// upstream consumers see the same schema the original cluster root
+/// exposed, regardless of how the chosen tree shape rearranges
+/// relations underneath.
+class JoinTreeEmitter {
+ public:
+  /// Emits the tree-IR for the join tree DPhyp chose, rooted at the memo
+  /// entry `root`. `rootOutputColumns` are the columns the result must expose
+  /// (see class comment); `graph` supplies each memo op's relation and edge,
+  /// and `builder` hash-conses the emitted nodes.
+  static NodeCP emit(
+      MemoOpCP root,
+      const JoinHypergraph& graph,
+      const ColumnVector& rootOutputColumns,
+      Builder& builder);
+
+  /// Emits a cross-product combine of independently planned connected
+  /// components. Each component subtree is emitted, then the components
+  /// are folded left-deep into keyless inner `Join` nodes (Velox lowers
+  /// these to NestedLoopJoin): the largest component (by estimated
+  /// cardinality) drives as the bottom-left probe, the rest join as
+  /// builds in ascending cardinality. Cross-component filter conjuncts
+  /// are placed at the lowest fold whose cover satisfies them. The root
+  /// carries `rootOutputColumns`. Requires at least two components.
+  /// `numWorkers > 1` broadcasts each cross-product build so a single-task
+  /// (Values / global-aggregate) or scan component is not co-located with
+  /// another component in one fragment.
+  static NodeCP emitComponents(
+      const std::vector<MemoOpCP>& componentRoots,
+      const JoinHypergraph& graph,
+      const ColumnVector& rootOutputColumns,
+      Builder& builder,
+      int32_t numWorkers);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/KeyHash.h
+++ b/axiom/optimizer/v2/KeyHash.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <type_traits>
+
+#include "axiom/optimizer/QueryGraph.h"
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Hashes a single value. Pointer / integer / enum / range / Frame are
+/// handled generically; pointer-elements of ranges are hashed by address,
+/// matching how `Key::operator==` compares them.
+template <typename T>
+size_t hashOne(const T& value);
+
+// Forward declaration: keeps `hashOf` (template) able to resolve to this
+// non-template overload during phase-1 name lookup; otherwise the generic
+// `hashOne<Frame>` template hits the catch-all static_assert.
+size_t hashOne(const Frame& frame);
+
+/// Hashes a list of fields by combining `hashOne` of each via `hashMix`.
+template <typename... Args>
+size_t hashOf(const Args&... args) {
+  size_t hash = 0;
+  ((hash = velox::bits::hashMix(hash, hashOne(args))), ...);
+  return hash;
+}
+
+inline size_t hashOne(const Frame& frame) {
+  return hashOf(
+      frame.type,
+      frame.startType,
+      frame.startValue,
+      frame.endType,
+      frame.endValue);
+}
+
+template <typename T>
+size_t hashOne(const T& value) {
+  if constexpr (std::is_pointer_v<T>) {
+    return reinterpret_cast<uintptr_t>(value);
+  } else if constexpr (std::is_enum_v<T>) {
+    return static_cast<size_t>(value);
+  } else if constexpr (std::is_integral_v<T>) {
+    return static_cast<size_t>(value);
+  } else if constexpr (requires {
+                         value.begin();
+                         value.end();
+                       }) {
+    size_t hash = 0;
+    for (const auto& element : value) {
+      hash = velox::bits::hashMix(hash, hashOne(element));
+    }
+    return hash;
+  } else {
+    static_assert(
+        sizeof(T) == 0, "Add a hashOne overload for this type in KeyHash.h");
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/LimitAndOrderPass.cpp
+++ b/axiom/optimizer/v2/LimitAndOrderPass.cpp
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/LimitAndOrderPass.h"
+
+#include <algorithm>
+#include <limits>
+#include <optional>
+#include <utility>
+
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+namespace {
+
+// A count of this value means "no row bound" (a pure OFFSET).
+constexpr int64_t kNoCount = std::numeric_limits<int64_t>::max();
+
+// A row bound: skip 'offset' rows, then emit up to 'count' (kNoCount means
+// unbounded).
+struct LimitBound {
+  int64_t offset;
+  int64_t count;
+};
+
+// Composes two bounds: 'inner' is applied first, then 'outer' on its output.
+// inner yields 'inner.count' rows after skipping 'inner.offset'; outer skips
+// 'outer.offset' more of those and takes 'outer.count'.
+LimitBound collapse(const LimitBound& outer, const LimitBound& inner) {
+  const int64_t offset = inner.offset + outer.offset;
+  int64_t count;
+  if (inner.count == kNoCount) {
+    // Inner unbounded: outer's bound governs the rows after outer.offset.
+    count = outer.count;
+  } else {
+    const int64_t afterOuterOffset =
+        std::max<int64_t>(0, inner.count - outer.offset);
+    count = outer.count == kNoCount ? afterOuterOffset
+                                    : std::min(outer.count, afterOuterOffset);
+  }
+  return {offset, count};
+}
+
+// State threaded top-down.
+struct LimitContext {
+  // The row bound the consumer imposes on the current node's output, placed as
+  // low as the per-node rules allow.
+  std::optional<LimitBound> pending;
+
+  // Whether the row order produced at the current node is preserved all the
+  // way to the query output. A bare Sort reached with this false is dropped.
+  bool orderPreserved{true};
+};
+
+// Top-down rewriter that threads the pending row bound and the
+// order-preservation flag (see `LimitContext`) and applies the per-node
+// limit/order rules described on `LimitAndOrderPass`.
+class LimitAndOrderRewriter : public NodeRewriter<LimitContext> {
+ public:
+  using NodeRewriter::NodeRewriter;
+
+ protected:
+  // A Limit folds into the pending bound (collapse) and is dropped here; the
+  // bound flows down to be fused into a Sort/TopN or materialized at a barrier.
+  NodeCP rewriteLimit(const Limit* node, LimitContext& context) override {
+    const LimitBound here{node->offset(), node->count()};
+    const LimitBound bound =
+        context.pending ? collapse(*context.pending, here) : here;
+    if (bound.count == 0) {
+      return builder().makeEmptyValues(node->outputColumns());
+    }
+    context.pending = bound;
+    return rewrite(node->input(), context);
+  }
+
+  // A bounded pending bound fuses into a TopN. With no bound, a Sort whose
+  // order is not observed (orderPreserved == false) is dropped — this covers a
+  // Sort feeding an order-non-preserving operator and Sort-over-Sort. An
+  // unbounded bound (pure OFFSET) keeps the Sort (the offset selects specific
+  // sorted rows) under a materialized Limit. Nothing pushes below a Sort.
+  NodeCP rewriteSort(const Sort* node, LimitContext& context) override {
+    const auto pending = std::exchange(context.pending, std::nullopt);
+    const bool dropSort = !pending && !context.orderPreserved;
+    // A Sort establishes its own order, so its input's order is not preserved.
+    context.orderPreserved = false;
+    const NodeCP newInput = rewrite(node->input(), context);
+    if (pending && pending->count != kNoCount) {
+      return builder().make<TopN>(
+          {newInput,
+           node->orderKeys(),
+           node->orderTypes(),
+           pending->offset,
+           pending->count});
+    }
+    if (dropSort) {
+      return newInput;
+    }
+    const NodeCP sort = newInput == node->input()
+        ? node
+        : builder().make<Sort>(
+              {newInput, node->orderKeys(), node->orderTypes()});
+    return materialize(pending, sort);
+  }
+
+  // A pending bound folds into the TopN's bound; nothing pushes below a TopN.
+  NodeCP rewriteTopN(const TopN* node, LimitContext& context) override {
+    const auto pending = std::exchange(context.pending, std::nullopt);
+    // A TopN establishes its own order, so its input's order is not preserved.
+    context.orderPreserved = false;
+    const NodeCP newInput = rewrite(node->input(), context);
+    if (pending) {
+      const LimitBound folded =
+          collapse(*pending, {node->offset(), node->count()});
+      if (folded.count == 0) {
+        return builder().makeEmptyValues(node->outputColumns());
+      }
+      return builder().make<TopN>(
+          {newInput,
+           node->orderKeys(),
+           node->orderTypes(),
+           folded.offset,
+           folded.count});
+    }
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder().make<TopN>(
+        {newInput,
+         node->orderKeys(),
+         node->orderTypes(),
+         node->offset(),
+         node->count()});
+  }
+
+  // UnionAll: copy a bounded bound into every leg (each leg needs at most
+  // offset + count rows) and keep the original bound above the union.
+  NodeCP rewriteUnionAll(const UnionAll* node, LimitContext& context) override {
+    const auto pending = std::exchange(context.pending, std::nullopt);
+    std::optional<LimitBound> legBound;
+    if (pending && pending->count != kNoCount) {
+      legBound = LimitBound{0, pending->offset + pending->count};
+    }
+
+    NodeVector newInputs;
+    newInputs.reserve(node->inputs().size());
+    bool changed = false;
+    for (const NodeCP input : node->inputs()) {
+      LimitContext legContext;
+      legContext.pending = legBound;
+      // UnionAll does not preserve any leg's row order.
+      legContext.orderPreserved = false;
+      const NodeCP newInput = rewrite(input, legContext);
+      changed |= newInput != input;
+      newInputs.push_back(newInput);
+    }
+
+    const NodeCP newUnion = changed
+        ? builder().make<UnionAll>(
+              {std::move(newInputs), node->legColumns(), node->outputColumns()})
+        : node;
+    return materialize(pending, newUnion);
+  }
+
+  // EnforceSingleRow yields <=1 row and throws if its input has more. A bound
+  // with offset 0 keeps that row, so it is redundant and dropped. A positive
+  // offset yields zero rows, but the node must still run to enforce its
+  // single-row check, so the bound is materialized above it rather than
+  // replacing the node (which would skip the check).
+  NodeCP rewriteEnforceSingleRow(
+      const EnforceSingleRow* node,
+      LimitContext& context) override {
+    const auto pending = std::exchange(context.pending, std::nullopt);
+    const auto bound =
+        (pending && pending->offset > 0) ? pending : std::nullopt;
+    return materialize(
+        bound, NodeRewriter::rewriteEnforceSingleRow(node, context));
+  }
+
+  // Barriers: a bound cannot move below them, so materialize it above and
+  // rewrite the inputs with no pending bound. 'preservesOrder' says whether the
+  // node passes its input's order through (drives the bare-Sort drop below).
+  //
+  // The multi-input barriers (Join, Apply) delegate to the base rewriter, which
+  // rewrites all inputs with this one shared context. That is safe because the
+  // macro clears `pending` (via the std::exchange below) and sets
+  // `orderPreserved` false *before* delegating, so no input is rewritten with
+  // the bound and none re-enables order preservation.
+#define LIMIT_BARRIER(NodeT, RewriteMethod, preservesOrder)                  \
+  NodeCP RewriteMethod(const NodeT* node, LimitContext& context) override {  \
+    const auto pending = std::exchange(context.pending, std::nullopt);       \
+    if (!(preservesOrder)) {                                                 \
+      context.orderPreserved = false;                                        \
+    }                                                                        \
+    return materialize(pending, NodeRewriter::RewriteMethod(node, context)); \
+  }
+
+  LIMIT_BARRIER(Scan, rewriteScan, true)
+  LIMIT_BARRIER(Values, rewriteValues, true)
+  LIMIT_BARRIER(Filter, rewriteFilter, true)
+  LIMIT_BARRIER(Aggregate, rewriteAggregate, false)
+  LIMIT_BARRIER(GroupId, rewriteGroupId, false)
+  LIMIT_BARRIER(Unnest, rewriteUnnest, false)
+  LIMIT_BARRIER(Join, rewriteJoin, false)
+  LIMIT_BARRIER(Window, rewriteWindow, false)
+  LIMIT_BARRIER(Apply, rewriteApply, false)
+  LIMIT_BARRIER(EnforceDistinct, rewriteEnforceDistinct, false)
+  LIMIT_BARRIER(TopNRowNumber, rewriteTopNRowNumber, false)
+  LIMIT_BARRIER(Exchange, rewriteExchange, false)
+
+#undef LIMIT_BARRIER
+
+  // Project, AssignUniqueId, and MarkDistinct are row-preserving (1:1), so the
+  // base rewrites — which thread the pending bound into the input — push the
+  // bound below them unchanged.
+
+ private:
+  // Wraps 'node' in a Limit carrying the bound, or returns it unchanged when
+  // there is no bound.
+  NodeCP materialize(const std::optional<LimitBound>& pending, NodeCP node) {
+    if (!pending) {
+      return node;
+    }
+    return builder().make<Limit>({node, pending->offset, pending->count});
+  }
+};
+
+} // namespace
+
+NodeCP LimitAndOrderPass::run(NodeCP root, Builder& builder) {
+  LimitContext context;
+  return LimitAndOrderRewriter(builder).rewrite(root, context);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/LimitAndOrderPass.h
+++ b/axiom/optimizer/v2/LimitAndOrderPass.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Fuses and pushes limits and orders down the tree IR. In one top-down
+/// traversal it threads a pending row bound and an order-preservation flag,
+/// applying these rewrites:
+///
+///  - fuses a `Limit` over a `Sort` into a `TopN`;
+///  - collapses a `Limit` over a `Limit` or `TopN` into a single bound;
+///  - pushes a `Limit` through row-preserving nodes (`Project`,
+///    `AssignUniqueId`, `MarkDistinct`) and copies it into each `UnionAll` leg;
+///  - drops a bare `Sort` whose order no consumer observes.
+class LimitAndOrderPass {
+ public:
+  /// Returns `root` with the rewrites above applied. Runs after decorrelate.
+  static NodeCP run(NodeCP root, Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/MemoOp.cpp
+++ b/axiom/optimizer/v2/MemoOp.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/MemoOp.h"
+
+#include <folly/container/F14Map.h>
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+const folly::F14FastMap<MemoOpKind, std::string_view>& memoOpKindNames() {
+  static const folly::F14FastMap<MemoOpKind, std::string_view> kNames = {
+      {MemoOpKind::kLeaf, "Leaf"},
+      {MemoOpKind::kJoin, "Join"},
+      {MemoOpKind::kExchange, "Exchange"},
+  };
+  return kNames;
+}
+
+RelationSet combinedCover(MemoOpCP left, MemoOpCP right) {
+  RelationSet result{left->cover()};
+  result.unionSet(right->cover());
+  return result;
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(MemoOpKind, memoOpKindNames);
+
+JoinOp::JoinOp(
+    Cost cost,
+    MemoOpCP leftChild,
+    MemoOpCP rightChild,
+    size_t edge,
+    velox::core::JoinType type,
+    bool reversedAnti,
+    std::vector<size_t> extraEdges,
+    Partitioning outputPartitioning)
+    : MemoOp{cost, MemoOpKind::kJoin, std::move(outputPartitioning)},
+      left{leftChild},
+      right{rightChild},
+      edgeIndex{edge},
+      joinType{type},
+      reversedAnti{reversedAnti},
+      extraEdges{std::move(extraEdges)},
+      cover_{combinedCover(leftChild, rightChild)} {}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/MemoOp.h
+++ b/axiom/optimizer/v2/MemoOp.h
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "axiom/common/Enums.h"
+#include "axiom/optimizer/v2/Cost.h"
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "axiom/optimizer/v2/RelationSet.h"
+#include "velox/core/PlanNode.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+enum class MemoOpKind : uint8_t {
+  kLeaf,
+  kJoin,
+  kExchange,
+};
+
+AXIOM_DECLARE_ENUM_NAME(MemoOpKind);
+
+/// Base class for DPhyp's slim memo entries. Each entry records
+/// the choices DPhyp made for one subplan — kind, children, edge,
+/// join type — not full IR data, which lives on the hypergraph and
+/// the original tree IR.
+class MemoOp {
+ public:
+  /// Cost of this subplan. Set once by the cost model immediately after
+  /// construction and treated as immutable thereafter.
+  Cost cost;
+
+  virtual ~MemoOp() = default;
+
+  MemoOpKind kind() const {
+    return kind_;
+  }
+
+  bool is(MemoOpKind kind) const {
+    return kind_ == kind;
+  }
+
+  /// Downcast to a known subclass. Caller must have checked `is(...)`.
+  template <typename T>
+  const T* as() const {
+    return static_cast<const T*>(this);
+  }
+
+  /// Set of relations covered by this subplan.
+  virtual RelationSet cover() const = 0;
+
+  /// Global (across-tasks) partitioning of this subplan's output — the
+  /// dimension the property-aware memo keeps non-dominated alternatives on.
+  /// `kUnspecified` unless an `ExchangeOp` establishes a partitioning, or a
+  /// `JoinOp` over inputs co-partitioned on its keys inherits one. Set at
+  /// construction; every op leaves it unspecified at `numWorkers=1`, so the
+  /// memo behaves as single-best.
+  const Partitioning& outputPartitioning() const {
+    return outputPartitioning_;
+  }
+
+ protected:
+  MemoOp(Cost cost, MemoOpKind kind, Partitioning outputPartitioning = {})
+      : cost{cost},
+        kind_{kind},
+        outputPartitioning_{std::move(outputPartitioning)} {}
+
+ private:
+  const MemoOpKind kind_;
+  const Partitioning outputPartitioning_;
+};
+
+using MemoOpCP = const MemoOp*;
+
+/// Leaf entry: a single relation. The IR node lives at
+/// `graph.relation(relationId).node()`.
+class LeafOp : public MemoOp {
+ public:
+  const int8_t relationId;
+
+  LeafOp(Cost cost, int8_t id, Partitioning outputPartitioning = {})
+      : MemoOp{cost, MemoOpKind::kLeaf, std::move(outputPartitioning)},
+        relationId{id} {}
+
+  RelationSet cover() const override {
+    return RelationSet::singleton(relationId);
+  }
+};
+
+/// Join entry: combines two child subplans via the predicate at
+/// `graph.edges()[edgeIndex]`. `joinType` records the join
+/// semantic chosen.
+class JoinOp : public MemoOp {
+ public:
+  MemoOpCP const left;
+  MemoOpCP const right;
+  const size_t edgeIndex;
+  const velox::core::JoinType joinType;
+
+  /// True when this candidate is an antijoin played in its reversed
+  /// (build-on-the-preserved-side) orientation, lowered at emit to a
+  /// kRightSemiProject + Filter(not mark) + Project. A null-aware antijoin
+  /// carrying an extra filter has no valid reversed form (Velox forbids a
+  /// null-aware kRightSemiProject with an internal filter) and stays native.
+  const bool reversedAnti;
+
+  /// Additional inner equi-join edges that also cross this join's partition
+  /// and are applied together with `edgeIndex`. Standard DPhyp conjoins all
+  /// predicates connecting the two subgraphs; with a cyclic join graph more
+  /// than one edge can cross a single partition. Empty for the common
+  /// single-edge join; every entry is a `kInner` equi-edge.
+  const std::vector<size_t> extraEdges;
+
+  JoinOp(
+      Cost cost,
+      MemoOpCP leftChild,
+      MemoOpCP rightChild,
+      size_t edge,
+      velox::core::JoinType type,
+      bool reversedAnti = false,
+      std::vector<size_t> extraEdges = {},
+      Partitioning outputPartitioning = {});
+
+  RelationSet cover() const override {
+    return cover_;
+  }
+
+ private:
+  const RelationSet cover_;
+};
+
+/// Memo entry for a remote exchange (repartition) wrapping `input`, lowered to
+/// an `ir.Exchange` by `JoinTreeEmitter`. Its `outputPartitioning()` is the
+/// target partitioning; its cost is the child's plus the shuffle, computed by
+/// the candidate generator and passed in at construction.
+class ExchangeOp : public MemoOp {
+ public:
+  MemoOpCP const input;
+
+  ExchangeOp(Cost cost, MemoOpCP inputChild, Partitioning partitioning)
+      : MemoOp{cost, MemoOpKind::kExchange, std::move(partitioning)},
+        input{inputChild} {}
+
+  RelationSet cover() const override {
+    return input->cover();
+  }
+};
+
+using ExchangeOpCP = const ExchangeOp*;
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1,0 +1,1983 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Node.h"
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/KeyHash.h"
+#include "axiom/optimizer/v2/NodePrinter.h"
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+const auto& nodeTypeNames() {
+  static const folly::F14FastMap<NodeType, std::string_view> kNames = {
+      {NodeType::kScan, "Scan"},
+      {NodeType::kFilter, "Filter"},
+      {NodeType::kProject, "Project"},
+      {NodeType::kLimit, "Limit"},
+      {NodeType::kSort, "Sort"},
+      {NodeType::kTopN, "TopN"},
+      {NodeType::kAggregate, "Aggregate"},
+      {NodeType::kGroupId, "GroupId"},
+      {NodeType::kMarkDistinct, "MarkDistinct"},
+      {NodeType::kValues, "Values"},
+      {NodeType::kUnnest, "Unnest"},
+      {NodeType::kUnionAll, "UnionAll"},
+      {NodeType::kJoin, "Join"},
+      {NodeType::kWindow, "Window"},
+      {NodeType::kTopNRowNumber, "TopNRowNumber"},
+      {NodeType::kApply, "Apply"},
+      {NodeType::kEnforceSingleRow, "EnforceSingleRow"},
+      {NodeType::kAssignUniqueId, "AssignUniqueId"},
+      {NodeType::kEnforceDistinct, "EnforceDistinct"},
+      {NodeType::kExchange, "Exchange"},
+      {NodeType::kTableWrite, "TableWrite"},
+  };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(NodeType, nodeTypeNames);
+
+std::string Node::toString() const {
+  return NodePrinter::toText(this);
+}
+
+namespace {
+
+// Per-operator derivation of per-driver local properties. Each node computes
+// these in its constructor from its already-constructed inputs; distribution
+// and relation-level properties are added with their consumers.
+
+// Keeps the local properties expressible over `columns`: a `kGrouped` entry
+// survives only if all its columns do; a `kSorted` entry is truncated to its
+// leading run of columns in `columns`. A dropped or truncated entry ends the
+// list — nothing nested under a broken outer property still holds.
+LocalPropertyVector projectLocal(
+    const LocalPropertyVector& local,
+    const PlanObjectSet& columns) {
+  LocalPropertyVector result;
+  for (const LocalProperty& property : local) {
+    if (property.kind == LocalPropertyKind::kGrouped) {
+      if (!columns.containsAll(property.columns)) {
+        break;
+      }
+      result.push_back(property);
+      continue;
+    }
+    LocalProperty truncated{.kind = LocalPropertyKind::kSorted};
+    for (size_t i = 0; i < property.columns.size(); ++i) {
+      if (!columns.contains(property.columns[i])) {
+        break;
+      }
+      truncated.columns.push_back(property.columns[i]);
+      truncated.orders.push_back(property.orders[i]);
+    }
+    if (truncated.columns.empty()) {
+      break;
+    }
+    const bool full = truncated.columns.size() == property.columns.size();
+    result.push_back(std::move(truncated));
+    if (!full) {
+      break;
+    }
+  }
+  return result;
+}
+
+// Keeps an input's local properties expressible over `columns` (see
+// `projectLocal`), for a node that emits only a subset of its input.
+LocalPropertyVector retainedLocal(NodeCP input, const ColumnVector& columns) {
+  return projectLocal(
+      input->physicalProperties().local, PlanObjectSet::fromObjects(columns));
+}
+
+// Keeps an input's unique key-sets whose columns all survive in `columns`, for
+// a node that emits only a subset of its input. A key-set with a dropped member
+// is no longer a key of the output, so it is removed whole.
+UniqueKeySetVector retainedUnique(NodeCP input, const ColumnVector& columns) {
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  UniqueKeySetVector result;
+  for (const UniqueKeySet& key : input->physicalProperties().unique) {
+    if (key.columns.isSubset(columnSet)) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+// A single `Sorted` property over the leading run of `keys` that are columns,
+// paired with their orders. A computed sort key is not an output column, so it
+// (and everything after it) is dropped; empty when the first key is not a
+// column.
+LocalPropertyVector sortedLocal(
+    const ExprVector& keys,
+    const OrderTypeVector& orderTypes) {
+  ColumnVector columns;
+  OrderTypeVector orders;
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->isColumn()) {
+      break;
+    }
+    columns.push_back(keys[i]->as<Column>());
+    orders.push_back(orderTypes[i]);
+  }
+  if (columns.empty()) {
+    return {};
+  }
+  LocalPropertyVector result;
+  result.push_back(
+      {.kind = LocalPropertyKind::kSorted,
+       .columns = std::move(columns),
+       .orders = std::move(orders)});
+  return result;
+}
+
+// Local ordering an exchange's output carries: an order-preserving gather keeps
+// the merged sort order; every other exchange interleaves rows and keeps none.
+LocalPropertyVector exchangeLocal(const Partitioning& partitioning) {
+  if (partitioning.orderKeys.empty()) {
+    return {};
+  }
+  return sortedLocal(partitioning.orderKeys, partitioning.orderTypes);
+}
+
+// A single `Grouped` property over `columns` (empty when there are none).
+LocalPropertyVector groupedLocal(const ColumnVector& columns) {
+  if (columns.empty()) {
+    return {};
+  }
+  LocalPropertyVector result;
+  result.push_back({.kind = LocalPropertyKind::kGrouped, .columns = columns});
+  return result;
+}
+
+// A single `Grouped` property over one column.
+LocalPropertyVector groupedLocal(ColumnCP column) {
+  ColumnVector columns;
+  columns.push_back(column);
+  return groupedLocal(columns);
+}
+
+// A single global unique key over 'column' (e.g. AssignUniqueId's id).
+UniqueKeySetVector globalUniqueKey(ColumnCP column) {
+  UniqueKeySetVector result;
+  result.push_back(
+      UniqueKeySet{
+          .columns = PlanObjectSet::single(column),
+          .scope = PropertyScope::kGlobal});
+  return result;
+}
+
+// Uniqueness that survives a remote exchange. A repartition/gather moves rows
+// without duplicating them, so global uniqueness holds; but it can gather
+// cross-driver duplicates onto one driver, so driver-scope uniqueness does not
+// survive. A broadcast replicates rows and destroys even global uniqueness.
+UniqueKeySetVector uniqueAcrossExchange(
+    const UniqueKeySetVector& unique,
+    const Partitioning& partitioning) {
+  if (partitioning.is(PartitionKind::kBroadcast)) {
+    return {};
+  }
+  UniqueKeySetVector result;
+  for (const UniqueKeySet& key : unique) {
+    if (key.scope == PropertyScope::kGlobal) {
+      result.push_back(key);
+    }
+  }
+  return result;
+}
+
+// Local grouping an inner/left join gains from probe uniqueness: a hash join
+// emits each probe row's matches as one contiguous run, so the output is
+// grouped by any key unique on the probe whose columns all survive —
+// independent of the probe's input order, so this holds even after an exchange
+// erased the probe's own local grouping. Caveat: a spilling probe or a
+// driver-scrambling local exchange breaks it; valid at single-fragment,
+// numDrivers=1.
+void appendProbeUniqueGroupings(
+    NodeCP left,
+    const PlanObjectSet& outputColumns,
+    LocalPropertyVector& local) {
+  for (const UniqueKeySet& key : left->physicalProperties().unique) {
+    if (key.columns.isSubset(outputColumns)) {
+      local.push_back(
+          LocalProperty{
+              .kind = LocalPropertyKind::kGrouped,
+              .columns = key.columns.template toObjects<Column>()});
+    }
+  }
+}
+
+// The probe (left) side's local properties survive an inner / left join within
+// a driver; build-emitting and cross joins drop them.
+// TODO: order through a spillable join is not guaranteed once spilling is
+// enabled; revisit when spilling is modeled.
+LocalPropertyVector joinLocal(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    const ColumnVector& outputColumns) {
+  if (joinType == velox::core::JoinType::kInner ||
+      joinType == velox::core::JoinType::kLeft) {
+    LocalPropertyVector local = retainedLocal(left, outputColumns);
+    appendProbeUniqueGroupings(
+        left, PlanObjectSet::fromObjects(outputColumns), local);
+    return local;
+  }
+  return {};
+}
+
+// Properties an operator inherits when it neither repartitions nor changes
+// which rows exist in a way that breaks them: the input's distribution (minus
+// its merge order, which belonged to the gather it came from — see
+// `Partitioning::dropOrder`), local properties, and uniqueness. Such an
+// operator keeps all of the input's columns, so every inherited property
+// already references output columns.
+PhysicalProperties passThroughProperties(NodeCP input) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
+      .local = props.local,
+      .unique = props.unique};
+}
+
+// Properties of an operator that sorts its input on `orderKeys` without moving
+// rows across tasks: it keeps the input's distribution and uniqueness and adds
+// the per-driver sort order. A distributed sort is a per-task sort under a
+// separate gather-merge exchange, and a single-stage sort runs over an
+// already-gathered input — so the sort node itself inherits the input's
+// partitioning either way (it is not the gather).
+PhysicalProperties sortedProperties(
+    NodeCP input,
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
+      .local = sortedLocal(orderKeys, orderTypes),
+      .unique = props.unique};
+}
+
+// Remaps the input partitioning through a Project's column map: each partition
+// key (an input column) is re-expressed on the output column that projects it,
+// whether identity or rename (`exprs[i]` is a bare reference to the key, so its
+// output column `outputColumns[i]` carries the same values, hence the same hash
+// partition). A key not projected as a bare column — dropped, or appearing only
+// inside a computed expression — drops the partition to unspecified. Gather and
+// unspecified pass through unchanged.
+Partitioning projectGlobalPartition(
+    NodeCP input,
+    const ExprVector& exprs,
+    const ColumnVector& outputColumns) {
+  const Partitioning& partitioning =
+      input->physicalProperties().globalPartition;
+  if (partitioning.kind != PartitionKind::kPartitioned) {
+    return partitioning.dropOrder();
+  }
+  ExprVector keys;
+  keys.reserve(partitioning.keys.size());
+  for (ExprCP key : partitioning.keys) {
+    ExprCP projected = nullptr;
+    for (size_t i = 0; i < exprs.size(); ++i) {
+      if (exprs[i]->sameOrEqual(*key)) {
+        projected = outputColumns[i];
+        break;
+      }
+    }
+    if (projected == nullptr) {
+      return {};
+    }
+    keys.push_back(projected);
+  }
+  Partitioning result = partitioning;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// An output column equal to 'key', or null. Inner-join equalities merge the
+// equated columns into one equivalence class (see Column::equals); every member
+// holds the same value on every output row, so any surviving class member
+// partitions the output exactly as 'key' does. Only columns form equivalence
+// classes, so a non-column key has no substitute.
+ExprCP survivingEquiKey(ExprCP key, const PlanObjectSet& outputColumns) {
+  if (!key->is(PlanType::kColumnExpr)) {
+    return nullptr;
+  }
+
+  if (const auto* equivalence = key->as<Column>()->equivalence()) {
+    for (ColumnCP column : equivalence->columns) {
+      if (outputColumns.contains(column)) {
+        return column;
+      }
+    }
+  }
+
+  return nullptr;
+}
+
+// Output global partitioning of a join. Only an inner or left join keeps the
+// probe (left) rows in their partitions, so only those preserve a probe
+// partition; other join types drop it. If every probe key is still an output
+// column, the output is partitioned exactly as the probe was. Otherwise an
+// inner join recovers each remaining key: it keeps a key whose columns all
+// survive (a join projects columns unchanged, so a surviving column is
+// identity-projected, and an expression over surviving columns still partitions
+// the output), else substitutes an equal output column from the key's
+// inner-join equivalence class. A left join can't recover a key from its
+// null-padded build, so a dropped key makes its partition unspecified. A
+// non-hash distribution (gather / broadcast / arbitrary) carries no keys and is
+// inherited by kind, minus any merge order (see `Partitioning::dropOrder`).
+Partitioning joinGlobalPartition(
+    velox::core::JoinType joinType,
+    NodeCP left,
+    const ColumnVector& outputColumns) {
+  if (joinType != velox::core::JoinType::kInner &&
+      joinType != velox::core::JoinType::kLeft) {
+    return {};
+  }
+
+  const Partitioning& probe = left->physicalProperties().globalPartition;
+  if (probe.kind != PartitionKind::kPartitioned) {
+    return probe.dropOrder();
+  }
+
+  const auto outputSet = PlanObjectSet::fromObjects(outputColumns);
+  if (outputSet.containsAll(probe.keys)) {
+    return probe;
+  }
+
+  if (joinType != velox::core::JoinType::kInner) {
+    return {};
+  }
+
+  ExprVector keys;
+  keys.reserve(probe.keys.size());
+  for (ExprCP key : probe.keys) {
+    if (outputSet.containsColumns(key)) {
+      keys.push_back(key);
+      continue;
+    }
+    ExprCP equiKey = survivingEquiKey(key, outputSet);
+    if (equiKey == nullptr) {
+      return {};
+    }
+    keys.push_back(equiKey);
+  }
+
+  Partitioning result = probe;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// The input's partitioning re-expressed on the aggregate's output. An aggregate
+// streams over its input without moving rows, so it preserves the input's
+// partitioning — but only when that partitioning's keys are all grouping keys
+// (the only input values the aggregate keeps): then those keys are a
+// co-location of the groups and survive in the output, re-expressed on the
+// grouping output columns they map to. An input partitioned on anything else
+// does not co-locate the groups (it should not feed the aggregate at all) and
+// could not be expressed on the output, so the partitioning is unknown. A
+// grouping-set aggregate reads its GroupId, which has no known partitioning, so
+// it falls into the unknown case. A non-hash distribution (gather / broadcast /
+// arbitrary) is inherited by kind only, with its merge order dropped (see
+// `Partitioning::dropOrder`), as the aggregate reorders rows and so does not
+// preserve one. `groupingColumns` are the output columns holding the grouping
+// values, aligned with `groupingKeys`.
+Partitioning aggregateInputPartition(
+    NodeCP input,
+    const ExprVector& groupingKeys,
+    const ColumnVector& groupingColumns) {
+  const Partitioning& inputPartition =
+      input->physicalProperties().globalPartition;
+  if (inputPartition.kind != PartitionKind::kPartitioned) {
+    return inputPartition.dropOrder();
+  }
+  ExprVector keys;
+  keys.reserve(inputPartition.keys.size());
+  for (ExprCP key : inputPartition.keys) {
+    const auto it = std::ranges::find(groupingKeys, key);
+    if (it == groupingKeys.end()) {
+      return {};
+    }
+    keys.push_back(groupingColumns[it - groupingKeys.begin()]);
+  }
+  Partitioning result = inputPartition;
+  result.keys = std::move(keys);
+  return result;
+}
+
+// Output partitioning of a complete (single / final) aggregation: a global
+// aggregate gathers to one task; otherwise the input's partitioning
+// re-expressed on the output (see `aggregateInputPartition`).
+Partitioning aggregateGlobalPartition(
+    NodeCP input,
+    const ExprVector& groupingKeys,
+    const ColumnVector& groupingColumns) {
+  if (groupingKeys.empty()) {
+    return Partitioning::globalGather();
+  }
+  return aggregateInputPartition(input, groupingKeys, groupingColumns);
+}
+
+// Output partitioning of a scan of a bucketed (connector-partitioned) table:
+// the connector's partition function on the output columns matching the
+// layout's partition columns. Unspecified when the table is not partitioned or
+// a partition column is not in the scan's output (so the partitioning can't be
+// expressed over the output).
+Partitioning scanGlobalPartition(const Scan::Key& key) {
+  const auto* schemaTable = key.baseTable->schemaTable;
+  if (schemaTable == nullptr || schemaTable->columnGroups.empty()) {
+    return {};
+  }
+  const connector::TableLayout* layout = schemaTable->columnGroups[0]->layout;
+  if (layout == nullptr) {
+    return {};
+  }
+  const auto partitionType = layout->partitionType();
+  const auto& partitionColumns = layout->partitionColumns();
+  if (partitionType == nullptr || partitionColumns.empty()) {
+    return {};
+  }
+
+  ExprVector keys;
+  keys.reserve(partitionColumns.size());
+  for (const auto* partitionColumn : partitionColumns) {
+    ColumnCP match = nullptr;
+    for (ColumnCP column : key.outputColumns) {
+      if (column->name() == partitionColumn->name()) {
+        match = column;
+        break;
+      }
+    }
+    if (match == nullptr) {
+      return {};
+    }
+    keys.push_back(match);
+  }
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .partitionType = partitionType.get(),
+      .keys = std::move(keys),
+      .scope = PropertyScope::kGlobal};
+}
+
+} // namespace
+
+Scan::Scan(Key key)
+    : Node(
+          NodeType::kScan,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{.globalPartition = scanGlobalPartition(key)}),
+      baseTable_(key.baseTable),
+      filters_(std::move(key.filters)) {
+  VELOX_CHECK_NOT_NULL(baseTable_);
+  folly::F14FastSet<std::string_view> schemaNames;
+  folly::F14FastSet<std::string> outputNames;
+  schemaNames.reserve(this->outputColumns().size());
+  outputNames.reserve(this->outputColumns().size());
+  for (ColumnCP column : this->outputColumns()) {
+    VELOX_CHECK(
+        schemaNames.insert(column->name()).second,
+        "Scan outputColumns contains duplicate underlying column name: {}",
+        column->name());
+    VELOX_CHECK(
+        outputNames.insert(column->outputName()).second,
+        "Scan outputColumns contains duplicate output name: {}",
+        column->outputName());
+  }
+}
+
+size_t Scan::KeyHash::operator()(const Scan* node) const {
+  return hashOf(node->baseTable(), node->outputColumns(), node->filters());
+}
+
+size_t Scan::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.baseTable, key.outputColumns, key.filters);
+}
+
+bool Scan::KeyEq::operator()(const Scan* left, const Scan* right) const {
+  return left->baseTable() == right->baseTable() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->filters() == right->filters();
+}
+
+bool Scan::KeyEq::operator()(const Key& key, const Scan* node) const {
+  return key.baseTable == node->baseTable() &&
+      key.outputColumns == node->outputColumns() &&
+      key.filters == node->filters();
+}
+
+bool Scan::KeyEq::operator()(const Scan* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Filter::Filter(Key key)
+    : Node(
+          NodeType::kFilter,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      predicates_(std::move(key.predicates)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!predicates_.empty(), "Filter must have at least one predicate");
+}
+
+size_t Filter::KeyHash::operator()(const Filter* filter) const {
+  return hashOf(filter->input(), filter->predicates());
+}
+
+size_t Filter::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.predicates);
+}
+
+bool Filter::KeyEq::operator()(const Filter* left, const Filter* right) const {
+  return left->input() == right->input() &&
+      left->predicates() == right->predicates();
+}
+
+bool Filter::KeyEq::operator()(const Key& key, const Filter* filter) const {
+  return key.input == filter->input() && key.predicates == filter->predicates();
+}
+
+bool Filter::KeyEq::operator()(const Filter* filter, const Key& key) const {
+  return (*this)(key, filter);
+}
+
+Project::Project(Key key)
+    : Node(
+          NodeType::kProject,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .globalPartition = projectGlobalPartition(
+                  key.input,
+                  key.exprs,
+                  key.outputColumns),
+              .local = retainedLocal(key.input, key.outputColumns),
+              .unique = retainedUnique(key.input, key.outputColumns)}),
+      input_(key.input),
+      exprs_(std::move(key.exprs)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_EQ(this->outputColumns().size(), exprs_.size());
+}
+
+size_t Project::KeyHash::operator()(const Project* node) const {
+  return hashOf(node->input(), node->outputColumns(), node->exprs());
+}
+
+size_t Project::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.outputColumns, key.exprs);
+}
+
+bool Project::KeyEq::operator()(const Project* left, const Project* right)
+    const {
+  return left->input() == right->input() && left->exprs() == right->exprs() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Project::KeyEq::operator()(const Key& key, const Project* node) const {
+  return key.input == node->input() && key.exprs == node->exprs() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Project::KeyEq::operator()(const Project* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Limit::Limit(Key key)
+    : Node(
+          NodeType::kLimit,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      offset_(key.offset),
+      count_(key.count) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_GE(offset_, 0);
+  VELOX_CHECK_GE(count_, 0);
+}
+
+size_t Limit::KeyHash::operator()(const Limit* node) const {
+  return hashOf(node->input(), node->offset(), node->count());
+}
+
+size_t Limit::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.offset, key.count);
+}
+
+bool Limit::KeyEq::operator()(const Limit* left, const Limit* right) const {
+  return left->input() == right->input() && left->offset() == right->offset() &&
+      left->count() == right->count();
+}
+
+bool Limit::KeyEq::operator()(const Key& key, const Limit* node) const {
+  return key.input == node->input() && key.offset == node->offset() &&
+      key.count == node->count();
+}
+
+bool Limit::KeyEq::operator()(const Limit* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Sort::Sort(Key key)
+    : Node(
+          NodeType::kSort,
+          ColumnVector{key.input->outputColumns()},
+          sortedProperties(key.input, key.orderKeys, key.orderTypes)),
+      input_(key.input),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "Sort must have at least one order key");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+}
+
+size_t Sort::KeyHash::operator()(const Sort* node) const {
+  return hashOf(node->input(), node->orderKeys(), node->orderTypes());
+}
+
+size_t Sort::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.orderKeys, key.orderTypes);
+}
+
+bool Sort::KeyEq::operator()(const Sort* left, const Sort* right) const {
+  return left->input() == right->input() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes();
+}
+
+bool Sort::KeyEq::operator()(const Key& key, const Sort* node) const {
+  return key.input == node->input() && key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes();
+}
+
+bool Sort::KeyEq::operator()(const Sort* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TopN::TopN(Key key)
+    : Node(
+          NodeType::kTopN,
+          ColumnVector{key.input->outputColumns()},
+          sortedProperties(key.input, key.orderKeys, key.orderTypes)),
+      input_(key.input),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)),
+      offset_(key.offset),
+      count_(key.count) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "TopN must have at least one order key");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+  VELOX_CHECK_GE(offset_, 0);
+  VELOX_CHECK_GE(count_, 0);
+}
+
+size_t TopN::KeyHash::operator()(const TopN* node) const {
+  return hashOf(
+      node->input(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->offset(),
+      node->count());
+}
+
+size_t TopN::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.orderKeys, key.orderTypes, key.offset, key.count);
+}
+
+bool TopN::KeyEq::operator()(const TopN* left, const TopN* right) const {
+  return left->input() == right->input() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->offset() == right->offset() && left->count() == right->count();
+}
+
+bool TopN::KeyEq::operator()(const Key& key, const TopN* node) const {
+  return key.input == node->input() && key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() && key.offset == node->offset() &&
+      key.count == node->count();
+}
+
+bool TopN::KeyEq::operator()(const TopN* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// Physical properties of an aggregate's output, by step. A `kPartial`
+// pre-aggregates per task without moving rows or gathering (even for an empty
+// grouping): it keeps the input's partitioning re-expressed on its output, but
+// its keys are not globally unique (the same key recurs across tasks).
+// `kSingle` / `kFinal` produce the complete result — globally unique on the
+// grouping keys, and partitioned on them when the input is (the `kFinal`'s
+// input is the exchange that partitioned the partials).
+PhysicalProperties aggregateProperties(const Aggregate::Key& key) {
+  // The grouping values are materialized as the leading output columns, aligned
+  // one-to-one with `groupingKeys`; properties are expressed over those output
+  // columns, not the (possibly computed) grouping-key expressions.
+  ColumnVector groupingColumns;
+  groupingColumns.reserve(key.groupingKeys.size());
+  for (size_t i = 0; i < key.groupingKeys.size(); ++i) {
+    groupingColumns.push_back(key.outputColumns[i]);
+  }
+  if (key.step == AggregateStep::kPartial) {
+    return PhysicalProperties{
+        .globalPartition = aggregateInputPartition(
+            key.input, key.groupingKeys, groupingColumns),
+        .local = groupedLocal(groupingColumns)};
+  }
+  // An aggregate emits one row per distinct grouping-key combination, so the
+  // grouping output columns are a global unique key (the empty grouping is the
+  // single global row, unique on the empty set; a grouping-set aggregate's
+  // group-id is one of the keys, so distinct key sets stay distinct).
+  return PhysicalProperties{
+      .globalPartition = aggregateGlobalPartition(
+          key.input, key.groupingKeys, groupingColumns),
+      .local = groupedLocal(groupingColumns),
+      .unique = {UniqueKeySet{
+          .columns = PlanObjectSet::fromObjects(groupingColumns),
+          .scope = PropertyScope::kGlobal}}};
+}
+
+} // namespace
+
+Aggregate::Aggregate(Key key)
+    : Node(
+          NodeType::kAggregate,
+          ColumnVector{key.outputColumns},
+          aggregateProperties(key)),
+      input_(key.input),
+      groupingKeys_(std::move(key.groupingKeys)),
+      aggregates_(std::move(key.aggregates)),
+      step_(key.step),
+      groupId_(key.groupId),
+      globalGroupingSets_(std::move(key.globalGroupingSets)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(), groupingKeys_.size() + aggregates_.size());
+  // Velox couples the two: a group-id key is meaningful for empty-input default
+  // rows only alongside the global sets it labels.
+  VELOX_CHECK_EQ(groupId_ != nullptr, !globalGroupingSets_.empty());
+  if (groupId_ != nullptr) {
+    VELOX_CHECK(
+        std::ranges::find(groupingKeys_, groupId_) != groupingKeys_.end(),
+        "groupId must be one of the grouping keys");
+  }
+}
+
+size_t Aggregate::KeyHash::operator()(const Aggregate* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->groupingKeys(),
+      node->aggregates(),
+      node->outputColumns());
+  hash = velox::bits::hashMix(hash, hashOf(node->groupId()));
+  for (auto idx : node->globalGroupingSets()) {
+    hash = velox::bits::hashMix(hash, static_cast<size_t>(idx));
+  }
+  return velox::bits::hashMix(hash, static_cast<size_t>(node->step()));
+}
+
+size_t Aggregate::KeyHash::operator()(const Key& key) const {
+  size_t hash =
+      hashOf(key.input, key.groupingKeys, key.aggregates, key.outputColumns);
+  hash = velox::bits::hashMix(hash, hashOf(key.groupId));
+  for (auto idx : key.globalGroupingSets) {
+    hash = velox::bits::hashMix(hash, static_cast<size_t>(idx));
+  }
+  return velox::bits::hashMix(hash, static_cast<size_t>(key.step));
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* left, const Aggregate* right)
+    const {
+  return left->input() == right->input() &&
+      left->groupingKeys() == right->groupingKeys() &&
+      left->aggregates() == right->aggregates() &&
+      left->outputColumns() == right->outputColumns() &&
+      left->step() == right->step() && left->groupId() == right->groupId() &&
+      left->globalGroupingSets() == right->globalGroupingSets();
+}
+
+bool Aggregate::KeyEq::operator()(const Key& key, const Aggregate* node) const {
+  return key.input == node->input() &&
+      key.groupingKeys == node->groupingKeys() &&
+      key.aggregates == node->aggregates() &&
+      key.outputColumns == node->outputColumns() && key.step == node->step() &&
+      key.groupId == node->groupId() &&
+      key.globalGroupingSets == node->globalGroupingSets();
+}
+
+bool Aggregate::KeyEq::operator()(const Aggregate* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+GroupId::GroupId(Key key)
+    : Node(NodeType::kGroupId, ColumnVector{key.outputColumns}, {}),
+      input_(key.input),
+      groupingKeys_(std::move(key.groupingKeys)),
+      aggregationInputs_(std::move(key.aggregationInputs)),
+      groupingSets_(std::move(key.groupingSets)),
+      groupingKeyColumns_(std::move(key.groupingKeyColumns)),
+      groupId_(key.groupId) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(groupId_);
+  VELOX_CHECK_EQ(groupId_->value().type->kind(), velox::TypeKind::BIGINT);
+  VELOX_CHECK_EQ(groupingKeys_.size(), groupingKeyColumns_.size());
+  VELOX_CHECK(!groupingSets_.empty());
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      groupingKeyColumns_.size() + aggregationInputs_.size() + 1);
+}
+
+size_t GroupId::KeyHash::operator()(const GroupId* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->groupingKeys(),
+      node->aggregationInputs(),
+      node->groupingKeyColumns(),
+      node->groupId(),
+      node->outputColumns());
+  const auto& groupingSets = node->groupingSets();
+  for (size_t setIdx = 0; setIdx < groupingSets.size(); ++setIdx) {
+    // Mix setIdx and set size to break symmetry across index permutations
+    // (e.g., {{1,2},{3}} vs {{1},{2,3}}).
+    hash = velox::bits::hashMix(hash, setIdx);
+    hash = velox::bits::hashMix(hash, groupingSets[setIdx].size());
+    for (auto index : groupingSets[setIdx]) {
+      hash = velox::bits::hashMix(hash, static_cast<size_t>(index));
+    }
+  }
+  return hash;
+}
+
+size_t GroupId::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.groupingKeys,
+      key.aggregationInputs,
+      key.groupingKeyColumns,
+      key.groupId,
+      key.outputColumns);
+  const auto& groupingSets = key.groupingSets;
+  for (size_t setIdx = 0; setIdx < groupingSets.size(); ++setIdx) {
+    // Mix setIdx and set size to break symmetry across index permutations
+    // (e.g., {{1,2},{3}} vs {{1},{2,3}}).
+    hash = velox::bits::hashMix(hash, setIdx);
+    hash = velox::bits::hashMix(hash, groupingSets[setIdx].size());
+    for (auto index : groupingSets[setIdx]) {
+      hash = velox::bits::hashMix(hash, static_cast<size_t>(index));
+    }
+  }
+  return hash;
+}
+
+bool GroupId::KeyEq::operator()(const GroupId* left, const GroupId* right)
+    const {
+  return left->input() == right->input() &&
+      left->groupingKeys() == right->groupingKeys() &&
+      left->aggregationInputs() == right->aggregationInputs() &&
+      left->groupingSets() == right->groupingSets() &&
+      left->groupingKeyColumns() == right->groupingKeyColumns() &&
+      left->groupId() == right->groupId() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool GroupId::KeyEq::operator()(const Key& key, const GroupId* node) const {
+  return key.input == node->input() &&
+      key.groupingKeys == node->groupingKeys() &&
+      key.aggregationInputs == node->aggregationInputs() &&
+      key.groupingSets == node->groupingSets() &&
+      key.groupingKeyColumns == node->groupingKeyColumns() &&
+      key.groupId == node->groupId() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool GroupId::KeyEq::operator()(const GroupId* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+MarkDistinct::MarkDistinct(Key key)
+    : Node(
+          NodeType::kMarkDistinct,
+          ColumnVector{key.outputColumns},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      markers_(std::move(key.markers)),
+      distinctKeys_(std::move(key.distinctKeys)),
+      masks_(std::move(key.masks)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!markers_.empty());
+  const size_t expectedMarkers = masks_.empty() ? 1 : masks_.size() + 1;
+  VELOX_CHECK_EQ(markers_.size(), expectedMarkers);
+  for (ColumnCP marker : markers_) {
+    VELOX_CHECK_EQ(marker->value().type->kind(), velox::TypeKind::BOOLEAN);
+  }
+  for (ColumnCP mask : masks_) {
+    VELOX_CHECK_EQ(mask->value().type->kind(), velox::TypeKind::BOOLEAN);
+  }
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + markers_.size());
+}
+
+size_t MarkDistinct::KeyHash::operator()(const MarkDistinct* node) const {
+  return hashOf(
+      node->input(),
+      node->markers(),
+      node->distinctKeys(),
+      node->masks(),
+      node->outputColumns());
+}
+
+size_t MarkDistinct::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.markers, key.distinctKeys, key.masks, key.outputColumns);
+}
+
+bool MarkDistinct::KeyEq::operator()(
+    const MarkDistinct* left,
+    const MarkDistinct* right) const {
+  return left->input() == right->input() &&
+      left->markers() == right->markers() &&
+      left->distinctKeys() == right->distinctKeys() &&
+      left->masks() == right->masks() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool MarkDistinct::KeyEq::operator()(const Key& key, const MarkDistinct* node)
+    const {
+  return key.input == node->input() && key.markers == node->markers() &&
+      key.distinctKeys == node->distinctKeys() && key.masks == node->masks() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool MarkDistinct::KeyEq::operator()(const MarkDistinct* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+Values::Values(Key key)
+    : Node(NodeType::kValues, ColumnVector{key.outputColumns}, {}),
+      source_(key.source),
+      rows_(key.rows) {
+  VELOX_CHECK(
+      source_ == nullptr || rows_ == nullptr,
+      "Values cannot carry both a passthrough source and folded rows");
+
+  const auto numColumns = this->outputColumns().size();
+  if (source_ != nullptr) {
+    const auto& rowType = source_->outputType();
+    VELOX_CHECK_EQ(
+        rowType->size(),
+        numColumns,
+        "Values source schema must match outputColumns count");
+    for (size_t i = 0; i < numColumns; ++i) {
+      VELOX_CHECK(
+          rowType->childAt(i)->equivalent(
+              *this->outputColumns()[i]->value().type),
+          "Values source column {} type must match outputColumns",
+          i);
+    }
+  } else if (rows_ != nullptr) {
+    VELOX_CHECK_EQ(
+        rows_->kind(),
+        velox::TypeKind::ARRAY,
+        "Values folded rows must be an array of row variants");
+    for (const auto& row : rows_->array()) {
+      VELOX_CHECK_EQ(
+          row.kind(),
+          velox::TypeKind::ROW,
+          "Values folded rows must be row variants");
+      VELOX_CHECK_EQ(
+          row.row().size(),
+          numColumns,
+          "Values folded row field count must match outputColumns");
+    }
+  }
+}
+
+size_t Values::KeyHash::operator()(const Values* node) const {
+  return hashOf(node->source(), node->rows(), node->outputColumns());
+}
+
+size_t Values::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.source, key.rows, key.outputColumns);
+}
+
+bool Values::KeyEq::operator()(const Values* left, const Values* right) const {
+  return left->source() == right->source() && left->rows() == right->rows() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Values::KeyEq::operator()(const Key& key, const Values* node) const {
+  return key.source == node->source() && key.rows == node->rows() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Values::KeyEq::operator()(const Values* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Unnest::Unnest(Key key)
+    : Node(
+          NodeType::kUnnest,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .local = retainedLocal(key.input, key.replicatedColumns)}),
+      input_(key.input),
+      unnestExpressions_(std::move(key.unnestExpressions)),
+      replicatedColumns_(std::move(key.replicatedColumns)),
+      unnestColumns_(std::move(key.unnestColumns)),
+      ordinalityColumn_(key.ordinalityColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(
+      !unnestExpressions_.empty(), "Unnest must have at least one expression");
+  VELOX_CHECK_EQ(
+      unnestColumns_.size(),
+      unnestExpressions_.size(),
+      "Unnest unnestColumns must align with unnestExpressions");
+  // Each expression unnests into one result column for an ARRAY, two (key,
+  // value) for a MAP.
+  for (size_t i = 0; i < unnestExpressions_.size(); ++i) {
+    const auto kind = unnestExpressions_[i]->value().type->kind();
+    if (kind == velox::TypeKind::ARRAY) {
+      VELOX_CHECK_EQ(
+          unnestColumns_[i].size(),
+          1,
+          "Unnest of an ARRAY expression produces one result column");
+    } else if (kind == velox::TypeKind::MAP) {
+      VELOX_CHECK_EQ(
+          unnestColumns_[i].size(),
+          2,
+          "Unnest of a MAP expression produces two result columns (key, value)");
+    } else {
+      VELOX_FAIL(
+          "Unnest expression must be ARRAY or MAP, got {}",
+          unnestExpressions_[i]->value().type->toString());
+    }
+  }
+  // Every outputColumns entry must be a Column the structured fields produce: a
+  // replicated input column, a per-expression result, or the ordinality column.
+  // Only per-expression results may be pruned from the output; replicated
+  // columns and the ordinality column must all appear.
+  PlanObjectSet produced;
+  for (ColumnCP column : replicatedColumns_) {
+    produced.add(column);
+  }
+  for (const auto& perExpr : unnestColumns_) {
+    for (ColumnCP column : perExpr) {
+      produced.add(column);
+    }
+  }
+  if (ordinalityColumn_ != nullptr) {
+    produced.add(ordinalityColumn_);
+  }
+
+  for (ColumnCP column : this->outputColumns()) {
+    VELOX_CHECK(
+        produced.contains(column),
+        "Unnest outputColumns references a Column not produced by structured fields");
+  }
+
+  const auto outputSet = PlanObjectSet::fromObjects(this->outputColumns());
+  for (ColumnCP column : replicatedColumns_) {
+    VELOX_CHECK(
+        outputSet.contains(column),
+        "Unnest replicatedColumns must all appear in outputColumns");
+  }
+  VELOX_CHECK(
+      ordinalityColumn_ == nullptr || outputSet.contains(ordinalityColumn_),
+      "Unnest ordinalityColumn must appear in outputColumns");
+}
+
+size_t Unnest::KeyHash::operator()(const Unnest* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->unnestExpressions(),
+      node->outputColumns(),
+      node->replicatedColumns(),
+      node->ordinalityColumn());
+  const auto& unnestColumns = node->unnestColumns();
+  for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
+    // Mix idx and inner size to break symmetry across index permutations
+    // (e.g., [[a,b],[c]] vs [[a],[b,c]]).
+    hash = velox::bits::hashMix(hash, idx);
+    hash = velox::bits::hashMix(hash, unnestColumns[idx].size());
+    for (const auto* column : unnestColumns[idx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+size_t Unnest::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.unnestExpressions,
+      key.outputColumns,
+      key.replicatedColumns,
+      key.ordinalityColumn);
+  const auto& unnestColumns = key.unnestColumns;
+  for (size_t idx = 0; idx < unnestColumns.size(); ++idx) {
+    // Mix idx and inner size to break symmetry across index permutations
+    // (e.g., [[a,b],[c]] vs [[a],[b,c]]).
+    hash = velox::bits::hashMix(hash, idx);
+    hash = velox::bits::hashMix(hash, unnestColumns[idx].size());
+    for (const auto* column : unnestColumns[idx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+bool Unnest::KeyEq::operator()(const Unnest* left, const Unnest* right) const {
+  return left->input() == right->input() &&
+      left->unnestExpressions() == right->unnestExpressions() &&
+      left->replicatedColumns() == right->replicatedColumns() &&
+      left->unnestColumns() == right->unnestColumns() &&
+      left->ordinalityColumn() == right->ordinalityColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Unnest::KeyEq::operator()(const Key& key, const Unnest* node) const {
+  return key.input == node->input() &&
+      key.unnestExpressions == node->unnestExpressions() &&
+      key.replicatedColumns == node->replicatedColumns() &&
+      key.unnestColumns == node->unnestColumns() &&
+      key.ordinalityColumn == node->ordinalityColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Unnest::KeyEq::operator()(const Unnest* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+
+// Output global partitioning of a union: bucketed on the union output columns
+// when every leg is connector-bucketed on leg columns that map (via legColumns)
+// to those same output columns, with copartitionable partitionings. The
+// representative type is the min-partition-count leg's — its count equals the
+// copartition's — reused as a query-lifetime pointer. Unspecified otherwise, so
+// the union then distributes its legs independently.
+Partitioning unionGlobalPartition(const UnionAll::Key& key) {
+  const connector::PartitionType* representative = nullptr;
+  ExprVector outputKeys;
+  for (size_t leg = 0; leg < key.inputs.size(); ++leg) {
+    const Partitioning& part =
+        key.inputs[leg]->physicalProperties().globalPartition;
+    if (part.kind != PartitionKind::kPartitioned ||
+        part.partitionType == nullptr) {
+      return {};
+    }
+    // Map each leg partition key to the union output column at the same index.
+    const ColumnVector& legColumns = key.legColumns[leg];
+    ExprVector legOutputKeys;
+    legOutputKeys.reserve(part.keys.size());
+    for (ExprCP legKey : part.keys) {
+      ExprCP mapped = nullptr;
+      for (size_t i = 0; i < legColumns.size(); ++i) {
+        if (legColumns[i] == legKey) {
+          mapped = key.outputColumns[i];
+          break;
+        }
+      }
+      if (mapped == nullptr) {
+        return {};
+      }
+      legOutputKeys.push_back(mapped);
+    }
+
+    if (leg == 0) {
+      outputKeys = std::move(legOutputKeys);
+      representative = part.partitionType;
+      continue;
+    }
+    if (legOutputKeys.size() != outputKeys.size()) {
+      return {};
+    }
+    for (size_t i = 0; i < outputKeys.size(); ++i) {
+      if (legOutputKeys[i] != outputKeys[i]) {
+        return {};
+      }
+    }
+    // copartition is only a feasibility check; the output reuses the
+    // min-partition-count leg's layout-owned type, whose count equals
+    // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
+    const auto compatible = representative->copartition(*part.partitionType);
+    if (compatible == nullptr) {
+      return {};
+    }
+    if (part.partitionType->numPartitions() < representative->numPartitions()) {
+      representative = part.partitionType;
+    }
+    VELOX_DCHECK_EQ(
+        representative->numPartitions(),
+        compatible->numPartitions(),
+        "Co-bucketed union output must reuse a layout type matching copartition's count");
+  }
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .partitionType = representative,
+      .keys = std::move(outputKeys),
+      .scope = PropertyScope::kGlobal};
+}
+
+} // namespace
+
+UnionAll::UnionAll(Key key)
+    : Node(
+          NodeType::kUnionAll,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{.globalPartition = unionGlobalPartition(key)}),
+      inputs_(std::move(key.inputs)),
+      legColumns_(std::move(key.legColumns)) {
+  VELOX_CHECK_GE(inputs_.size(), 2, "UnionAll requires at least two inputs");
+  for (auto* input : inputs_) {
+    VELOX_CHECK_NOT_NULL(input);
+  }
+  VELOX_CHECK_EQ(
+      legColumns_.size(),
+      inputs_.size(),
+      "UnionAll legColumns must have one entry per input");
+  const auto numOutputs = this->outputColumns().size();
+  for (size_t i = 0; i < inputs_.size(); ++i) {
+    VELOX_CHECK_EQ(
+        legColumns_[i].size(),
+        numOutputs,
+        "UnionAll legColumns[i] must align with outputColumns");
+    const auto available =
+        PlanObjectSet::fromObjects(inputs_[i]->outputColumns());
+    for (ColumnCP column : legColumns_[i]) {
+      VELOX_CHECK(
+          available.contains(column),
+          "UnionAll legColumns[{}] references a Column not in inputs[{}]->outputColumns()",
+          i,
+          i);
+    }
+  }
+}
+
+size_t UnionAll::KeyHash::operator()(const UnionAll* node) const {
+  const auto& legColumns = node->legColumns();
+  size_t hash = hashOf(node->inputs(), node->outputColumns());
+  for (size_t legIdx = 0; legIdx < legColumns.size(); ++legIdx) {
+    // Mix legIdx and leg size to break symmetry across pointer permutations
+    // (e.g., [[a,b],[c,d]] vs [[a,d],[c,b]]).
+    hash = velox::bits::hashMix(hash, legIdx);
+    hash = velox::bits::hashMix(hash, legColumns[legIdx].size());
+    for (const auto* column : legColumns[legIdx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+size_t UnionAll::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(key.inputs, key.outputColumns);
+  for (size_t legIdx = 0; legIdx < key.legColumns.size(); ++legIdx) {
+    // Mix legIdx and leg size to break symmetry across pointer permutations
+    // (e.g., [[a,b],[c,d]] vs [[a,d],[c,b]]).
+    hash = velox::bits::hashMix(hash, legIdx);
+    hash = velox::bits::hashMix(hash, key.legColumns[legIdx].size());
+    for (const auto* column : key.legColumns[legIdx]) {
+      hash = velox::bits::hashMix(hash, reinterpret_cast<uintptr_t>(column));
+    }
+  }
+  return hash;
+}
+
+bool UnionAll::KeyEq::operator()(const UnionAll* left, const UnionAll* right)
+    const {
+  return std::ranges::equal(left->inputs(), right->inputs()) &&
+      left->legColumns() == right->legColumns() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool UnionAll::KeyEq::operator()(const Key& key, const UnionAll* node) const {
+  return std::ranges::equal(key.inputs, node->inputs()) &&
+      key.legColumns == node->legColumns() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool UnionAll::KeyEq::operator()(const UnionAll* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Join::Join(Key key)
+    : Node(
+          NodeType::kJoin,
+          ColumnVector{key.outputColumns},
+          PhysicalProperties{
+              .globalPartition = joinGlobalPartition(
+                  key.joinType,
+                  key.left,
+                  key.outputColumns),
+              .local = joinLocal(key.joinType, key.left, key.outputColumns)}),
+      inputs_{key.left, key.right},
+      joinType_(key.joinType),
+      leftKeys_(std::move(key.leftKeys)),
+      rightKeys_(std::move(key.rightKeys)),
+      filter_(std::move(key.filter)),
+      nullAware_(key.nullAware),
+      nullAsValue_(key.nullAsValue) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+  VELOX_CHECK_EQ(leftKeys_.size(), rightKeys_.size());
+  if (nullAware_) {
+    VELOX_CHECK(
+        joinType_ == velox::core::JoinType::kAnti ||
+            joinType_ == velox::core::JoinType::kLeftSemiProject ||
+            joinType_ == velox::core::JoinType::kRightSemiProject,
+        "nullAware only valid for kAnti / kLeftSemiProject / kRightSemiProject, got: {}",
+        joinType_);
+    // Velox forbids a null-aware right semi project that also carries an
+    // internal filter (velox PlanNode.h). The negated-mark filter of a
+    // reversed antijoin is a separate FilterNode, not this internal filter.
+    VELOX_CHECK(
+        joinType_ != velox::core::JoinType::kRightSemiProject ||
+            filter_.empty(),
+        "Null-aware kRightSemiProject does not support an internal filter");
+  }
+  VELOX_CHECK(
+      !(nullAware_ && nullAsValue_),
+      "nullAware and nullAsValue are mutually exclusive");
+}
+
+size_t Join::KeyHash::operator()(const Join* node) const {
+  return hashOf(
+      node->left(),
+      node->right(),
+      node->joinType(),
+      node->leftKeys(),
+      node->rightKeys(),
+      node->filter(),
+      node->outputColumns(),
+      node->nullAware(),
+      node->nullAsValue());
+}
+
+size_t Join::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.left,
+      key.right,
+      key.joinType,
+      key.leftKeys,
+      key.rightKeys,
+      key.filter,
+      key.outputColumns,
+      key.nullAware,
+      key.nullAsValue);
+}
+
+bool Join::KeyEq::operator()(const Join* left, const Join* right) const {
+  return left->left() == right->left() && left->right() == right->right() &&
+      left->joinType() == right->joinType() &&
+      left->leftKeys() == right->leftKeys() &&
+      left->rightKeys() == right->rightKeys() &&
+      left->filter() == right->filter() &&
+      left->nullAware() == right->nullAware() &&
+      left->nullAsValue() == right->nullAsValue() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Join::KeyEq::operator()(const Key& key, const Join* node) const {
+  return key.left == node->left() && key.right == node->right() &&
+      key.joinType == node->joinType() && key.leftKeys == node->leftKeys() &&
+      key.rightKeys == node->rightKeys() && key.filter == node->filter() &&
+      key.nullAware == node->nullAware() &&
+      key.nullAsValue == node->nullAsValue() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Join::KeyEq::operator()(const Join* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+Window::Window(Key key)
+    : Node(
+          NodeType::kWindow,
+          ColumnVector{key.outputColumns},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      functions_(std::move(key.functions)),
+      partitionKeys_(std::move(key.partitionKeys)),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!functions_.empty(), "Window must have at least one function");
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + functions_.size());
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+}
+
+size_t Window::KeyHash::operator()(const Window* node) const {
+  size_t hash = hashOf(
+      node->input(),
+      node->partitionKeys(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->outputColumns());
+  for (const auto& function : node->functions()) {
+    hash = velox::bits::hashMix(
+        hash, hashOf(function.call, function.frame, function.ignoreNulls));
+  }
+  return hash;
+}
+
+size_t Window::KeyHash::operator()(const Key& key) const {
+  size_t hash = hashOf(
+      key.input,
+      key.partitionKeys,
+      key.orderKeys,
+      key.orderTypes,
+      key.outputColumns);
+  for (const auto& function : key.functions) {
+    hash = velox::bits::hashMix(
+        hash, hashOf(function.call, function.frame, function.ignoreNulls));
+  }
+  return hash;
+}
+
+bool Window::KeyEq::operator()(const Window* left, const Window* right) const {
+  return left->input() == right->input() &&
+      left->functions() == right->functions() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Window::KeyEq::operator()(const Key& key, const Window* node) const {
+  return key.input == node->input() && key.functions == node->functions() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Window::KeyEq::operator()(const Window* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TopNRowNumber::TopNRowNumber(Key key)
+    : Node(NodeType::kTopNRowNumber, ColumnVector{key.outputColumns}, {}),
+      input_(key.input),
+      rankFunction_(key.rankFunction),
+      partitionKeys_(std::move(key.partitionKeys)),
+      orderKeys_(std::move(key.orderKeys)),
+      orderTypes_(std::move(key.orderTypes)),
+      limit_(key.limit),
+      rankColumn_(key.rankColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(!orderKeys_.empty(), "TopNRowNumber must have order keys");
+  VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
+  VELOX_CHECK_GT(limit_, 0);
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + (rankColumn_ != nullptr ? 1 : 0));
+}
+
+size_t TopNRowNumber::KeyHash::operator()(const TopNRowNumber* node) const {
+  return hashOf(
+      node->input(),
+      static_cast<int>(node->rankFunction()),
+      node->partitionKeys(),
+      node->orderKeys(),
+      node->orderTypes(),
+      node->limit(),
+      node->rankColumn(),
+      node->outputColumns());
+}
+
+size_t TopNRowNumber::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      static_cast<int>(key.rankFunction),
+      key.partitionKeys,
+      key.orderKeys,
+      key.orderTypes,
+      key.limit,
+      key.rankColumn,
+      key.outputColumns);
+}
+
+bool TopNRowNumber::KeyEq::operator()(
+    const TopNRowNumber* left,
+    const TopNRowNumber* right) const {
+  return left->input() == right->input() &&
+      left->rankFunction() == right->rankFunction() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->orderKeys() == right->orderKeys() &&
+      left->orderTypes() == right->orderTypes() &&
+      left->limit() == right->limit() &&
+      left->rankColumn() == right->rankColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool TopNRowNumber::KeyEq::operator()(const Key& key, const TopNRowNumber* node)
+    const {
+  return key.input == node->input() &&
+      key.rankFunction == node->rankFunction() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.orderKeys == node->orderKeys() &&
+      key.orderTypes == node->orderTypes() && key.limit == node->limit() &&
+      key.rankColumn == node->rankColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool TopNRowNumber::KeyEq::operator()(const TopNRowNumber* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+Apply::Apply(Key key)
+    : Node(NodeType::kApply, ColumnVector{key.outputColumns}, {}),
+      inputs_{key.input, key.body},
+      correlationColumns_(std::move(key.correlationColumns)),
+      kind_(key.kind),
+      filter_(std::move(key.filter)),
+      enforceSingleRow_(key.enforceSingleRow),
+      markColumn_(key.markColumn),
+      inLhs_(key.inLhs),
+      inBodyKey_(key.inBodyKey),
+      includeMarker_(key.includeMarker) {
+  VELOX_CHECK_NOT_NULL(inputs_[0]);
+  VELOX_CHECK_NOT_NULL(inputs_[1]);
+
+  // Allowed kinds at Apply: correlated scalar (kLeft) and EXISTS/IN
+  // (kLeftSemiProject). Uncorrelated scalars are lowered directly to
+  // cross-join + EnforceSingleRow at translate time — no Apply. kAnti
+  // / kLeftSemiFilter emerge from the post-decorrelate peephole, never
+  // at Apply.
+  const bool isLeft = kind_ == velox::core::JoinType::kLeft;
+  VELOX_CHECK(
+      isLeft || kind_ == velox::core::JoinType::kLeftSemiProject,
+      "Apply.kind must be kLeft / kLeftSemiProject; got: {}",
+      kind_);
+
+  if (isLeft) {
+    VELOX_CHECK_NOT_NULL(
+        includeMarker_, "kLeft Apply requires an includeMarker");
+    VELOX_CHECK_EQ(
+        includeMarker_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "Apply.includeMarker must be BOOLEAN");
+    VELOX_CHECK_NULL(
+        markColumn_,
+        "markColumn is kLeftSemiProject-only; kLeft leaves it null");
+    VELOX_CHECK_NULL(inLhs_, "inLhs is IN-only; non-semi Apply leaves it null");
+    VELOX_CHECK_NULL(
+        inBodyKey_, "inBodyKey is IN-only; non-semi Apply leaves it null");
+  } else {
+    VELOX_CHECK_NULL(
+        includeMarker_, "includeMarker is kLeft-only; kSemi leaves it null");
+    VELOX_CHECK_NOT_NULL(
+        markColumn_, "kLeftSemiProject Apply requires a markColumn");
+    VELOX_CHECK_EQ(
+        markColumn_->value().type->kind(),
+        velox::TypeKind::BOOLEAN,
+        "kLeftSemiProject markColumn must be BOOLEAN");
+    VELOX_CHECK(
+        !enforceSingleRow_,
+        "kLeftSemiProject Apply must have enforceSingleRow == false "
+        "(semi/anti has no cardinality assertion)");
+  }
+  // The IN pair is set together: both null (scalar / EXISTS) or both
+  // non-null (IN). Forbid the half-set state.
+  VELOX_CHECK_EQ(
+      inLhs_ == nullptr,
+      inBodyKey_ == nullptr,
+      "Apply.inLhs and Apply.inBodyKey must be set together (both null "
+      "for scalar / EXISTS; both non-null for IN)");
+
+  // outputColumns shape check, per kind:
+  //   kLeft             : input.outputColumns
+  //                       ++ unique(body.outputColumns) ++ includeMarker
+  //   kLeftSemiProject  : input.outputColumns ++ markColumn
+  //
+  // A body column that already appears in input.outputColumns by
+  // Column* identity occupies a single output slot.
+  const auto& inputCols = inputs_[0]->outputColumns();
+  for (size_t i = 0; i < inputCols.size(); ++i) {
+    VELOX_CHECK(
+        outputColumns()[i] == inputCols[i],
+        "Apply.outputColumns prefix must match input.outputColumns");
+  }
+  if (isLeft) {
+    VELOX_CHECK_GE(
+        outputColumns().size(),
+        inputCols.size() + 1,
+        "kLeft Apply.outputColumns shorter than input + includeMarker");
+    const size_t bodySlots = outputColumns().size() - inputCols.size() - 1;
+    VELOX_CHECK_LE(
+        bodySlots,
+        inputs_[1]->outputColumns().size(),
+        "Apply body-col slot count exceeds body's outputColumns");
+    PlanObjectSet seen = PlanObjectSet::fromObjects(inputCols);
+    for (size_t i = 0; i < bodySlots; ++i) {
+      ColumnCP column = outputColumns()[inputCols.size() + i];
+      VELOX_CHECK(
+          !seen.contains(column),
+          "Apply.outputColumns body cols must be unique vs input and each other");
+      seen.add(column);
+    }
+    VELOX_CHECK(
+        outputColumns().back() == includeMarker_,
+        "Apply.outputColumns must end with includeMarker for kLeft");
+  } else {
+    VELOX_CHECK_EQ(
+        outputColumns().size(),
+        inputCols.size() + 1,
+        "kLeftSemiProject Apply.outputColumns size mismatch");
+    VELOX_CHECK(
+        outputColumns().back() == markColumn_,
+        "Apply.outputColumns must end with markColumn for kLeftSemiProject");
+  }
+}
+
+size_t Apply::KeyHash::operator()(const Apply* node) const {
+  return hashOf(
+      node->input(),
+      node->body(),
+      node->correlationColumns(),
+      node->kind(),
+      node->filter(),
+      node->enforceSingleRow(),
+      node->markColumn(),
+      node->inLhs(),
+      node->inBodyKey(),
+      node->includeMarker(),
+      node->outputColumns());
+}
+
+size_t Apply::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      key.body,
+      key.correlationColumns,
+      key.kind,
+      key.filter,
+      key.enforceSingleRow,
+      key.markColumn,
+      key.inLhs,
+      key.inBodyKey,
+      key.includeMarker,
+      key.outputColumns);
+}
+
+bool Apply::KeyEq::operator()(const Apply* left, const Apply* right) const {
+  return left->input() == right->input() && left->body() == right->body() &&
+      left->correlationColumns() == right->correlationColumns() &&
+      left->kind() == right->kind() && left->filter() == right->filter() &&
+      left->enforceSingleRow() == right->enforceSingleRow() &&
+      left->markColumn() == right->markColumn() &&
+      left->inLhs() == right->inLhs() &&
+      left->inBodyKey() == right->inBodyKey() &&
+      left->includeMarker() == right->includeMarker() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool Apply::KeyEq::operator()(const Key& key, const Apply* node) const {
+  return key.input == node->input() && key.body == node->body() &&
+      key.correlationColumns == node->correlationColumns() &&
+      key.kind == node->kind() && key.filter == node->filter() &&
+      key.enforceSingleRow == node->enforceSingleRow() &&
+      key.markColumn == node->markColumn() && key.inLhs == node->inLhs() &&
+      key.inBodyKey == node->inBodyKey() &&
+      key.includeMarker == node->includeMarker() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool Apply::KeyEq::operator()(const Apply* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+namespace {
+ColumnVector withIdColumn(const ColumnVector& columns, ColumnCP idColumn) {
+  ColumnVector result;
+  result.reserve(columns.size() + 1);
+  for (ColumnCP column : columns) {
+    result.push_back(column);
+  }
+  result.push_back(idColumn);
+  return result;
+}
+} // namespace
+
+AssignUniqueId::AssignUniqueId(Key key)
+    : Node(
+          NodeType::kAssignUniqueId,
+          withIdColumn(key.input->outputColumns(), key.idColumn),
+          PhysicalProperties{
+              .local = groupedLocal(key.idColumn),
+              .unique = globalUniqueKey(key.idColumn)}),
+      input_(key.input),
+      idColumn_(key.idColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(idColumn_);
+  VELOX_CHECK_EQ(idColumn_->value().type->kind(), velox::TypeKind::BIGINT);
+}
+
+size_t AssignUniqueId::KeyHash::operator()(const AssignUniqueId* node) const {
+  return hashOf(node->input(), node->idColumn());
+}
+
+size_t AssignUniqueId::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.idColumn);
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const AssignUniqueId* left,
+    const AssignUniqueId* right) const {
+  return left->input() == right->input() &&
+      left->idColumn() == right->idColumn();
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const Key& key,
+    const AssignUniqueId* node) const {
+  return key.input == node->input() && key.idColumn == node->idColumn();
+}
+
+bool AssignUniqueId::KeyEq::operator()(
+    const AssignUniqueId* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+EnforceSingleRow::EnforceSingleRow(Key key)
+    : Node(
+          NodeType::kEnforceSingleRow,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input) {
+  VELOX_CHECK_NOT_NULL(input_);
+}
+
+size_t EnforceSingleRow::KeyHash::operator()(
+    const EnforceSingleRow* node) const {
+  return hashOf(node->input());
+}
+
+size_t EnforceSingleRow::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input);
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const EnforceSingleRow* left,
+    const EnforceSingleRow* right) const {
+  return left->input() == right->input();
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const Key& key,
+    const EnforceSingleRow* node) const {
+  return key.input == node->input();
+}
+
+bool EnforceSingleRow::KeyEq::operator()(
+    const EnforceSingleRow* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+EnforceDistinct::EnforceDistinct(Key key)
+    : Node(
+          NodeType::kEnforceDistinct,
+          ColumnVector{key.input->outputColumns()},
+          passThroughProperties(key.input)),
+      input_(key.input),
+      distinctKeys_(std::move(key.distinctKeys)),
+      errorMessage_(key.errorMessage) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK(
+      !distinctKeys_.empty(),
+      "EnforceDistinct must have at least one distinct key");
+  VELOX_CHECK_NOT_NULL(errorMessage_);
+}
+
+size_t EnforceDistinct::KeyHash::operator()(const EnforceDistinct* node) const {
+  return hashOf(node->input(), node->distinctKeys(), node->errorMessage());
+}
+
+size_t EnforceDistinct::KeyHash::operator()(const Key& key) const {
+  return hashOf(key.input, key.distinctKeys, key.errorMessage);
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const EnforceDistinct* left,
+    const EnforceDistinct* right) const {
+  return left->input() == right->input() &&
+      left->distinctKeys() == right->distinctKeys() &&
+      left->errorMessage() == right->errorMessage();
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const Key& key,
+    const EnforceDistinct* node) const {
+  return key.input == node->input() &&
+      key.distinctKeys == node->distinctKeys() &&
+      key.errorMessage == node->errorMessage();
+}
+
+bool EnforceDistinct::KeyEq::operator()(
+    const EnforceDistinct* node,
+    const Key& key) const {
+  return (*this)(key, node);
+}
+
+Exchange::Exchange(Key key)
+    : Node(
+          NodeType::kExchange,
+          ColumnVector{key.input->outputColumns()},
+          // A remote exchange drops per-driver local order/grouping (rows
+          // interleave) — except an order-preserving gather, which keeps the
+          // merged sort order. Uniqueness survives per uniqueAcrossExchange
+          // (global-scope only, none under a broadcast).
+          PhysicalProperties{
+              .globalPartition = key.partitioning,
+              .local = exchangeLocal(key.partitioning),
+              .unique = uniqueAcrossExchange(
+                  key.input->physicalProperties().unique,
+                  key.partitioning)}),
+      input_(key.input),
+      partitioning_(std::move(key.partitioning)) {
+  VELOX_CHECK_NOT_NULL(input_);
+}
+
+size_t Exchange::KeyHash::operator()(const Exchange* node) const {
+  const auto& partitioning = node->partitioning();
+  return hashOf(
+      node->input(),
+      static_cast<uint8_t>(partitioning.kind),
+      partitioning.partitionType,
+      partitioning.keys,
+      partitioning.orderKeys,
+      partitioning.orderTypes,
+      static_cast<uint8_t>(partitioning.scope),
+      partitioning.replicateNullsAndAny);
+}
+
+size_t Exchange::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      static_cast<uint8_t>(key.partitioning.kind),
+      key.partitioning.partitionType,
+      key.partitioning.keys,
+      key.partitioning.orderKeys,
+      key.partitioning.orderTypes,
+      static_cast<uint8_t>(key.partitioning.scope),
+      key.partitioning.replicateNullsAndAny);
+}
+
+bool Exchange::KeyEq::operator()(const Exchange* left, const Exchange* right)
+    const {
+  return left->input() == right->input() &&
+      left->partitioning() == right->partitioning();
+}
+
+bool Exchange::KeyEq::operator()(const Key& key, const Exchange* node) const {
+  return key.input == node->input() && key.partitioning == node->partitioning();
+}
+
+bool Exchange::KeyEq::operator()(const Exchange* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
+TableWrite::TableWrite(Key key)
+    : Node(
+          NodeType::kTableWrite,
+          ColumnVector{Column::create("rows", Value(toType(velox::BIGINT())))},
+          {}),
+      input_(key.input),
+      table_(key.table),
+      kind_(key.kind),
+      columnExprs_(std::move(key.columnExprs)) {
+  VELOX_CHECK_NOT_NULL(input_);
+  VELOX_CHECK_NOT_NULL(table_);
+  VELOX_CHECK(
+      !columnExprs_.empty(), "TableWrite must write at least one column");
+  VELOX_CHECK_EQ(columnExprs_.size(), table_->type()->size());
+}
+
+size_t TableWrite::KeyHash::operator()(const TableWrite* node) const {
+  return hashOf(
+      node->input(),
+      node->table(),
+      static_cast<uint8_t>(node->kind()),
+      node->columnExprs());
+}
+
+size_t TableWrite::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input, key.table, static_cast<uint8_t>(key.kind), key.columnExprs);
+}
+
+bool TableWrite::KeyEq::operator()(
+    const TableWrite* left,
+    const TableWrite* right) const {
+  return left->input() == right->input() && left->table() == right->table() &&
+      left->kind() == right->kind() &&
+      left->columnExprs() == right->columnExprs();
+}
+
+bool TableWrite::KeyEq::operator()(const Key& key, const TableWrite* node)
+    const {
+  return key.input == node->input() && key.table == node->table() &&
+      key.kind == node->kind() && key.columnExprs == node->columnExprs();
+}
+
+bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
+    const {
+  return (*this)(key, node);
+}
+
+#define V2_DEFINE_ACCEPT(NodeT)                                               \
+  void NodeT::accept(const NodeVisitor& visitor, NodeVisitorContext& context) \
+      const {                                                                 \
+    visitor.visit(*this, context);                                            \
+  }
+
+V2_DEFINE_ACCEPT(Scan)
+V2_DEFINE_ACCEPT(Filter)
+V2_DEFINE_ACCEPT(Project)
+V2_DEFINE_ACCEPT(Limit)
+V2_DEFINE_ACCEPT(Sort)
+V2_DEFINE_ACCEPT(TopN)
+V2_DEFINE_ACCEPT(Aggregate)
+V2_DEFINE_ACCEPT(GroupId)
+V2_DEFINE_ACCEPT(MarkDistinct)
+V2_DEFINE_ACCEPT(Values)
+V2_DEFINE_ACCEPT(Unnest)
+V2_DEFINE_ACCEPT(UnionAll)
+V2_DEFINE_ACCEPT(Join)
+V2_DEFINE_ACCEPT(Window)
+V2_DEFINE_ACCEPT(TopNRowNumber)
+V2_DEFINE_ACCEPT(Apply)
+V2_DEFINE_ACCEPT(EnforceSingleRow)
+V2_DEFINE_ACCEPT(AssignUniqueId)
+V2_DEFINE_ACCEPT(EnforceDistinct)
+V2_DEFINE_ACCEPT(Exchange)
+V2_DEFINE_ACCEPT(TableWrite)
+
+#undef V2_DEFINE_ACCEPT
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1,0 +1,1800 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <array>
+#include <span>
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+#include "velox/core/PlanNode.h"
+
+/// Tree-IR for the optimizer.
+///
+/// Nodes are immutable and, like all `PlanObject`s, arena-allocated from the
+/// shared `QueryGraphContext`.
+namespace facebook::axiom::optimizer::v2 {
+
+/// Discriminator for Node subtypes.
+enum class NodeType : uint8_t {
+  kScan,
+  kFilter,
+  kProject,
+  kLimit,
+  kSort,
+  kTopN,
+  kAggregate,
+  kGroupId,
+  kMarkDistinct,
+  kValues,
+  kUnnest,
+  kUnionAll,
+  kJoin,
+  kWindow,
+  kTopNRowNumber,
+  kApply,
+  kEnforceSingleRow,
+  kAssignUniqueId,
+  kEnforceDistinct,
+  kExchange,
+  kTableWrite,
+};
+
+AXIOM_DECLARE_ENUM_NAME(NodeType);
+
+class Node;
+class NodeVisitor;
+class NodeVisitorContext;
+using NodeCP = const Node*;
+using NodeVector = QGVector<NodeCP>;
+
+/// Base class for tree-IR operator nodes. Immutable. All members are const
+/// and initialized via the constructor. Abstract — instantiate via a subclass.
+///
+/// Cross-node references — predicates, join/grouping/sort keys, expression
+/// operands, per-leg layouts — bind by pointer identity, and keys may be
+/// arbitrary expressions, not just columns: `GROUP BY mod(a, 2)` carries a
+/// `Call` grouping key, and sort and partition keys are the same. Positional
+/// indices into a producer's `outputColumns()` are never used: pruning,
+/// duplicate-column collapse, and any other rewrite that reshapes a producer's
+/// `outputColumns` would then force rewiring at every consumer. Same-node
+/// sub-vector indices (e.g., `GroupId::groupingSets` into `groupingKeyColumns`)
+/// are positional and OK — they reference structure internal to the node, not a
+/// producer. The IR never binds by column name; names on `Column::name_` /
+/// `alias_` exist only as display labels for EXPLAIN.
+///
+/// A node's `PhysicalProperties`, by contrast, always reference this node's own
+/// output columns — an invariant each derivation upholds and the base
+/// constructor verifies (`checkReferencesColumns`). Velox's column-key
+/// requirement for aggregation / ordering / windowing / exchange is a separate,
+/// emit-time concern that `PrecomputeProjections` materializes.
+///
+/// Each node kind enforces its own column-identity contract: outputs contain no
+/// duplicate columns, and each kind extends or transforms its input schema in a
+/// specific way. See each subclass's docblock for the exact rules.
+///
+/// Instantiate nodes only through a `Builder` (`builder.make<T>(key)`), never
+/// by constructing a subclass directly: `make` hash-conses on the subclass's
+/// nested `Key` struct (its identity — two nodes of a kind intern to the same
+/// instance iff their `Key`s compare equal: input pointer(s) plus the node's
+/// parameter expression / column pointers). Direct construction bypasses
+/// interning. See `Builder.h`.
+class Node : public PlanObject {
+ public:
+  NodeType nodeType() const {
+    return nodeType_;
+  }
+
+  bool is(NodeType nodeType) const {
+    return nodeType_ == nodeType;
+  }
+
+  std::string_view nodeTypeName() const {
+    return NodeTypeName::toName(nodeType_);
+  }
+
+  /// Columns produced by this node, in output order.
+  const ColumnVector& outputColumns() const {
+    return outputColumns_;
+  }
+
+  /// Physical properties of this node's output: per-driver local ordering /
+  /// grouping, distribution, and relation-level facts. Derived from the inputs
+  /// at construction and immutable. Fields stay unset until decided — e.g.
+  /// distribution is unspecified until an exchange is placed, which mints a new
+  /// node rather than mutating this one.
+  const PhysicalProperties& physicalProperties() const {
+    return physicalProperties_;
+  }
+
+  /// Inputs in dependency order; empty for leaves. Returns a view into
+  /// node-owned storage; callers must not retain it past the node's
+  /// lifetime.
+  virtual std::span<const NodeCP> inputs() const = 0;
+
+  /// Double-dispatch hook for `NodeVisitor`.
+  virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const = 0;
+
+  std::string toString() const override;
+
+ protected:
+  Node(
+      NodeType nodeType,
+      ColumnVector outputColumns,
+      PhysicalProperties properties)
+      : PlanObject(PlanType::kV2Node),
+        nodeType_(nodeType),
+        outputColumns_(std::move(outputColumns)),
+        physicalProperties_(std::move(properties)) {
+    physicalProperties_.checkReferencesColumns(
+        PlanObjectSet::fromObjects(outputColumns_));
+  }
+
+ private:
+  const NodeType nodeType_;
+  const ColumnVector outputColumns_;
+  const PhysicalProperties physicalProperties_;
+};
+
+/// Reads rows from a connector-backed table (`BaseTable`).
+class Scan : public Node {
+ public:
+  struct Key {
+    BaseTableCP baseTable;
+    /// Strict consumer-required output columns; may be empty (e.g.
+    /// `SELECT count(1) FROM t` needs no column values from the table).
+    /// Distinct by pointer; both `outputName()` and the underlying `name()`
+    /// are unique within the vector. `filters` may reference columns that are
+    /// NOT in this set; the connector-side read schema is computed as
+    /// `outputColumns ∪ refs(filters)` when building the final Velox plan.
+    ColumnVector outputColumns;
+    /// Predicates (joined with AND) offered to the connector during planning;
+    /// may be empty. The connector accepts those it can evaluate and rejects
+    /// the rest; rejected predicates are re-applied as a `Filter` node above
+    /// the `TableScan` when building the final Velox plan.
+    ExprVector filters;
+  };
+
+  /// Transparent hasher for interning `Scan`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Scan* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Scan`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Scan* left, const Scan* right) const;
+    bool operator()(const Key& key, const Scan* node) const;
+    bool operator()(const Scan* node, const Key& key) const;
+  };
+
+  explicit Scan(Key key);
+
+  BaseTableCP baseTable() const {
+    return baseTable_;
+  }
+
+  const ExprVector& filters() const {
+    return filters_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const BaseTableCP baseTable_;
+  const ExprVector filters_;
+};
+
+using ScanCP = const Scan*;
+
+/// Selects rows from its input that match all of its predicates (joined with
+/// AND). Does not change the schema: `outputColumns()` are the input's columns
+/// unchanged (the same `Column` pointers).
+class Filter : public Node {
+ public:
+  struct Key {
+    /// Input node whose rows are filtered.
+    NodeCP input;
+    /// Predicates joined with AND; non-empty.
+    ExprVector predicates;
+  };
+
+  /// Transparent hasher for interning `Filter`s by identity (input +
+  /// predicates), read from either a stored `Filter*` or a lookup `Key`.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Filter* filter) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Filter`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Filter* left, const Filter* right) const;
+    bool operator()(const Key& key, const Filter* filter) const;
+    bool operator()(const Filter* filter, const Key& key) const;
+  };
+
+  explicit Filter(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  /// Predicates joined with AND. Non-empty.
+  const ExprVector& predicates() const {
+    return predicates_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector predicates_;
+};
+
+using FilterCP = const Filter*;
+
+/// Computes output columns from input expressions. Output schema is
+/// `outputColumns`; the i-th output column is produced by `exprs[i]`.
+///
+/// Example: `SELECT a, b + 1 AS c FROM t` translates to:
+///
+///     Project(input=t, exprs=[t.a, t.b + 1], outputColumns=[t.a, c])
+///
+/// where `t.a` is a pass-through (same `Column*` as the input), and
+/// `c` is a fresh `Column*` for the computed expression.
+class Project : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Output expressions, positional with `outputColumns`.
+    ExprVector exprs;
+    /// Output columns, positional with `exprs` (see the class docblock for the
+    /// pass-through vs fresh-column rule).
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Project`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Project* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Project`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Project* left, const Project* right) const;
+    bool operator()(const Key& key, const Project* node) const;
+    bool operator()(const Project* node, const Key& key) const;
+  };
+
+  explicit Project(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& exprs() const {
+    return exprs_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector exprs_;
+};
+
+using ProjectCP = const Project*;
+
+/// Returns up to `count` rows starting from `offset`. Does not change the
+/// schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers).
+class Limit : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Number of leading rows to skip; >= 0.
+    int64_t offset;
+    /// Maximum number of rows to return; >= 0.
+    /// `std::numeric_limits<int64_t>::max()` means no limit (e.g. `OFFSET n`
+    /// with no `LIMIT`), 0 means empty result.
+    int64_t count;
+  };
+
+  /// Transparent hasher for interning `Limit`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Limit* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Limit`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Limit* left, const Limit* right) const;
+    bool operator()(const Key& key, const Limit* node) const;
+    bool operator()(const Limit* node, const Key& key) const;
+  };
+
+  explicit Limit(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using LimitCP = const Limit*;
+
+/// Sorts rows by `orderKeys` with directions in `orderTypes`. Does not change
+/// the schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers).
+class Sort : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Sort keys, outermost first; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+  };
+
+  /// Transparent hasher for interning `Sort`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Sort* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Sort`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Sort* left, const Sort* right) const;
+    bool operator()(const Key& key, const Sort* node) const;
+    bool operator()(const Sort* node, const Key& key) const;
+  };
+
+  explicit Sort(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+};
+
+using SortCP = const Sort*;
+
+/// Sorts rows by `orderKeys` / `orderTypes` and returns up to `count` rows
+/// starting from `offset` — a bounded Sort. A Limit directly over a Sort fuses
+/// into this. Does not change the schema:
+/// `outputColumns()` are the input's columns unchanged (the same `Column`
+/// pointers).
+class TopN : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Sort keys, outermost first; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Number of leading rows to skip; >= 0.
+    int64_t offset;
+    /// Maximum number of rows to return; >= 0.
+    int64_t count;
+  };
+
+  /// Transparent hasher for interning `TopN`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TopN* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TopN`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TopN* left, const TopN* right) const;
+    bool operator()(const Key& key, const TopN* node) const;
+    bool operator()(const TopN* node, const Key& key) const;
+  };
+
+  explicit TopN(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  int64_t offset() const {
+    return offset_;
+  }
+
+  int64_t count() const {
+    return count_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+  const int64_t offset_;
+  const int64_t count_;
+};
+
+using TopNCP = const TopN*;
+
+/// Vector of `optimizer::Aggregate*` (an aggregate-function Call). The
+/// type is distinct from `ExprVector` so consumers don't need to
+/// downcast each element to access aggregate-specific accessors
+/// (`condition`, `orderKeys`, etc.); the `Aggregate` node carries
+/// this type directly.
+using AggregateCallVector = QGVector<const optimizer::Aggregate*>;
+
+/// Stage of a (possibly distributed) aggregation, reusing Velox's enum.
+/// `kSingle` computes the complete result in one pass. `kPartial`
+/// pre-aggregates its input and emits intermediate accumulators (one per
+/// aggregate, typed by `optimizer::Aggregate::intermediateType()`); `kFinal`
+/// consumes those accumulators and emits the final result. A two-stage
+/// distributed aggregate is `kFinal` over a remote `Exchange` over `kPartial`.
+using AggregateStep = velox::core::AggregationNode::Step;
+
+/// Groups input rows by `groupingKeys` and computes `aggregates` per
+/// group. Output schema is `groupingKeys` followed by `aggregates`
+/// (one output column each).
+///
+/// Example: `SELECT a, sum(b) FROM t GROUP BY a` translates to:
+///
+///     Aggregate(input=t, groupingKeys=[t.a], aggregates=[sum(t.b)],
+///               outputColumns=[t.a, sum_b])
+///
+/// One output row per distinct value of `t.a`, with `sum_b` the sum
+/// of `t.b` within that group.
+///
+/// GROUPING SETS / ROLLUP / CUBE have no dedicated representation here: they
+/// are lowered to a `GroupId` input plus a plain aggregate keyed on an explicit
+/// group-id column, so this node has no grouping-set concept of its own. That
+/// group-id column, when present, is also recorded in `groupId` (with
+/// `globalGroupingSets`).
+class Aggregate : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Grouping keys; empty for a global aggregate.
+    ExprVector groupingKeys;
+    /// Aggregate functions, one per output aggregate column.
+    AggregateCallVector aggregates;
+    /// Output columns: the `groupingKeys`, then the `aggregates`, positionally.
+    ColumnVector outputColumns;
+    /// Aggregation stage. For a `kPartial` step, `outputColumns`' aggregate
+    /// positions hold intermediate accumulators (typed by
+    /// `intermediateType()`), not final results.
+    AggregateStep step{AggregateStep::kSingle};
+
+    /// Group-id column from the upstream `GroupId`, or null for a plain
+    /// aggregate. Set iff `globalGroupingSets` is non-empty; when set it also
+    /// appears in `groupingKeys`.
+    ColumnCP groupId{nullptr};
+    /// Group-id values of the global (empty) grouping sets. Non-empty only for
+    /// a GROUPING SETS / ROLLUP / CUBE aggregate with a global `()` set; drives
+    /// Velox's default-row-per-global-set behavior over empty input.
+    QGVector<int32_t> globalGroupingSets;
+  };
+
+  /// Transparent hasher for interning `Aggregate`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Aggregate* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Aggregate`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Aggregate* left, const Aggregate* right) const;
+    bool operator()(const Key& key, const Aggregate* node) const;
+    bool operator()(const Aggregate* node, const Key& key) const;
+  };
+
+  explicit Aggregate(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const AggregateCallVector& aggregates() const {
+    return aggregates_;
+  }
+
+  AggregateStep step() const {
+    return step_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  const QGVector<int32_t>& globalGroupingSets() const {
+    return globalGroupingSets_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector groupingKeys_;
+  const AggregateCallVector aggregates_;
+  const AggregateStep step_;
+  const ColumnCP groupId_;
+  const QGVector<int32_t> globalGroupingSets_;
+};
+
+using AggregateCP = const Aggregate*;
+
+/// Replicates each input row once per grouping set, emitting NULL for keys
+/// inactive in that set and tagging the copy with the set's index. The
+/// downstream `Aggregate` then groups by
+/// `groupingKeyColumns ++ [groupId]` and runs the aggregates over the
+/// replicated rows; the SQL `GROUPING SETS` / `ROLLUP` / `CUBE` semantics
+/// fall out of that grouping.
+///
+/// `outputColumns` = `groupingKeyColumns ++ aggregationInputs' columns ++
+/// [groupId]`. Velox `GroupingKeyInfo` maps each `groupingKeys` expression to
+/// the corresponding `groupingKeyColumns` output name; both vectors are
+/// positionally aligned.
+class GroupId : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Input-side expressions whose values populate each replicated grouping
+    /// key; positionally aligned with `groupingKeyColumns`.
+    ExprVector groupingKeys;
+    /// Input columns referenced by the downstream `Aggregate`'s aggregate
+    /// functions; passed through to the output unchanged.
+    ExprVector aggregationInputs;
+    /// Non-empty; each entry lists the `groupingKeyColumns` indices active for
+    /// that set. Inactive keys are emitted as NULL in that set's output rows.
+    QGVector<QGVector<int32_t>> groupingSets;
+    /// Fresh output columns for the (possibly NULL-padded) grouping keys.
+    ColumnVector groupingKeyColumns;
+    /// Output column holding the grouping-set index (BIGINT, zero-based).
+    ColumnCP groupId;
+    /// Output columns: `groupingKeyColumns`, then `aggregationInputs`' columns,
+    /// then `groupId`.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `GroupId`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const GroupId* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `GroupId`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const GroupId* left, const GroupId* right) const;
+    bool operator()(const Key& key, const GroupId* node) const;
+    bool operator()(const GroupId* node, const Key& key) const;
+  };
+
+  explicit GroupId(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& groupingKeys() const {
+    return groupingKeys_;
+  }
+
+  const ExprVector& aggregationInputs() const {
+    return aggregationInputs_;
+  }
+
+  const QGVector<QGVector<int32_t>>& groupingSets() const {
+    return groupingSets_;
+  }
+
+  const ColumnVector& groupingKeyColumns() const {
+    return groupingKeyColumns_;
+  }
+
+  ColumnCP groupId() const {
+    return groupId_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector groupingKeys_;
+  const ExprVector aggregationInputs_;
+  const QGVector<QGVector<int32_t>> groupingSets_;
+  const ColumnVector groupingKeyColumns_;
+  const ColumnCP groupId_;
+};
+
+using GroupIdCP = const GroupId*;
+
+/// Marks the first occurrence of each `(distinctKeys)` tuple from `input`
+/// with `true` and subsequent occurrences with `false`. Used to lower
+/// `DISTINCT` aggregates to non-distinct ones with a FILTER mask: a
+/// downstream `Aggregate` reads `agg(x) FILTER (marker)` and sees each
+/// `(group, x)` tuple at most once.
+///
+/// One `MarkDistinct` serves all distinct aggregates over the same key set.
+/// `markers[0]` is the no-mask marker: true on the first occurrence of each
+/// tuple overall, read by the unfiltered distinct aggregates. Each `masks[i]`
+/// is the `FILTER` condition of a filtered distinct aggregate, paired with
+/// `markers[i+1]`, which is true on the first occurrence of each tuple among
+/// the rows where `masks[i]` holds. `masks` is empty when no distinct aggregate
+/// over this key set carries a `FILTER`.
+///
+/// `outputColumns` = `input.outputColumns ++ markers` (input columns pass
+/// through unchanged).
+class MarkDistinct : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Output marker columns (BOOLEAN); `markers[0]` is the no-mask marker.
+    /// See the class doc.
+    ColumnVector markers;
+    /// Columns / expressions tested for distinctness, in positional order.
+    ExprVector distinctKeys;
+    /// FILTER condition per filtered distinct aggregate, positionally aligned
+    /// with `markers[1..]`. Empty when no distinct aggregate over the key set
+    /// carries a FILTER.
+    ColumnVector masks;
+    /// Output columns: `input`'s columns, then `markers`.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `MarkDistinct`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const MarkDistinct* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `MarkDistinct`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const MarkDistinct* left, const MarkDistinct* right) const;
+    bool operator()(const Key& key, const MarkDistinct* node) const;
+    bool operator()(const MarkDistinct* node, const Key& key) const;
+  };
+
+  explicit MarkDistinct(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ColumnVector& markers() const {
+    return markers_;
+  }
+
+  const ExprVector& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  const ColumnVector& masks() const {
+    return masks_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ColumnVector markers_;
+  const ExprVector distinctKeys_;
+  const ColumnVector masks_;
+};
+
+using MarkDistinctCP = const MarkDistinct*;
+
+/// Embeds a constant table in the plan. `outputColumns` defines the schema
+/// in all three cases. At most one of `source` / `rows` is non-null:
+///   - `source != nullptr, rows == nullptr`: pass through a
+///     `logical_plan::ValuesNode` whose `Variants` or `Vectors` data is
+///     read when building the final Velox plan.
+///   - `source == nullptr, rows != nullptr`: an arena-allocated
+///     `Variant::array(...)` of row `Variant`s (each element is
+///     `Variant::row(...)`). Produced by translate-time folding of
+///     `lp::ValuesNode::Exprs`.
+///   - `source == nullptr, rows == nullptr`: empty table — zero rows with
+///     schema from `outputColumns`. Used for the `LIMIT 0` rewrite.
+class Values : public Node {
+ public:
+  struct Key {
+    /// Set to pass through a logical-plan `ValuesNode` (see class doc).
+    const logical_plan::ValuesNode* source;
+    /// Set to embed arena-folded row `Variant`s (see class doc).
+    const velox::Variant* rows;
+    /// Output schema (defines the columns in all cases).
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Values`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Values* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Values`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Values* left, const Values* right) const;
+    bool operator()(const Key& key, const Values* node) const;
+    bool operator()(const Values* node, const Key& key) const;
+  };
+
+  explicit Values(Key key);
+
+  const logical_plan::ValuesNode* source() const {
+    return source_;
+  }
+
+  const velox::Variant* rows() const {
+    return rows_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const logical_plan::ValuesNode* const source_;
+  const velox::Variant* const rows_;
+};
+
+using ValuesCP = const Values*;
+
+/// Expands array / map expressions row-wise. The output has three disjoint
+/// kinds of columns, exposed as separate accessors so consumers never need
+/// positional decoding: `replicatedColumns` (pass-through input columns),
+/// `unnestColumns[i]` (per-expression result columns), and the optional
+/// `ordinalityColumn`. `outputColumns()` returns the concatenation in that
+/// order, for downstream consumers that need a single vector view.
+class Unnest : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Array / map expressions expanded row-wise, in positional order.
+    ExprVector unnestExpressions;
+    /// Subset of `input->outputColumns()` to pass through; may be empty.
+    ColumnVector replicatedColumns;
+    /// One `ColumnVector` per `unnestExpressions[i]`: the result columns
+    /// produced by that expression (1 for ARRAY, 2 for MAP — key, value).
+    QGVector<ColumnVector> unnestColumns;
+    /// Optional ordinality column; null when this node does not produce
+    /// ordinality.
+    ColumnCP ordinalityColumn;
+    /// Visible schema. Every `Column*` here is a `replicatedColumns` column, a
+    /// column in some `unnestColumns[i]`, or `ordinalityColumn`. All
+    /// `replicatedColumns` and `ordinalityColumn` must appear; only
+    /// per-expression `unnestColumns` may be pruned out.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Unnest`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Unnest* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Unnest`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Unnest* left, const Unnest* right) const;
+    bool operator()(const Key& key, const Unnest* node) const;
+    bool operator()(const Unnest* node, const Key& key) const;
+  };
+
+  explicit Unnest(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& unnestExpressions() const {
+    return unnestExpressions_;
+  }
+
+  const ColumnVector& replicatedColumns() const {
+    return replicatedColumns_;
+  }
+
+  const QGVector<ColumnVector>& unnestColumns() const {
+    return unnestColumns_;
+  }
+
+  ColumnCP ordinalityColumn() const {
+    return ordinalityColumn_;
+  }
+
+  bool withOrdinality() const {
+    return ordinalityColumn_ != nullptr;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector unnestExpressions_;
+  const ColumnVector replicatedColumns_;
+  const QGVector<ColumnVector> unnestColumns_;
+  const ColumnCP ordinalityColumn_;
+};
+
+using UnnestCP = const Unnest*;
+
+/// Concatenates rows from all inputs (UNION ALL semantics).
+/// `outputColumns` is a fresh duplicate-free output schema; `legColumns[i]`
+/// maps each output position to a `Column*` from `inputs[i]`.
+///
+/// Example: `SELECT a, b FROM t UNION ALL SELECT x, y FROM u` translates to:
+///
+///     UnionAll(inputs=[t, u],
+///              legColumns=[[t.a, t.b],  // leg 0: which t columns feed outputs
+///                          [u.x, u.y]], // leg 1: which u columns feed outputs
+///              outputColumns=[union_col_0, union_col_1])
+///
+/// `legColumns[i][j]` is the `Column*` from `inputs[i]->outputColumns()`
+/// that supplies values for union output position `j`. The same
+/// `Column*` may repeat within a leg to fan one input column into
+/// multiple union positions (e.g., `SELECT a, a FROM t` after the
+/// translate-time deduplication collapses both selected `a`s to one input
+/// column).
+class UnionAll : public Node {
+ public:
+  struct Key {
+    /// Inputs to concatenate; >= 2.
+    NodeVector inputs;
+    /// Per input, the `Column*`s (from that input's `outputColumns()`) that
+    /// feed each output position: one entry per input, each sized like
+    /// `outputColumns`. See the class doc.
+    QGVector<ColumnVector> legColumns;
+    /// Fresh, duplicate-free output schema.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `UnionAll`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const UnionAll* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `UnionAll`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const UnionAll* left, const UnionAll* right) const;
+    bool operator()(const Key& key, const UnionAll* node) const;
+    bool operator()(const UnionAll* node, const Key& key) const;
+  };
+
+  explicit UnionAll(Key key);
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  const QGVector<ColumnVector>& legColumns() const {
+    return legColumns_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeVector inputs_;
+  const QGVector<ColumnVector> legColumns_;
+};
+
+using UnionAllCP = const UnionAll*;
+
+/// Joins two inputs by `joinType` with paired equi-keys plus an optional
+/// residual `filter`. `outputColumns` projects columns from the inputs; see the
+/// field doc.
+///
+/// Example: `SELECT * FROM t INNER JOIN u ON t.a = u.a AND t.b > u.b`
+/// translates to:
+///
+///     Join(left=t, right=u, joinType=kInner,
+///          leftKeys=[t.a], rightKeys=[u.a],
+///          filter=(t.b > u.b),
+///          outputColumns=[t.a, t.b, u.a, u.b])
+///
+/// `leftKeys[i]` joins against `rightKeys[i]` via equality; the two
+/// vectors must have the same size. The match condition is
+/// `AND(leftKeys[i] = rightKeys[i] for all i) AND AND(filter)`.
+/// `filter` is a flat vector of predicates joined with AND (the producer is
+/// responsible for flattening and for lifting any equi-pairs into the key
+/// vectors).
+///
+/// Lowering depends on key presence:
+///   - `leftKeys` non-empty → `HashJoinNode`, with `filter` as the
+///     optional residual non-equi predicate.
+///   - `leftKeys` empty, `filter` empty → `NestedLoopJoinNode` cross
+///     product.
+///   - `leftKeys` empty, `filter` non-empty → `NestedLoopJoinNode`
+///     filter-only join.
+///
+/// `nullAware` (semi / anti only) enables NULL-aware semantics for
+/// `IN` / `NOT IN`. `nullAsValue` (set ops INTERSECT / EXCEPT) treats
+/// `NULL == NULL` as true on equi-keys. Mutually exclusive.
+class Join : public Node {
+ public:
+  struct Key {
+    /// Left input.
+    NodeCP left;
+    /// Right input.
+    NodeCP right;
+    /// Join type (inner / left / full / semi / anti / ...).
+    velox::core::JoinType joinType;
+    /// Left equi-keys; positional with `rightKeys` and the same size.
+    ExprVector leftKeys;
+    /// Right equi-keys; positional with `leftKeys`.
+    ExprVector rightKeys;
+    /// Residual non-equi predicates joined with AND; may be empty.
+    ExprVector filter;
+    /// NULL-aware semantics for IN / NOT IN (semi / anti only).
+    bool nullAware{false};
+    /// Treats NULL == NULL as true on equi-keys (INTERSECT / EXCEPT).
+    bool nullAsValue{false};
+    /// Output columns, each drawn from the left or right input; semi / anti
+    /// joins draw only from the preserved side. Pruned to what consumers need.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Join`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Join* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Join`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Join* left, const Join* right) const;
+    bool operator()(const Key& key, const Join* node) const;
+    bool operator()(const Join* node, const Key& key) const;
+  };
+
+  explicit Join(Key key);
+
+  NodeCP left() const {
+    return inputs_[0];
+  }
+
+  NodeCP right() const {
+    return inputs_[1];
+  }
+
+  velox::core::JoinType joinType() const {
+    return joinType_;
+  }
+
+  std::string_view joinTypeName() const {
+    return velox::core::JoinTypeName::toName(joinType_);
+  }
+
+  bool isInner() const {
+    return joinType_ == velox::core::JoinType::kInner;
+  }
+
+  bool isLeft() const {
+    return joinType_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isFull() const {
+    return joinType_ == velox::core::JoinType::kFull;
+  }
+
+  const ExprVector& leftKeys() const {
+    return leftKeys_;
+  }
+
+  const ExprVector& rightKeys() const {
+    return rightKeys_;
+  }
+
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  bool nullAware() const {
+    return nullAware_;
+  }
+
+  bool nullAsValue() const {
+    return nullAsValue_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const velox::core::JoinType joinType_;
+  const ExprVector leftKeys_;
+  const ExprVector rightKeys_;
+  const ExprVector filter_;
+  const bool nullAware_;
+  const bool nullAsValue_;
+};
+
+using JoinCP = const Join*;
+
+/// One window function invocation. Frame is per-function (as in Velox
+/// `WindowNode::Function`), so functions sharing a partition / order but
+/// differing only in frame still group under a single `Window` node.
+struct WindowFunction {
+  /// The window function and its arguments.
+  ExprCP call;
+
+  /// The row/range window over which this function is evaluated.
+  Frame frame;
+
+  /// When true, NULL inputs are skipped when evaluating the function
+  /// (e.g. the `IGNORE NULLS` option in SQL frontends).
+  bool ignoreNulls;
+
+  bool operator==(const WindowFunction&) const = default;
+};
+
+using WindowFunctions = QGVector<WindowFunction>;
+
+/// Evaluates one or more window function calls. Output schema is input
+/// columns followed by one output column per window function.
+class Window : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Window function invocations sharing this partition / order; non-empty.
+    /// Each carries its own frame.
+    WindowFunctions functions;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Order-by keys; positional with `orderTypes`.
+    ExprVector orderKeys;
+    /// Sort direction per order key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Output columns: `input`'s columns, then one per window function.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Window`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Window* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Window`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Window* left, const Window* right) const;
+    bool operator()(const Key& key, const Window* node) const;
+    bool operator()(const Window* node, const Key& key) const;
+  };
+
+  explicit Window(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const WindowFunctions& functions() const {
+    return functions_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const WindowFunctions functions_;
+  const ExprVector partitionKeys_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+};
+
+using WindowCP = const Window*;
+
+/// Per-partition top-`limit` rows ranked by a ranking function (row_number /
+/// rank / dense_rank). Produced by fusing
+/// a `Filter(rankColumn <op> n)` over a single-ranking-function `Window`. The
+/// rank column is emitted only when `rankColumn` is set; otherwise the output
+/// is just the input columns.
+class TopNRowNumber : public Node {
+ public:
+  using RankFunction = velox::core::TopNRowNumberNode::RankFunction;
+
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Ranking function (row_number / rank / dense_rank).
+    RankFunction rankFunction;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Order-by keys; positional with `orderTypes`, non-empty.
+    ExprVector orderKeys;
+    /// Sort direction per order key; positional with `orderKeys`.
+    OrderTypeVector orderTypes;
+    /// Per-partition row cap; > 0.
+    int32_t limit;
+    /// Column carrying the ranking-function result in the output, or null to
+    /// omit it (the output is then just the input columns).
+    ColumnCP rankColumn;
+    /// Output columns: `input`'s columns, plus `rankColumn` when set.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `TopNRowNumber`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TopNRowNumber* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TopNRowNumber`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TopNRowNumber* left, const TopNRowNumber* right)
+        const;
+    bool operator()(const Key& key, const TopNRowNumber* node) const;
+    bool operator()(const TopNRowNumber* node, const Key& key) const;
+  };
+
+  explicit TopNRowNumber(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  RankFunction rankFunction() const {
+    return rankFunction_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  const ExprVector& orderKeys() const {
+    return orderKeys_;
+  }
+
+  const OrderTypeVector& orderTypes() const {
+    return orderTypes_;
+  }
+
+  int32_t limit() const {
+    return limit_;
+  }
+
+  ColumnCP rankColumn() const {
+    return rankColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const RankFunction rankFunction_;
+  const ExprVector partitionKeys_;
+  const ExprVector orderKeys_;
+  const OrderTypeVector orderTypes_;
+  const int32_t limit_;
+  const ColumnCP rankColumn_;
+};
+
+using TopNRowNumberCP = const TopNRowNumber*;
+
+/// Apply is a "true dependent join" — a relational join whose right side
+/// (`body`, conceptually evaluated per `input` row) may reference `input`'s
+/// columns.
+///
+/// "Body" rather than "subquery": at translate time Apply's right side IS
+/// the translated subquery, but as decorrelate iterates it peels operators
+/// off and `body` evolves. The decorrelate pass and downstream consumers
+/// reason about Apply as a generic dependent-join node whose right side is
+/// `body`; only Translate uses the SQL term "subquery" in its prose.
+///
+/// Example: `SELECT (SELECT max(u.b) FROM u WHERE u.a = t.a) FROM t`
+/// translates to:
+///
+///     Apply(kLeft, input=t,
+///           body=Aggregate(Filter(u.a=t.a, u), max(u.b)),
+///           correlationColumns=[t.a],
+///           filter=null,
+///           enforceSingleRow=false)
+///
+/// Apply is transient: produced by `translate` at every `lp::SubqueryExpr`
+/// site, eliminated by `pass.decorrelate` before any later pass.
+///
+/// Per-kind semantics:
+///
+///   kLeft             Correlated scalar / lateral subquery. Left-outer-join
+///                     semantics. Body may produce N rows per outer. Output:
+///                     `input.outputColumns ++ unique(body.outputColumns)
+///                     ++ [includeMarker]` — a body column already in input
+///                     occupies a single output slot. (NULL-padded for
+///                     outers with no match; `includeMarker` is `true`
+///                     on real rows, NULL on pad rows.)
+///   kLeftSemiProject  EXISTS / IN. Output:
+///                     `input.outputColumns ++ markColumn` — a fresh BOOLEAN
+///                     true iff any body row exists for the outer
+///                     matching `filter` AND (for IN) `inLhs = inBodyKey`.
+///                     NULL-aware for IN.
+///
+/// `kLeftSemiFilter` and `kAnti` never appear at Apply — they emerge only
+/// from a post-decorrelate peephole that recognizes
+/// `Filter(mark, Join(kLeftSemiProject, ..., mark))`.
+class Apply : public Node {
+ public:
+  struct Key {
+    /// Left ("outer") input.
+    NodeCP input;
+    /// Right side, evaluated per `input` row; may reference `input`'s columns.
+    NodeCP body;
+    /// `input` columns the current `body` still references; recomputed by
+    /// decorrelate after each peel. Empty at terminus, where Apply becomes a
+    /// Join.
+    ColumnVector correlationColumns;
+    /// `kLeft` (correlated scalar / lateral) or `kLeftSemiProject` (EXISTS /
+    /// IN).
+    velox::core::JoinType kind;
+    /// Residual predicates joined with AND; become `Join.filter` at terminus.
+    ExprVector filter;
+    /// Assert the body returns 0-or-1 row per outer (>1 rows errors);
+    /// correlated scalar subqueries only.
+    bool enforceSingleRow;
+    /// `kLeftSemiProject` mark output (BOOLEAN); null for `kLeft`.
+    ColumnCP markColumn;
+    /// IN equi-pair left side (the `lhs` of `lhs IN (SELECT ...)`), kept as a
+    /// pair rather than `eq(inLhs, inBodyKey)` so consumers read each side
+    /// directly; drives `nullAware()`. Null unless an IN subquery.
+    ExprCP inLhs;
+    /// IN equi-pair body side; see `inLhs`. Null unless an IN subquery.
+    ExprCP inBodyKey;
+    /// `kLeft` pad-row marker (BOOLEAN); null for `kLeftSemiProject`.
+    ColumnCP includeMarker;
+    /// Output columns; per-kind layout in the class doc.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `Apply`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Apply* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Apply`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Apply* left, const Apply* right) const;
+    bool operator()(const Key& key, const Apply* node) const;
+    bool operator()(const Apply* node, const Key& key) const;
+  };
+
+  explicit Apply(Key key);
+
+  NodeCP input() const {
+    return inputs_[0];
+  }
+
+  NodeCP body() const {
+    return inputs_[1];
+  }
+
+  const ColumnVector& correlationColumns() const {
+    return correlationColumns_;
+  }
+
+  velox::core::JoinType kind() const {
+    return kind_;
+  }
+
+  std::string_view kindName() const {
+    return velox::core::JoinTypeName::toName(kind_);
+  }
+
+  bool isLeft() const {
+    return kind_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isLeftSemiProject() const {
+    return kind_ == velox::core::JoinType::kLeftSemiProject;
+  }
+
+  const ExprVector& filter() const {
+    return filter_;
+  }
+
+  bool enforceSingleRow() const {
+    return enforceSingleRow_;
+  }
+
+  ColumnCP markColumn() const {
+    return markColumn_;
+  }
+
+  ExprCP inLhs() const {
+    return inLhs_;
+  }
+
+  ExprCP inBodyKey() const {
+    return inBodyKey_;
+  }
+
+  ColumnCP includeMarker() const {
+    return includeMarker_;
+  }
+
+  bool nullAware() const {
+    return inLhs_ != nullptr;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return inputs_;
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const std::array<NodeCP, 2> inputs_;
+  const ColumnVector correlationColumns_;
+  const velox::core::JoinType kind_;
+  const ExprVector filter_;
+  const bool enforceSingleRow_;
+  const ColumnCP markColumn_;
+  const ExprCP inLhs_;
+  const ExprCP inBodyKey_;
+  const ColumnCP includeMarker_;
+};
+
+using ApplyCP = const Apply*;
+
+/// Asserts the input contains at most one row and passes it through unchanged;
+/// an empty input yields a single all-NULL row, and more than one row raises an
+/// error. Does not change the schema: `outputColumns()` are the input's columns
+/// unchanged (the same `Column` pointers). Used to enforce the 0-or-1-row
+/// cardinality of an uncorrelated scalar subquery.
+class EnforceSingleRow : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+  };
+
+  /// Transparent hasher for interning `EnforceSingleRow`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const EnforceSingleRow* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `EnforceSingleRow`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const EnforceSingleRow* left, const EnforceSingleRow* right)
+        const;
+    bool operator()(const Key& key, const EnforceSingleRow* node) const;
+    bool operator()(const EnforceSingleRow* node, const Key& key) const;
+  };
+
+  explicit EnforceSingleRow(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+};
+
+using EnforceSingleRowCP = const EnforceSingleRow*;
+
+/// Emits each input row unchanged, appending `idColumn` — a value unique across
+/// all output rows.
+class AssignUniqueId : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Appended id column (BIGINT).
+    ColumnCP idColumn;
+  };
+
+  /// Transparent hasher for interning `AssignUniqueId`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const AssignUniqueId* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `AssignUniqueId`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const AssignUniqueId* left, const AssignUniqueId* right)
+        const;
+    bool operator()(const Key& key, const AssignUniqueId* node) const;
+    bool operator()(const AssignUniqueId* node, const Key& key) const;
+  };
+
+  explicit AssignUniqueId(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  ColumnCP idColumn() const {
+    return idColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ColumnCP idColumn_;
+};
+
+using AssignUniqueIdCP = const AssignUniqueId*;
+
+/// Asserts that `distinctKeys` are unique across the input — at most one row
+/// per distinct combination of their values — raising a runtime error carrying
+/// `errorMessage` on the first duplicate. Does not change the schema:
+/// `outputColumns()` are the input's columns unchanged (the same `Column`
+/// pointers). Used to enforce the 0-or-1-row cardinality of a correlated scalar
+/// subquery.
+class EnforceDistinct : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Keys asserted unique across the input; non-empty.
+    ExprVector distinctKeys;
+    /// Error message raised on the first duplicate.
+    Name errorMessage;
+  };
+
+  /// Transparent hasher for interning `EnforceDistinct`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const EnforceDistinct* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `EnforceDistinct`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const EnforceDistinct* left, const EnforceDistinct* right)
+        const;
+    bool operator()(const Key& key, const EnforceDistinct* node) const;
+    bool operator()(const EnforceDistinct* node, const Key& key) const;
+  };
+
+  explicit EnforceDistinct(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& distinctKeys() const {
+    return distinctKeys_;
+  }
+
+  Name errorMessage() const {
+    return errorMessage_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector distinctKeys_;
+  const Name errorMessage_;
+};
+
+using EnforceDistinctCP = const EnforceDistinct*;
+
+/// Redistributes input rows across tasks with a remote exchange — lowered to a
+/// `PartitionedOutput`→`Exchange` pair straddling a fragment boundary — setting
+/// `partitioning` as the output's global partitioning. Does not change the
+/// schema: `outputColumns()` are the input's columns unchanged (the same
+/// `Column` pointers). The only node that repartitions: it imposes a global
+/// partitioning via a shuffle, whereas other nodes derive theirs from their
+/// input. The distributed memo places it when a consumer needs a partitioning
+/// the input lacks.
+class Exchange : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Global partitioning imposed on the output via the shuffle.
+    Partitioning partitioning;
+  };
+
+  /// Transparent hasher for interning `Exchange`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const Exchange* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `Exchange`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const Exchange* left, const Exchange* right) const;
+    bool operator()(const Key& key, const Exchange* node) const;
+    bool operator()(const Exchange* node, const Key& key) const;
+  };
+
+  explicit Exchange(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const Partitioning& partitioning() const {
+    return partitioning_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const Partitioning partitioning_;
+};
+
+using ExchangeCP = const Exchange*;
+
+/// Writes its input rows to a table (CTAS / INSERT; DELETE / UPDATE deferred).
+/// A root sink: its single BIGINT output column is the
+/// written row count, consumed by no node.
+class TableWrite : public Node {
+ public:
+  struct Key {
+    /// Input node (rows to write).
+    NodeCP input;
+    /// Target table; emit reads its `type()` and `layouts()` for the insert
+    /// handle.
+    const connector::Table* table;
+    /// Write form (INSERT / CTAS / ...).
+    connector::WriteKind kind;
+    /// Per-target-column values, non-empty and 1:1 with the table schema
+    /// (`table->type()`).
+    ExprVector columnExprs;
+  };
+
+  /// Transparent hasher for interning `TableWrite`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const TableWrite* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `TableWrite`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const TableWrite* left, const TableWrite* right) const;
+    bool operator()(const Key& key, const TableWrite* node) const;
+    bool operator()(const TableWrite* node, const Key& key) const;
+  };
+
+  explicit TableWrite(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const connector::Table* table() const {
+    return table_;
+  }
+
+  connector::WriteKind kind() const {
+    return kind_;
+  }
+
+  const ExprVector& columnExprs() const {
+    return columnExprs_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const connector::Table* const table_;
+  const connector::WriteKind kind_;
+  const ExprVector columnExprs_;
+};
+
+using TableWriteCP = const TableWrite*;
+
+} // namespace facebook::axiom::optimizer::v2
+
+AXIOM_ENUM_FORMATTER(facebook::axiom::optimizer::v2::NodeType);

--- a/axiom/optimizer/v2/NodeExpressions.h
+++ b/axiom/optimizer/v2/NodeExpressions.h
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Invokes `visit(expression)` for each expression that lives directly
+/// on `node` (predicates, projection exprs, aggregate args, join keys,
+/// etc.). Does NOT recurse into sub-nodes — callers that need a full
+/// tree walk recurse via `node->inputs()` themselves.
+///
+/// Used by passes that need to inspect every expression on a Node
+/// uniformly across all Node kinds (correlation tracking, column-use
+/// analysis, etc.). Kept central so per-pass implementations don't
+/// each maintain their own switch over `NodeType`.
+///
+/// For nodes that carry no expressions (Scan, Values, Limit,
+/// EnforceSingleRow, AssignUniqueId), no callbacks are invoked.
+///
+/// For nested `Apply`, only the boundary-level expressions (`filter`,
+/// `inLhs`, `inBodyKey`) are visited. `correlationColumns` is NOT
+/// visited — those are nested-Apply boundary references to the nested
+/// Apply's input cols, not references from the outer caller's
+/// perspective. Refs to outer cols inside the nested Apply's body are
+/// reached via input-tree recursion.
+///
+/// `visit` should be callable as `visit(ExprCP)`. `ColumnCP` is
+/// passed where appropriate (Unnest's `replicatedColumns`, UnionAll's
+/// `legColumns` entries — both are column references); since `Column`
+/// derives from `Expr`, the upcast is implicit.
+template <typename Visit>
+void forEachExpressionInNode(NodeCP node, Visit&& visit) {
+  switch (node->nodeType()) {
+    case NodeType::kFilter:
+      for (ExprCP predicate : node->as<Filter>()->predicates()) {
+        visit(predicate);
+      }
+      break;
+    case NodeType::kProject:
+      for (ExprCP expression : node->as<Project>()->exprs()) {
+        visit(expression);
+      }
+      break;
+    case NodeType::kAggregate: {
+      const Aggregate* aggregate = node->as<Aggregate>();
+      for (ExprCP groupingKey : aggregate->groupingKeys()) {
+        visit(groupingKey);
+      }
+      for (const auto* aggregateCall : aggregate->aggregates()) {
+        for (ExprCP argument : aggregateCall->args()) {
+          visit(argument);
+        }
+        if (aggregateCall->condition() != nullptr) {
+          visit(aggregateCall->condition());
+        }
+        for (ExprCP orderKey : aggregateCall->orderKeys()) {
+          visit(orderKey);
+        }
+      }
+      break;
+    }
+    case NodeType::kSort:
+      for (ExprCP orderKey : node->as<Sort>()->orderKeys()) {
+        visit(orderKey);
+      }
+      break;
+    case NodeType::kTopN:
+      for (ExprCP orderKey : node->as<TopN>()->orderKeys()) {
+        visit(orderKey);
+      }
+      break;
+    case NodeType::kJoin: {
+      const Join* join = node->as<Join>();
+      for (ExprCP key : join->leftKeys()) {
+        visit(key);
+      }
+      for (ExprCP key : join->rightKeys()) {
+        visit(key);
+      }
+      for (ExprCP conjunct : join->filter()) {
+        visit(conjunct);
+      }
+      break;
+    }
+    case NodeType::kApply: {
+      const Apply* apply = node->as<Apply>();
+      for (ExprCP conjunct : apply->filter()) {
+        visit(conjunct);
+      }
+      if (apply->inLhs() != nullptr) {
+        visit(apply->inLhs());
+      }
+      if (apply->inBodyKey() != nullptr) {
+        visit(apply->inBodyKey());
+      }
+      // correlationColumns: nested-Apply boundary refs (to nested
+      // input cols), not refs from the outer caller's perspective.
+      // Refs to outer cols inside the nested body reach the caller via
+      // input-tree recursion.
+      break;
+    }
+    case NodeType::kEnforceDistinct:
+      for (ExprCP key : node->as<EnforceDistinct>()->distinctKeys()) {
+        visit(key);
+      }
+      break;
+    case NodeType::kExchange:
+      for (ExprCP key : node->as<Exchange>()->partitioning().keys) {
+        visit(key);
+      }
+      break;
+    case NodeType::kWindow: {
+      const Window* window = node->as<Window>();
+      for (ExprCP key : window->partitionKeys()) {
+        visit(key);
+      }
+      for (ExprCP key : window->orderKeys()) {
+        visit(key);
+      }
+      for (const auto& windowFunction : window->functions()) {
+        visit(windowFunction.call);
+        if (windowFunction.frame.startValue != nullptr) {
+          visit(windowFunction.frame.startValue);
+        }
+        if (windowFunction.frame.endValue != nullptr) {
+          visit(windowFunction.frame.endValue);
+        }
+      }
+      break;
+    }
+    case NodeType::kTopNRowNumber: {
+      const TopNRowNumber* topN = node->as<TopNRowNumber>();
+      for (ExprCP key : topN->partitionKeys()) {
+        visit(key);
+      }
+      for (ExprCP key : topN->orderKeys()) {
+        visit(key);
+      }
+      break;
+    }
+    case NodeType::kUnnest: {
+      const Unnest* unnest = node->as<Unnest>();
+      for (ExprCP expression : unnest->unnestExpressions()) {
+        visit(expression);
+      }
+      for (ColumnCP column : unnest->replicatedColumns()) {
+        visit(column);
+      }
+      break;
+    }
+    case NodeType::kUnionAll: {
+      const UnionAll* unionAll = node->as<UnionAll>();
+      for (const auto& leg : unionAll->legColumns()) {
+        for (ColumnCP column : leg) {
+          visit(column);
+        }
+      }
+      break;
+    }
+    case NodeType::kGroupId: {
+      const GroupId* groupId = node->as<GroupId>();
+      for (ExprCP key : groupId->groupingKeys()) {
+        visit(key);
+      }
+      for (ExprCP input : groupId->aggregationInputs()) {
+        visit(input);
+      }
+      break;
+    }
+    case NodeType::kMarkDistinct: {
+      const MarkDistinct* markDistinct = node->as<MarkDistinct>();
+      for (ExprCP key : markDistinct->distinctKeys()) {
+        visit(key);
+      }
+      for (ColumnCP mask : markDistinct->masks()) {
+        visit(mask);
+      }
+      break;
+    }
+    case NodeType::kTableWrite:
+      for (ExprCP expression : node->as<TableWrite>()->columnExprs()) {
+        visit(expression);
+      }
+      break;
+    case NodeType::kScan:
+    case NodeType::kValues:
+    case NodeType::kLimit:
+    case NodeType::kEnforceSingleRow:
+    case NodeType::kAssignUniqueId:
+      // No expressions on these nodes.
+      break;
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -1,0 +1,367 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/NodePrinter.h"
+
+#include <fmt/format.h>
+#include <fmt/ranges.h>
+#include <ranges>
+#include <sstream>
+#include "axiom/optimizer/v2/NodeVisitor.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+std::string spaces(size_t depth) {
+  return std::string(depth, ' ');
+}
+
+std::string formatExpr(ExprCP expr) {
+  if (expr == nullptr) {
+    return "<null>";
+  }
+  return expr->toString();
+}
+
+std::string formatColumns(const ColumnVector& columns) {
+  auto formatted =
+      columns | std::views::transform([](ColumnCP c) {
+        return fmt::format("{}:{}", c->toString(), c->value().type->toString());
+      });
+  return fmt::to_string(fmt::join(formatted, ", "));
+}
+
+// Templated so any range of Expr-derived pointers (ExprVector,
+// AggregateCallVector, etc.) formats the same way.
+template <typename Range>
+std::string formatExprs(const Range& exprs) {
+  auto texts = exprs |
+      std::views::transform([](const auto* expr) { return formatExpr(expr); });
+  return fmt::to_string(fmt::join(texts, ", "));
+}
+
+class Printer : public NodeVisitor {
+ public:
+  struct Context : public NodeVisitorContext {
+    std::stringstream out;
+    size_t indent{0};
+  };
+
+  // Bumps `ctx.indent` by 2 on construction, restores on destruction.
+  class IndentGuard {
+   public:
+    explicit IndentGuard(Context& ctx) : ctx_(ctx) {
+      ctx_.indent += 2;
+    }
+    ~IndentGuard() {
+      ctx_.indent -= 2;
+    }
+    IndentGuard(const IndentGuard&) = delete;
+    IndentGuard& operator=(const IndentGuard&) = delete;
+
+   private:
+    Context& ctx_;
+  };
+
+  void visit(const Scan& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(
+        ctx, node, fmt::format("[{}]", node.baseTable()->schemaTable->name()));
+    const auto pad = spaces(ctx.indent + 2);
+    for (ExprCP filter : node.filters()) {
+      ctx.out << pad << "filter: " << formatExpr(filter) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Filter& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    for (ExprCP pred : node.predicates()) {
+      ctx.out << pad << "predicate: " << formatExpr(pred) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Project& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    const auto& cols = node.outputColumns();
+    const auto& exprs = node.exprs();
+    for (size_t i = 0; i < cols.size(); ++i) {
+      ctx.out << pad << cols[i]->toString() << " := " << formatExpr(exprs[i])
+              << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Limit& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[{}, {}]", node.offset(), node.count()));
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Sort& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TopN& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[{}, {}]", node.offset(), node.count()));
+    ctx.out << spaces(ctx.indent + 2)
+            << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Aggregate& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.groupingKeys().empty()) {
+      ctx.out << pad << "groupingKeys: " << formatExprs(node.groupingKeys())
+              << '\n';
+    }
+    if (!node.aggregates().empty()) {
+      ctx.out << pad << "aggregates: " << formatExprs(node.aggregates())
+              << '\n';
+    }
+    if (!node.globalGroupingSets().empty()) {
+      ctx.out << pad << "globalGroupingSets: "
+              << folly::join(", ", node.globalGroupingSets()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const GroupId& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "groupingKeys: " << formatExprs(node.groupingKeys())
+            << '\n';
+    if (!node.aggregationInputs().empty()) {
+      ctx.out << pad
+              << "aggregationInputs: " << formatExprs(node.aggregationInputs())
+              << '\n';
+    }
+    ctx.out << pad << "groupingSets: " << node.groupingSets().size()
+            << " set(s)\n";
+    visitInputs(node, ctx);
+  }
+
+  void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "distinctKeys: " << formatExprs(node.distinctKeys())
+            << '\n';
+    if (!node.masks().empty()) {
+      ctx.out << pad << "masks: " << formatExprs(node.masks()) << '\n';
+    }
+    ctx.out << pad << "markers: " << formatExprs(node.markers()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Values& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Unnest& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad
+            << "unnestExpressions: " << formatExprs(node.unnestExpressions())
+            << '\n';
+    if (node.withOrdinality()) {
+      ctx.out << pad << "withOrdinality: true\n";
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const UnionAll& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    const auto& legColumns = node.legColumns();
+    for (size_t i = 0; i < legColumns.size(); ++i) {
+      ctx.out << pad << "leg[" << i << "] columns: "
+              << formatExprs(
+                     ExprVector(legColumns[i].begin(), legColumns[i].end()))
+              << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Join& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    std::string details = std::string{"["} + std::string{node.joinTypeName()};
+    if (node.nullAware()) {
+      details += ", nullAware";
+    }
+    details += ']';
+    header(ctx, node, details);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.leftKeys().empty()) {
+      ctx.out << pad << "leftKeys: " << formatExprs(node.leftKeys()) << '\n';
+      ctx.out << pad << "rightKeys: " << formatExprs(node.rightKeys()) << '\n';
+    }
+    if (!node.filter().empty()) {
+      ctx.out << pad << "filter: " << formatExprs(node.filter()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Window& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.partitionKeys().empty()) {
+      ctx.out << pad << "partitionKeys: " << formatExprs(node.partitionKeys())
+              << '\n';
+    }
+    if (!node.orderKeys().empty()) {
+      ctx.out << pad << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node, fmt::format("[limit {}]", node.limit()));
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.partitionKeys().empty()) {
+      ctx.out << pad << "partitionKeys: " << formatExprs(node.partitionKeys())
+              << '\n';
+    }
+    ctx.out << pad << "orderKeys: " << formatExprs(node.orderKeys()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Apply& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    std::string details = std::string{"["} + std::string{node.kindName()};
+    if (node.enforceSingleRow()) {
+      details += ", enforceSingleRow";
+    }
+    if (node.nullAware()) {
+      details += ", nullAware";
+    }
+    details += ']';
+    header(ctx, node, details);
+    const auto pad = spaces(ctx.indent + 2);
+    if (!node.correlationColumns().empty()) {
+      ctx.out << pad
+              << "correlation: " << formatColumns(node.correlationColumns())
+              << '\n';
+    }
+    if (!node.filter().empty()) {
+      ctx.out << pad << "filter: " << formatExprs(node.filter()) << '\n';
+    }
+    if (node.markColumn() != nullptr) {
+      ctx.out << pad << "mark: " << node.markColumn()->toString() << '\n';
+    }
+    if (node.inLhs() != nullptr) {
+      ctx.out << pad << "inLhs: " << formatExpr(node.inLhs()) << '\n';
+      ctx.out << pad << "inBodyKey: " << formatExpr(node.inBodyKey()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    visitInputs(node, ctx);
+  }
+
+  void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "idColumn: " << node.idColumn()->toString() << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    const auto pad = spaces(ctx.indent + 2);
+    ctx.out << pad << "distinctKeys: " << formatExprs(node.distinctKeys())
+            << '\n';
+    if (node.errorMessage() != nullptr) {
+      ctx.out << pad << "errorMessage: " << node.errorMessage() << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
+  void visit(const Exchange& node, NodeVisitorContext& context) const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "partitionKeys: " << formatExprs(node.partitioning().keys)
+            << '\n';
+    visitInputs(node, ctx);
+  }
+
+  void visit(const TableWrite& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(ctx, node);
+    ctx.out << spaces(ctx.indent + 2)
+            << "columnExprs: " << formatExprs(node.columnExprs()) << '\n';
+    visitInputs(node, ctx);
+  }
+
+ private:
+  void header(Context& ctx, const Node& node, std::string_view extra = {})
+      const {
+    ctx.out << spaces(ctx.indent) << "- "
+            << NodeTypeName::toName(node.nodeType());
+    if (!extra.empty()) {
+      ctx.out << extra;
+    }
+    ctx.out << " -> " << formatColumns(node.outputColumns()) << '\n';
+  }
+
+  void visitInputs(const Node& node, Context& ctx) const {
+    IndentGuard guard(ctx);
+    NodeVisitor::visitInputs(node, ctx);
+  }
+};
+
+} // namespace
+
+std::string NodePrinter::toText(NodeCP root) {
+  Printer::Context ctx;
+  root->accept(Printer{}, ctx);
+  return ctx.out.str();
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodePrinter.h
+++ b/axiom/optimizer/v2/NodePrinter.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Renders an IR tree as indented text.
+class NodePrinter {
+ public:
+  /// Returns 'root' as indented text. Columns are shown by their `name()`
+  /// (the unique synthetic), not `outputName()`, so identity is visible.
+  static std::string toText(NodeCP root);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Empty context type for stateless rewriters.
+struct NoContext {};
+
+/// Visitor base for tree-IR rewrite passes. Default implementations
+/// recursively rewrite children and rebuild a node only when a child
+/// changed (identity-equal pointer comparison). Subclasses override the
+/// per-kind hooks they transform.
+///
+/// Stateless passes inherit `NodeRewriter<>`. State-bearing passes
+/// parameterize on a `TContext` that is threaded by reference through
+/// dispatch.
+template <typename TContext = NoContext>
+class NodeRewriter {
+ public:
+  explicit NodeRewriter(Builder& builder) : builder_(builder) {}
+  virtual ~NodeRewriter() = default;
+
+  /// Dispatches by `node->nodeType()` to the matching `rewriteX` hook.
+  NodeCP rewrite(NodeCP node, TContext& context) {
+    switch (node->nodeType()) {
+      case NodeType::kScan:
+        return rewriteScan(node->as<Scan>(), context);
+      case NodeType::kValues:
+        return rewriteValues(node->as<Values>(), context);
+      case NodeType::kFilter:
+        return rewriteFilter(node->as<Filter>(), context);
+      case NodeType::kProject:
+        return rewriteProject(node->as<Project>(), context);
+      case NodeType::kLimit:
+        return rewriteLimit(node->as<Limit>(), context);
+      case NodeType::kSort:
+        return rewriteSort(node->as<Sort>(), context);
+      case NodeType::kTopN:
+        return rewriteTopN(node->as<TopN>(), context);
+      case NodeType::kAggregate:
+        return rewriteAggregate(node->as<Aggregate>(), context);
+      case NodeType::kGroupId:
+        return rewriteGroupId(node->as<GroupId>(), context);
+      case NodeType::kMarkDistinct:
+        return rewriteMarkDistinct(node->as<MarkDistinct>(), context);
+      case NodeType::kUnnest:
+        return rewriteUnnest(node->as<Unnest>(), context);
+      case NodeType::kUnionAll:
+        return rewriteUnionAll(node->as<UnionAll>(), context);
+      case NodeType::kJoin:
+        return rewriteJoin(node->as<Join>(), context);
+      case NodeType::kWindow:
+        return rewriteWindow(node->as<Window>(), context);
+      case NodeType::kTopNRowNumber:
+        return rewriteTopNRowNumber(node->as<TopNRowNumber>(), context);
+      case NodeType::kApply:
+        return rewriteApply(node->as<Apply>(), context);
+      case NodeType::kEnforceSingleRow:
+        return rewriteEnforceSingleRow(node->as<EnforceSingleRow>(), context);
+      case NodeType::kAssignUniqueId:
+        return rewriteAssignUniqueId(node->as<AssignUniqueId>(), context);
+      case NodeType::kEnforceDistinct:
+        return rewriteEnforceDistinct(node->as<EnforceDistinct>(), context);
+      case NodeType::kExchange:
+        return rewriteExchange(node->as<Exchange>(), context);
+      case NodeType::kTableWrite:
+        return rewriteTableWrite(node->as<TableWrite>(), context);
+    }
+    VELOX_UNREACHABLE();
+  }
+
+  /// Convenience overload available when `TContext` is `NoContext`.
+  NodeCP rewrite(NodeCP node)
+    requires std::is_same_v<TContext, NoContext>
+  {
+    NoContext empty{};
+    return rewrite(node, empty);
+  }
+
+ protected:
+  virtual NodeCP rewriteScan(const Scan* node, TContext& /*context*/) {
+    return node;
+  }
+
+  virtual NodeCP rewriteValues(const Values* node, TContext& /*context*/) {
+    return node;
+  }
+
+  virtual NodeCP rewriteFilter(const Filter* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Filter>({newInput, node->predicates()});
+  }
+
+  virtual NodeCP rewriteProject(const Project* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Project>(
+        {newInput, node->exprs(), node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteLimit(const Limit* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Limit>(
+        {newInput, node->offset(), node->count()});
+  }
+
+  virtual NodeCP rewriteSort(const Sort* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Sort>(
+        {newInput, node->orderKeys(), node->orderTypes()});
+  }
+
+  virtual NodeCP rewriteTopN(const TopN* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<TopN>(
+        {newInput,
+         node->orderKeys(),
+         node->orderTypes(),
+         node->offset(),
+         node->count()});
+  }
+
+  virtual NodeCP rewriteAggregate(const Aggregate* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Aggregate>(Aggregate::Key{
+        .input = newInput,
+        .groupingKeys = node->groupingKeys(),
+        .aggregates = node->aggregates(),
+        .outputColumns = node->outputColumns(),
+        .step = node->step(),
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+  }
+
+  virtual NodeCP rewriteGroupId(const GroupId* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<GroupId>(
+        {newInput,
+         node->groupingKeys(),
+         node->aggregationInputs(),
+         node->groupingSets(),
+         node->groupingKeyColumns(),
+         node->groupId(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteMarkDistinct(
+      const MarkDistinct* node,
+      TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<MarkDistinct>(
+        {newInput,
+         node->markers(),
+         node->distinctKeys(),
+         node->masks(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteUnnest(const Unnest* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Unnest>(
+        {newInput,
+         node->unnestExpressions(),
+         node->replicatedColumns(),
+         node->unnestColumns(),
+         node->ordinalityColumn(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteUnionAll(const UnionAll* node, TContext& context) {
+    NodeVector newInputs;
+    newInputs.reserve(node->inputs().size());
+    bool changed = false;
+    for (NodeCP input : node->inputs()) {
+      NodeCP newInput = rewrite(input, context);
+      changed |= (newInput != input);
+      newInputs.push_back(newInput);
+    }
+    if (!changed) {
+      return node;
+    }
+    // legColumns are by Column*: valid as long as leg rewrites preserve
+    // identity of every referenced column. Rewrites that drop or replace a
+    // referenced column must remap legColumns explicitly; the UnionAll ctor
+    // enforces this.
+    return builder_.template make<UnionAll>(
+        {std::move(newInputs), node->legColumns(), node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteJoin(const Join* node, TContext& context) {
+    NodeCP newLeft = rewrite(node->left(), context);
+    NodeCP newRight = rewrite(node->right(), context);
+    if (newLeft == node->left() && newRight == node->right()) {
+      return node;
+    }
+    return builder_.template make<Join>(
+        {newLeft,
+         newRight,
+         node->joinType(),
+         node->leftKeys(),
+         node->rightKeys(),
+         node->filter(),
+         node->nullAware(),
+         node->nullAsValue(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteWindow(const Window* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Window>(
+        {newInput,
+         node->functions(),
+         node->partitionKeys(),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteTopNRowNumber(
+      const TopNRowNumber* node,
+      TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<TopNRowNumber>(
+        {newInput,
+         node->rankFunction(),
+         node->partitionKeys(),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->limit(),
+         node->rankColumn(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteApply(const Apply* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    NodeCP newBody = rewrite(node->body(), context);
+    if (newInput == node->input() && newBody == node->body()) {
+      return node;
+    }
+    return builder_.template make<Apply>(
+        {newInput,
+         newBody,
+         node->correlationColumns(),
+         node->kind(),
+         node->filter(),
+         node->enforceSingleRow(),
+         node->markColumn(),
+         node->inLhs(),
+         node->inBodyKey(),
+         node->includeMarker(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteEnforceSingleRow(
+      const EnforceSingleRow* node,
+      TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<EnforceSingleRow>({newInput});
+  }
+
+  virtual NodeCP rewriteAssignUniqueId(
+      const AssignUniqueId* node,
+      TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<AssignUniqueId>({newInput, node->idColumn()});
+  }
+
+  virtual NodeCP rewriteEnforceDistinct(
+      const EnforceDistinct* node,
+      TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<EnforceDistinct>(
+        {newInput, node->distinctKeys(), node->errorMessage()});
+  }
+
+  virtual NodeCP rewriteExchange(const Exchange* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<Exchange>({newInput, node->partitioning()});
+  }
+
+  virtual NodeCP rewriteTableWrite(const TableWrite* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<TableWrite>(
+        {newInput, node->table(), node->kind(), node->columnExprs()});
+  }
+
+  Builder& builder() {
+    return builder_;
+  }
+
+ private:
+  Builder& builder_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/NodeVisitor.h
+++ b/axiom/optimizer/v2/NodeVisitor.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+class NodeVisitorContext {
+ public:
+  virtual ~NodeVisitorContext() = default;
+};
+
+/// Double-dispatch visitor for v2 `Node` subclasses. Mirrors
+/// `logical_plan::PlanNodeVisitor`. Each subclass implements `accept` to
+/// forward to the matching `visit` overload.
+class NodeVisitor {
+ public:
+  virtual ~NodeVisitor() = default;
+
+  virtual void visit(const Scan& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Filter& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Project& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Limit& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Sort& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const TopN& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Aggregate& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const GroupId& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const MarkDistinct& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Values& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Unnest& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const UnionAll& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Join& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const Window& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const TopNRowNumber& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Apply& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const EnforceSingleRow& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const AssignUniqueId& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const EnforceDistinct& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const Exchange& node, NodeVisitorContext& context)
+      const = 0;
+  virtual void visit(const TableWrite& node, NodeVisitorContext& context)
+      const = 0;
+
+ protected:
+  void visitInputs(const Node& node, NodeVisitorContext& context) const {
+    for (NodeCP input : node.inputs()) {
+      input->accept(*this, context);
+    }
+  }
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/Optimize.h"
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/DecorrelatePass.h"
+#include "axiom/optimizer/v2/EmitPass.h"
+#include "axiom/optimizer/v2/EstimateLeafStatsPass.h"
+#include "axiom/optimizer/v2/ExpandAggregatePass.h"
+#include "axiom/optimizer/v2/LimitAndOrderPass.h"
+#include "axiom/optimizer/v2/PlanPhysicalPass.h"
+#include "axiom/optimizer/v2/PrecomputeProjectionsPass.h"
+#include "axiom/optimizer/v2/PushdownAndPrunePass.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
+#include "axiom/optimizer/v2/TranslatePass.h"
+#include "velox/core/PlanConsistencyChecker.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+PlanAndStats optimize(
+    const logical_plan::LogicalPlanNode& plan,
+    const connector::SchemaResolver& schemaResolver,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator,
+    const MultiFragmentPlan::Options& options) {
+  VELOX_USER_CHECK_GE(options.numWorkers, 1, "numWorkers must be at least 1");
+  VELOX_USER_CHECK_GE(options.numDrivers, 1, "numDrivers must be at least 1");
+
+  // Schema is owned here so its `connector::TablePtr`s — and the
+  // `TableLayout`s the IR's `BaseTable` nodes hold raw pointers to —
+  // stay alive through translate, precompute, and emit.
+  Schema schema(schemaResolver);
+
+  // Connector table handles are built once here and reused at emit.
+  ScanHandleCache scanHandles;
+
+  Builder builder;
+  auto translated = TranslatePass::run(plan, schema, evaluator, builder);
+  NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
+  NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
+  NodeCP pushed = PushdownAndPrunePass::run(limited, builder, evaluator);
+  if (session.options().useFilteredTableStats) {
+    EstimateLeafStatsPass::run(pushed, session, evaluator, scanHandles);
+  }
+  NodeCP physicalPlanned = PlanPhysicalPass::run(
+      pushed,
+      builder,
+      session.options(),
+      options.numWorkers,
+      options.numDrivers);
+  NodeCP precomputed = PrecomputeProjectionsPass::run(physicalPlanned, builder);
+  // Distinct aggregates lower to MarkDistinct here, after physical planning
+  // (grouping sets were already lowered to GroupId in translate).
+  NodeCP root = ExpandAggregatePass::run(precomputed, builder);
+
+  EmitPass::Result emitted = EmitPass::run(
+      root,
+      translated.outputColumns,
+      translated.outputNames,
+      session,
+      evaluator,
+      scanHandles,
+      options);
+
+  for (const auto& fragment : emitted.fragments) {
+    velox::core::PlanConsistencyChecker::check(fragment.fragment.planNode);
+  }
+
+  PlanAndStats result;
+  result.plan = std::make_shared<MultiFragmentPlan>(
+      std::move(emitted.fragments), options);
+  result.finishWrite = std::move(emitted.finishWrite);
+  return result;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/ToVelox.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// End-to-end optimizer entry point: lowers a logical plan to a distributed
+/// Velox execution plan (a `MultiFragmentPlan` of one or more fragments).
+///
+/// Stages over a tree IR:
+///   - Translate — build the tree IR from the logical plan;
+///   - Decorrelate — rewrite correlated subqueries as joins;
+///   - LimitAndOrder — fold limits into ordering operators;
+///   - PushdownAndPrune — push predicates down, prune unused columns;
+///   - EstimateLeafStats — populate base-table cardinalities from the
+///   connector;
+///   - PlanPhysical — cost-based join order and distribution;
+///   - PrecomputeProjections — lift compound expressions into `Project`s where
+///     Velox needs a column or literal;
+///   - ExpandAggregate — lower distinct aggregates to `MarkDistinct`;
+///   - Emit — lower to Velox `PlanNode`s.
+///
+/// `options.numWorkers` / `options.numDrivers` (each >= 1) are the target task
+/// and per-task driver counts; at `numWorkers > 1` the plan is distributed
+/// across fragments with remote exchanges.
+PlanAndStats optimize(
+    const logical_plan::LogicalPlanNode& plan,
+    const connector::SchemaResolver& schemaResolver,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator,
+    const MultiFragmentPlan::Options& options);
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalProperties.cpp
+++ b/axiom/optimizer/v2/PhysicalProperties.cpp
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+
+#include <folly/container/F14Map.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+const folly::F14FastMap<PropertyScope, std::string_view>& propertyScopeNames() {
+  static const folly::F14FastMap<PropertyScope, std::string_view> kNames = {
+      {PropertyScope::kGlobal, "Global"},
+      {PropertyScope::kDriver, "Driver"},
+  };
+  return kNames;
+}
+
+const folly::F14FastMap<PartitionKind, std::string_view>& partitionKindNames() {
+  static const folly::F14FastMap<PartitionKind, std::string_view> kNames = {
+      {PartitionKind::kUnspecified, "Unspecified"},
+      {PartitionKind::kPartitioned, "Partitioned"},
+      {PartitionKind::kGather, "Gather"},
+      {PartitionKind::kBroadcast, "Broadcast"},
+      {PartitionKind::kArbitrary, "Arbitrary"},
+  };
+  return kNames;
+}
+
+const folly::F14FastMap<LocalPropertyKind, std::string_view>&
+localPropertyKindNames() {
+  static const folly::F14FastMap<LocalPropertyKind, std::string_view> kNames = {
+      {LocalPropertyKind::kGrouped, "Grouped"},
+      {LocalPropertyKind::kSorted, "Sorted"},
+  };
+  return kNames;
+}
+
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(PropertyScope, propertyScopeNames);
+AXIOM_DEFINE_ENUM_NAME(PartitionKind, partitionKindNames);
+AXIOM_DEFINE_ENUM_NAME(LocalPropertyKind, localPropertyKindNames);
+
+Partitioning Partitioning::globalHash(
+    const ExprVector& keys,
+    bool replicateNullsAndAny) {
+  return Partitioning{
+      .kind = PartitionKind::kPartitioned,
+      .keys = keys,
+      .scope = PropertyScope::kGlobal,
+      .replicateNullsAndAny = replicateNullsAndAny};
+}
+
+Partitioning Partitioning::globalGather() {
+  return Partitioning{
+      .kind = PartitionKind::kGather, .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalGatherMerge(
+    const ExprVector& orderKeys,
+    const OrderTypeVector& orderTypes) {
+  return Partitioning{
+      .kind = PartitionKind::kGather,
+      .orderKeys = orderKeys,
+      .orderTypes = orderTypes,
+      .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalBroadcast() {
+  return Partitioning{
+      .kind = PartitionKind::kBroadcast, .scope = PropertyScope::kGlobal};
+}
+
+Partitioning Partitioning::globalArbitrary() {
+  return Partitioning{
+      .kind = PartitionKind::kArbitrary, .scope = PropertyScope::kGlobal};
+}
+
+bool Partitioning::coLocates(const ExprVector& columns) const {
+  if (kind != PartitionKind::kPartitioned || keys.empty()) {
+    return false;
+  }
+  const auto columnSet = PlanObjectSet::fromObjects(columns);
+  for (ExprCP key : keys) {
+    if (!columnSet.contains(key)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Partitioning::isBucketedOn(const ExprVector& otherKeys) const {
+  if (otherKeys.empty() || kind != PartitionKind::kPartitioned ||
+      partitionType == nullptr || keys.size() != otherKeys.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (!keys[i]->sameOrEqual(*otherKeys[i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool Partitioning::isBucketedCompatibleWith(
+    const ExprVector& otherKeys,
+    const connector::PartitionType& targetType) const {
+  if (!isBucketedOn(otherKeys)) {
+    return false;
+  }
+  const auto compatible = partitionType->copartition(targetType);
+  return compatible != nullptr &&
+      compatible->numPartitions() == partitionType->numPartitions();
+}
+
+bool Partitioning::sameClassAs(const Partitioning& other) const {
+  if (kind != other.kind || partitionType != other.partitionType ||
+      replicateNullsAndAny != other.replicateNullsAndAny ||
+      keys.size() != other.keys.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < keys.size(); ++i) {
+    if (keys[i] != other.keys[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void PhysicalProperties::checkReferencesColumns(
+    const PlanObjectSet& outputColumns) const {
+  // A partitioning may be on computed expressions (the partition function's
+  // input, e.g. a cast); the requirement is that it is evaluable here — every
+  // column its keys and merge order depend on is an output column.
+  const auto checkPartition = [&](const Partitioning& partition) {
+    VELOX_CHECK(
+        outputColumns.containsColumns(partition.keys) &&
+            outputColumns.containsColumns(partition.orderKeys),
+        "Partitioning depends on a column that is not in the node's output");
+  };
+  checkPartition(globalPartition);
+  checkPartition(driverPartition);
+  // Local orderings / groupings and unique key-sets are columns, not
+  // expressions.
+  for (const LocalProperty& property : local) {
+    VELOX_CHECK(
+        outputColumns.containsAll(property.columns),
+        "Local property references a column that is not in the node's output");
+  }
+  for (const UniqueKeySet& keySet : unique) {
+    VELOX_CHECK(
+        keySet.columns.isSubset(outputColumns),
+        "Unique key-set references a column that is not in the node's output");
+  }
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PhysicalProperties.h
+++ b/axiom/optimizer/v2/PhysicalProperties.h
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+#include "axiom/common/Enums.h"
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+
+/// Physical-property types for the optimizer: the per-operator output ordering,
+/// grouping, uniqueness, and partitioning that cost-based planning derives on
+/// each physical candidate and the property-aware memo keys on. This header
+/// declares the data shapes only; per-operator derivation and the satisfaction
+/// / shuffle-cost queries live alongside the memo that consumes them.
+///
+/// The model splits properties by how they behave under distribution. Three
+/// categories:
+///   - per-driver local: ordering and grouping (`LocalProperty`),
+///   - distribution: two independent partitioning slots, global and driver
+///     (`Partitioning` with a `PropertyScope`),
+///   - relation-level: uniqueness (`UniqueKeySet`).
+namespace facebook::axiom::optimizer::v2 {
+
+/// Scope at which a property holds. The two runtime levels distributed
+/// execution distinguishes: across tasks (`kGlobal`) and across drivers within
+/// one task (`kDriver`).
+///
+/// The scope's algebra differs by property:
+///   - Partitioning carries two *independent* slots, one per scope — global
+///     partitioned does not imply driver partitioned (a remote hash exchange
+///     feeds drivers round-robin), so both are tracked.
+///   - Uniqueness is a *lattice*: global uniqueness implies driver (per-driver)
+///     uniqueness but not the reverse, so a key-set stores the single widest
+///     scope at which it holds.
+enum class PropertyScope : uint8_t {
+  kGlobal,
+  kDriver,
+};
+
+AXIOM_DECLARE_ENUM_NAME(PropertyScope);
+
+/// Kind of data partitioning.
+enum class PartitionKind : uint8_t {
+  /// No specific partitioning is guaranteed.
+  kUnspecified,
+  /// Partitioned on `keys` using `partitionType` (connector-specific) or
+  /// standard Velox hash when `partitionType` is null.
+  kPartitioned,
+  /// All rows on one partition (single task, or single driver at driver scope).
+  kGather,
+  /// Every consumer receives a full copy.
+  kBroadcast,
+  /// Arbitrary / round-robin assignment.
+  kArbitrary,
+};
+
+AXIOM_DECLARE_ENUM_NAME(PartitionKind);
+
+/// Partitioning of a relation's rows at one scope. The same concept serves both
+/// the global (across-tasks) and driver (across-drivers) levels; `scope` says
+/// which. A `PhysicalProperties` carries one `Partitioning` per scope, and the
+/// two are independent.
+///
+/// Invariants:
+///   - `keys` is non-empty only when `kind == kPartitioned`.
+///   - `orderKeys` / `orderTypes` are non-empty only for an order-preserving
+///     `kGather` (see `globalGatherMerge`).
+///   - `partitionType` is null for standard Velox hash partitioning.
+///   - `keys` are expressions (not just columns) to match the partition
+///     function's input.
+struct Partitioning {
+  PartitionKind kind{PartitionKind::kUnspecified};
+
+  /// Connector-specific partition function, or null for standard Velox hash.
+  const connector::PartitionType* partitionType{nullptr};
+
+  /// Partition keys; empty unless `kind == kPartitioned`.
+  ExprVector keys;
+
+  /// Sort keys and their orders that an order-preserving gather merges on
+  /// (lowered to a Velox `MergeExchange`). Non-empty only for a `kGather`
+  /// produced by `globalGatherMerge`; empty for a plain gather.
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+
+  PropertyScope scope{PropertyScope::kGlobal};
+
+  /// When true, the partitioned output replicates null-keyed rows (and one
+  /// arbitrary row) to every partition. Required on the existence side of a
+  /// null-aware anti/semi join (NOT IN / IN) so a null key reaches all probe
+  /// partitions; otherwise NOT IN wrongly admits rows.
+  bool replicateNullsAndAny{false};
+
+  bool operator==(const Partitioning&) const = default;
+
+  bool is(PartitionKind other) const {
+    return kind == other;
+  }
+
+  /// A copy without the merge order (`orderKeys` / `orderTypes`). The merge
+  /// order belongs to the gather-merge exchange that produced it; an operator
+  /// that inherits a distribution without being that exchange keeps the kind
+  /// and keys but not the order (which, if preserved, is carried as a local
+  /// property).
+  Partitioning dropOrder() const {
+    Partitioning result = *this;
+    result.orderKeys = {};
+    result.orderTypes = {};
+    return result;
+  }
+
+  /// A standard global hash partitioning on `keys`. Set `replicateNullsAndAny`
+  /// for the existence side of a null-aware anti/semi join.
+  static Partitioning globalHash(
+      const ExprVector& keys,
+      bool replicateNullsAndAny = false);
+
+  /// A global gather (all rows on one task) partitioning.
+  static Partitioning globalGather();
+
+  /// A global gather that preserves ordering by merging the sorted per-task
+  /// streams (lowered to a Velox `MergeExchange`). `orderKeys` / `orderTypes`
+  /// are the sort keys to merge on.
+  static Partitioning globalGatherMerge(
+      const ExprVector& orderKeys,
+      const OrderTypeVector& orderTypes);
+
+  /// A global broadcast (every task receives a full copy) partitioning.
+  static Partitioning globalBroadcast();
+
+  /// A global arbitrary (round-robin / shared-pool) partitioning.
+  static Partitioning globalArbitrary();
+
+  /// True when this co-locates rows that agree on `columns` — i.e. it
+  /// hash-partitions on a subset of `columns`, so every group of equal
+  /// `columns` is wholly within one partition and an aggregation grouping on
+  /// `columns` needs no repartition. Not a co-partition test for joins: those
+  /// must align corresponding keys across both inputs, so use `sameClassAs`.
+  bool coLocates(const ExprVector& columns) const;
+
+  /// True when this is the same class as `other` — same kind, connector
+  /// function, and keys in order. Like `coLocates`, a pure class test: scope is
+  /// fixed by the containing slot, so it is not compared. Two `kUnspecified`
+  /// partitionings are the same class.
+  bool sameClassAs(const Partitioning& other) const;
+
+  /// True when this is connector-bucketed (`kPartitioned` with a non-null
+  /// `partitionType`) on exactly `otherKeys` — same expressions in the same
+  /// order. False for empty `otherKeys`.
+  bool isBucketedOn(const ExprVector& otherKeys) const;
+
+  /// True when this is bucketed on `otherKeys` (see `isBucketedOn`) with a
+  /// partitioning that copartitions with `targetType` at this bucketing's own
+  /// partition count — i.e. its rows already reach a `targetType`-bucketed
+  /// consumer or write target with no reshuffle.
+  bool isBucketedCompatibleWith(
+      const ExprVector& otherKeys,
+      const connector::PartitionType& targetType) const;
+};
+
+/// Kind of a per-driver local property.
+enum class LocalPropertyKind : uint8_t {
+  /// Rows with equal `columns` are contiguous (not necessarily ordered) within
+  /// a driver, and every such group is wholly within one driver. See
+  /// `LocalProperty` for the confinement contract.
+  kGrouped,
+  /// Rows ordered by `columns`, outermost key first, with the direction of each
+  /// given by the matching entry in `orders`.
+  kSorted,
+};
+
+AXIOM_DECLARE_ENUM_NAME(LocalPropertyKind);
+
+/// One entry in a relation's ordered list of per-driver local properties. The
+/// list order captures nesting: `[Grouped(P), Sorted(o1, o2)]` means grouped by
+/// the set `P`, and within each group ordered by `o1` then `o2`.
+///
+/// A `kGrouped` entry uses `columns` alone (the grouped set; order among its
+/// members is irrelevant) and leaves `orders` empty. A `kSorted` entry uses
+/// both in parallel: `columns` are the sort keys outermost first, and
+/// `orders[i]` is the direction of `columns[i]`.
+///
+/// A local property carries driver-confinement as part of its contract, not
+/// just contiguity: a `kGrouped` set of equal `columns` (or a `kSorted`
+/// equal-key run) is both contiguous within a driver's stream AND wholly
+/// confined to that one driver — no group spans drivers. Producers must attach
+/// a local property only when both hold; a source with mere per-driver
+/// contiguity but no confinement (e.g. a bucketed/sorted scan whose splits
+/// round-robin across drivers) must not. Consumers that decide driver placement
+/// (e.g. skipping a local repartition before a single-stage aggregation) rely
+/// on this directly: a local grouping on the keys means the groups are already
+/// driver-confined.
+struct LocalProperty {
+  LocalPropertyKind kind{LocalPropertyKind::kGrouped};
+  ColumnVector columns;
+  OrderTypeVector orders;
+};
+
+/// A relation's per-driver local properties, outermost first.
+using LocalPropertyVector = QGVector<LocalProperty>;
+
+/// A set of columns that is unique across the relation — i.e., functionally
+/// determines the row — at `scope`. Stored minimal: a key-set whose columns are
+/// a superset of another stored key-set is redundant and not kept, but
+/// independent minimal key-sets (e.g. `{a}` and `{b}` both unique) are all
+/// retained. `columns` is a set (a `PlanObjectSet`) so consumers can test
+/// containment ("is some unique key-set ⊆ the columns I care about?") directly.
+struct UniqueKeySet {
+  PlanObjectSet columns;
+  PropertyScope scope{PropertyScope::kGlobal};
+};
+
+/// Unique key-sets of a relation. May hold several independent minimal
+/// key-sets, each at its own scope.
+using UniqueKeySetVector = QGVector<UniqueKeySet>;
+
+/// The physical properties of one relation — the output of per-operator
+/// derivation and the value the property-aware memo compares. Bundles the three
+/// property categories.
+///
+/// The two partitioning slots are independent (see `PropertyScope`):
+/// `globalPartition.scope == kGlobal` and `driverPartition.scope == kDriver`.
+struct PhysicalProperties {
+  /// Partitioning across tasks; set by a remote exchange.
+  Partitioning globalPartition{.scope = PropertyScope::kGlobal};
+
+  /// Partitioning across drivers within a task; set by a local exchange.
+  Partitioning driverPartition{.scope = PropertyScope::kDriver};
+
+  /// Per-driver ordering and grouping, outermost first.
+  LocalPropertyVector local;
+
+  /// Unique key-sets, relation-level, each scope-tagged.
+  UniqueKeySetVector unique;
+
+  /// Checks the invariant that these properties are expressed over the node's
+  /// own `outputColumns`. A partitioning's keys and merge order may be computed
+  /// expressions (the partition function's input), but every column they depend
+  /// on must be an output column, so the partitioning is evaluable here.
+  /// Local-property columns and every unique key-set must themselves be output
+  /// columns. Fails (`VELOX_CHECK`) on violation. Called by the `Node` base
+  /// constructor.
+  void checkReferencesColumns(const PlanObjectSet& outputColumns) const;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -1,0 +1,820 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PlanPhysicalPass.h"
+
+#include <cstdint>
+#include <numeric>
+#include <vector>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/v2/CostModel.h"
+#include "axiom/optimizer/v2/DPhyp.h"
+#include "axiom/optimizer/v2/EstimateProvider.h"
+#include "axiom/optimizer/v2/HypergraphBuilder.h"
+#include "axiom/optimizer/v2/JoinCluster.h"
+#include "axiom/optimizer/v2/JoinTreeEmitter.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// True if every expression in 'keys' references at least one column.
+bool allKeysReferenceColumns(const ExprVector& keys) {
+  for (ExprCP key : keys) {
+    if (key->columns().empty()) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Reorder limit: inner / LEFT / RIGHT / FULL equi-joins,
+// plus filtering semijoin (kLeftSemiFilter), antijoin (kAnti), and
+// mark-preserving semijoin (kLeftSemiProject).
+bool isClusterable(const Join* join) {
+  using velox::core::JoinType;
+  if (join->leftKeys().empty()) {
+    return false;
+  }
+  // A hyperedge needs a non-empty relation set on both sides: the edge's
+  // left/right relation sets are the cluster leaves referenced by the
+  // left/right keys (HypergraphBuilder::unionExpressionRelations). A
+  // degenerate equi-key that references no column (e.g. the `1 = 1` a
+  // `1 IN (SELECT 1)` decorrelates to) would yield an empty side and trip
+  // the JoinEdge invariant, so such a join stays an opaque cluster leaf.
+  if (!allKeysReferenceColumns(join->leftKeys()) ||
+      !allKeysReferenceColumns(join->rightKeys())) {
+    return false;
+  }
+  const auto kind = join->joinType();
+  return kind == JoinType::kInner || kind == JoinType::kLeft ||
+      kind == JoinType::kRight || kind == JoinType::kFull ||
+      kind == JoinType::kLeftSemiFilter || kind == JoinType::kAnti ||
+      kind == JoinType::kLeftSemiProject;
+}
+
+void collectCluster(
+    NodeCP node,
+    JoinCluster& cluster,
+    bool dissolveCrossJoins) {
+  if (node->is(NodeType::kJoin)) {
+    const auto* join = node->as<Join>();
+    if (isClusterable(join)) {
+      cluster.joins.push_back(join);
+      collectCluster(join->left(), cluster, dissolveCrossJoins);
+      collectCluster(join->right(), cluster, dissolveCrossJoins);
+      return;
+    }
+    // A bare keyless inner join (no keys, no filter) is a comma-join cross
+    // product. Descend through it so its children join the cluster as
+    // separate relations, letting an equi-predicate elsewhere reconnect
+    // them (a spurious cross product that the join graph can avoid). A
+    // keyless join that carries a filter is a theta or decorrelated-subquery
+    // join; leave it an opaque leaf so its semantics are preserved.
+    if (dissolveCrossJoins && join->isInner() && join->leftKeys().empty() &&
+        join->filter().empty()) {
+      collectCluster(join->left(), cluster, dissolveCrossJoins);
+      collectCluster(join->right(), cluster, dissolveCrossJoins);
+      return;
+    }
+  }
+  if (node->is(NodeType::kUnnest)) {
+    const auto* unnest = node->as<Unnest>();
+    cluster.unnests.push_back(unnest);
+    collectCluster(unnest->input(), cluster, dissolveCrossJoins);
+    return;
+  }
+  cluster.leaves.push_back(node);
+}
+
+// True if some relation appears in an edge's TES but in no edge's left/right
+// endpoints. Such a relation is connected only by correlation (e.g. an outer
+// table referenced inside a decorrelated subquery), so DPhyp — which grows
+// subgraphs along edge endpoints — cannot assemble it. Dissolving a cross
+// join that strands such a relation produces an unplannable graph.
+bool hasEndpointStrandedRelation(const JoinHypergraph& graph) {
+  RelationSet endpoints;
+  RelationSet tesUnion;
+  for (size_t i = 0; i < graph.edges().size(); ++i) {
+    endpoints.unionSet(graph.edges()[i].left());
+    endpoints.unionSet(graph.edges()[i].right());
+    tesUnion.unionSet(graph.tes()[i]);
+  }
+  tesUnion.except(endpoints);
+  return !tesUnion.empty();
+}
+
+class PhysicalPlanRewriter : public NodeRewriter<> {
+ public:
+  PhysicalPlanRewriter(
+      Builder& builder,
+      const OptimizerOptions& options,
+      int32_t numWorkers,
+      int32_t numDrivers)
+      : NodeRewriter(builder),
+        options_{options},
+        numWorkers_{numWorkers},
+        numDrivers_{numDrivers} {}
+
+ protected:
+  // Rebuilds a join that DPhyp does not plan (non-clusterable cross / theta /
+  // decorrelated-subquery joins, and the syntactic-order / uncostable
+  // fallbacks) with its children rewritten, giving it a valid distributed input
+  // combination at numWorkers>1:
+  //   - keyed: co-partition both sides on the join keys (semi/anti
+  //   correctness),
+  //   - keyless with a broadcastable build: broadcast the build (cross /
+  //   theta),
+  //   - keyless, build not broadcastable (right / full): gather both sides.
+  NodeCP rewriteUnclusteredJoin(const Join* node, NoContext& context) {
+    NodeCP newLeft = rewrite(node->left(), context);
+    NodeCP newRight = rewrite(node->right(), context);
+    if (numWorkers_ > 1) {
+      if (!node->leftKeys().empty()) {
+        // A null-aware anti/semi join (NOT IN / IN) needs the existence side's
+        // null keys on every probe partition. canBroadcastBuild is true exactly
+        // when the right side is the non-preserved (existence) side.
+        const bool nullAware = node->nullAware();
+        const bool rightIsBuild = canBroadcastBuild(node->joinType());
+        // A bucketed side co-locates the join with no full shuffle. Not for
+        // null-aware anti/semi: a bucketed existence side confines a null key
+        // to one bucket, so it must shuffle-replicate.
+        if (nullAware ||
+            !coBucketJoinSides(
+                newLeft, newRight, node->leftKeys(), node->rightKeys())) {
+          newLeft =
+              partition(newLeft, node->leftKeys(), nullAware && !rightIsBuild);
+          newRight =
+              partition(newRight, node->rightKeys(), nullAware && rightIsBuild);
+        }
+      } else if (canBroadcastBuild(node->joinType())) {
+        newRight = broadcast(newRight);
+      } else {
+        newLeft = ensureGathered(newLeft);
+        newRight = ensureGathered(newRight);
+      }
+    }
+    if (newLeft == node->left() && newRight == node->right()) {
+      return node;
+    }
+    return builder().make<Join>(Join::Key{
+        .left = newLeft,
+        .right = newRight,
+        .joinType = node->joinType(),
+        .leftKeys = node->leftKeys(),
+        .rightKeys = node->rightKeys(),
+        .filter = node->filter(),
+        .nullAware = node->nullAware(),
+        .nullAsValue = node->nullAsValue(),
+        .outputColumns = node->outputColumns()});
+  }
+
+  NodeCP rewriteJoin(const Join* node, NoContext& context) override {
+    // Syntactic mode keeps every join in query order: rebuild the subtree
+    // as written, with no clustering or cost-based reordering.
+    if (options_.syntacticJoinOrder || !isClusterable(node)) {
+      return rewriteUnclusteredJoin(node, context);
+    }
+
+    JoinCluster cluster;
+    cluster.root = node;
+    collectCluster(node, cluster, /*dissolveCrossJoins=*/true);
+    if (cluster.joins.empty()) {
+      return rewriteUnclusteredJoin(node, context);
+    }
+
+    std::vector<NodeCP> rewrittenLeaves;
+    auto buildGraph = [&]() {
+      rewrittenLeaves.clear();
+      rewrittenLeaves.reserve(cluster.leaves.size());
+      for (NodeCP leaf : cluster.leaves) {
+        rewrittenLeaves.push_back(rewrite(leaf, context));
+      }
+      return HypergraphBuilder::build(
+          cluster, rewrittenLeaves, estimateProvider_);
+    };
+
+    JoinHypergraph graph = buildGraph();
+
+    // Dissolving a cross join can strand a correlation-only relation (in an
+    // edge's TES but no edge's endpoints), which DPhyp cannot assemble. Redo
+    // without dissolving so that relation stays bundled with its cross-join
+    // partner. Clusters that benefit from dissolution have no stranded
+    // relation and keep the dissolved form.
+    if (hasEndpointStrandedRelation(graph)) {
+      cluster = JoinCluster{};
+      cluster.root = node;
+      collectCluster(node, cluster, /*dissolveCrossJoins=*/false);
+      graph = buildGraph();
+    }
+
+    // Partition the cluster's relations into components, each closed under
+    // every edge's TES: DPhyp can only assemble a relation set once all
+    // relations in a crossing edge's TES are present, so two relations tied
+    // by any edge's TES must land in one component. A dissolved keyless
+    // cross join with no predicate connecting its sides yields separate
+    // components, combined later with cross products. Union-find over TES.
+    const size_t numRelations = graph.relations().size();
+    std::vector<int32_t> parent(numRelations);
+    std::iota(parent.begin(), parent.end(), 0);
+    auto find = [&](int32_t id) {
+      while (parent[id] != id) {
+        parent[id] = parent[parent[id]];
+        id = parent[id];
+      }
+      return id;
+    };
+    for (const RelationSet& tes : graph.tes()) {
+      int32_t representative = -1;
+      tes.forEach([&](int32_t id) {
+        if (representative < 0) {
+          representative = id;
+        } else {
+          parent[find(id)] = find(representative);
+        }
+      });
+    }
+    std::vector<RelationSet> components;
+    std::vector<int32_t> rootToComponent(numRelations, -1);
+    for (const auto& relation : graph.relations()) {
+      const int32_t root = find(relation.id());
+      if (rootToComponent[root] < 0) {
+        rootToComponent[root] = static_cast<int32_t>(components.size());
+        components.emplace_back();
+      }
+      components[rootToComponent[root]].add(relation.id());
+    }
+
+    graph.setTargetColumns(PlanObjectSet::fromObjects(node->outputColumns()));
+
+    DefaultCostModel costModel{estimateProvider_};
+    DPhyp dphyp{
+        graph,
+        costModel,
+        options_.dphypEnumerationBudget,
+        numWorkers_,
+        options_.broadcastSizeLimit};
+    if (components.size() == 1) {
+      MemoOpCP root = dphyp.enumerate();
+      // No costable plan (a relation or join key lacked stats): keep the
+      // cluster in query order.
+      if (root == nullptr) {
+        return rewriteUnclusteredJoin(node, context);
+      }
+      return JoinTreeEmitter::emit(
+          root, graph, node->outputColumns(), builder());
+    }
+    const std::vector<MemoOpCP> roots = dphyp.enumerate(components);
+    if (roots.empty()) {
+      return rewriteUnclusteredJoin(node, context);
+    }
+    return JoinTreeEmitter::emitComponents(
+        roots, graph, node->outputColumns(), builder(), numWorkers_);
+  }
+
+  // Remote exchanges that unconditionally establish a partitioning on 'input'.
+  NodeCP gather(NodeCP input) {
+    return builder().make<Exchange>({input, Partitioning::globalGather()});
+  }
+
+  // An order-preserving gather: merges the sorted per-task streams (the input
+  // must already be sorted on 'orderKeys') onto one task, lowering to a Velox
+  // MergeExchange.
+  NodeCP gatherMerge(
+      NodeCP input,
+      const ExprVector& orderKeys,
+      const OrderTypeVector& orderTypes) {
+    return builder().make<Exchange>(
+        {input, Partitioning::globalGatherMerge(orderKeys, orderTypes)});
+  }
+
+  NodeCP partition(
+      NodeCP input,
+      const ExprVector& keys,
+      bool replicateNullsAndAny = false) {
+    return builder().make<Exchange>(
+        {input, Partitioning::globalHash(keys, replicateNullsAndAny)});
+  }
+
+  NodeCP broadcast(NodeCP input) {
+    return builder().make<Exchange>({input, Partitioning::globalBroadcast()});
+  }
+
+  // Repartitions 'input' on 'keys' using 'targetType' (a connector
+  // partitioning), so it co-locates with a side already bucketed that way.
+  NodeCP partitionTo(
+      NodeCP input,
+      const ExprVector& keys,
+      const connector::PartitionType* targetType) {
+    Partitioning partitioning = Partitioning::globalHash(keys);
+    partitioning.partitionType = targetType;
+    return builder().make<Exchange>({input, std::move(partitioning)});
+  }
+
+  // Co-locates a keyed join without shuffling the bucketed side(s): keeps both
+  // when both are already bucketed on the keys and copartitionable, else aligns
+  // the unbucketed side to the bucketed one's connector partitioning. Returns
+  // true and updates 'left'/'right' when co-location applies; false when
+  // neither side is bucketed, or both are bucketed but not copartitionable — in
+  // either case the caller falls back to the standard shuffle.
+  bool coBucketJoinSides(
+      NodeCP& left,
+      NodeCP& right,
+      const ExprVector& leftKeys,
+      const ExprVector& rightKeys) {
+    const auto& leftPart = left->physicalProperties().globalPartition;
+    const auto& rightPart = right->physicalProperties().globalPartition;
+    const bool leftBucketed = leftPart.isBucketedOn(leftKeys);
+    const bool rightBucketed = rightPart.isBucketedOn(rightKeys);
+    if (leftBucketed && rightBucketed) {
+      return leftPart.partitionType->copartition(*rightPart.partitionType) !=
+          nullptr;
+    }
+    if (leftBucketed) {
+      right = partitionTo(right, rightKeys, leftPart.partitionType);
+      return true;
+    }
+    if (rightBucketed) {
+      left = partitionTo(left, leftKeys, rightPart.partitionType);
+      return true;
+    }
+    return false;
+  }
+
+  NodeCP arbitrary(NodeCP input) {
+    return builder().make<Exchange>({input, Partitioning::globalArbitrary()});
+  }
+
+  // True when 'input' already produces all rows on one task.
+  static bool isGathered(NodeCP input) {
+    return input->physicalProperties().globalPartition.is(
+        PartitionKind::kGather);
+  }
+
+  // True when every expression in 'sub' is also in 'super'.
+  static bool isSubset(const ExprVector& sub, const ExprVector& super) {
+    const auto superSet = PlanObjectSet::fromObjects(super);
+    for (ExprCP expr : sub) {
+      if (!superSet.contains(expr)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Ensures all rows reach one task: reuse when 'input' is already gathered,
+  // else a remote gather exchange. A no-op at a single worker, where one task
+  // already holds all rows.
+  NodeCP ensureGathered(NodeCP input) {
+    if (numWorkers_ == 1 || isGathered(input)) {
+      return input;
+    }
+    return gather(input);
+  }
+
+  // Ensures every group of equal 'keys' is co-located on one task so a grouping
+  // / partition / per-key-assertion consumer can run per group on one task:
+  // reuse when 'input' is already gathered (one task co-locates any keys) or
+  // already co-located on 'keys', else a remote hash exchange. Empty 'keys' is
+  // one global group, satisfied by a gather. A no-op at a single worker.
+  NodeCP ensureCoLocated(NodeCP input, const ExprVector& keys) {
+    if (numWorkers_ == 1 || isGathered(input)) {
+      return input;
+    }
+
+    if (keys.empty()) {
+      return gather(input);
+    }
+
+    if (input->physicalProperties().globalPartition.coLocates(keys)) {
+      return input;
+    }
+
+    return partition(input, keys);
+  }
+
+  NodeCP rewriteAggregate(const Aggregate* node, NoContext& context) override {
+    NodeCP input = rewrite(node->input(), context);
+    if (isSplittableAggregate(node)) {
+      // Remote two-stage: the input must shuffle across workers to co-locate
+      // its groups, so the partial reduces rows before that remote exchange.
+      if (numWorkers_ > 1 && needsShuffle(input, node->groupingKeys())) {
+        return rewriteAggregateSplit(node, input, /*remoteExchange=*/true);
+      }
+      // Local two-stage: the input is already co-located (e.g. a bucketed
+      // scan's grouped fragment), but at numDrivers > 1 a local exchange still
+      // brings each group to one driver, so the partial reduces rows before it.
+      // At numDrivers == 1 there is no exchange, so a single stage is optimal.
+      // The local exchange itself is not materialized here — emit inserts it at
+      // numDrivers > 1 (local exchanges are implicit).
+      if (numDrivers_ > 1) {
+        return rewriteAggregateSplit(node, input, /*remoteExchange=*/false);
+      }
+    }
+    return rewriteAggregateCoLocated(node, input, /*requiredCoLocation=*/{});
+  }
+
+  // True when 'node' can two-stage into partial + final, independent of whether
+  // the exchange between them is remote (numWorkers > 1) or local (numDrivers >
+  // 1) — the caller gates on that. Excluded: a DISTINCT aggregate (a per-task
+  // partial under-dedups and the final would over-count); and an ordered
+  // aggregate (the partial sees only a task-local order). GROUPING SETS
+  // aggregates split like any other — by this point they are already GroupId +
+  // a plain aggregate keyed on the group-id column.
+  bool isSplittableAggregate(const Aggregate* node) const {
+    for (const auto* aggregate : node->aggregates()) {
+      if (aggregate->isDistinct() || !aggregate->orderKeys().empty()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // True when co-locating 'input's groups on 'keys' requires a shuffle — i.e.
+  // when the single-stage path's `ensureCoLocated` would add one. Mirrors its
+  // conditions: a gathered input already co-locates any keys; a global
+  // aggregate (no keys) needs a gather unless already gathered; otherwise a
+  // shuffle is needed unless the input is already partitioned on the keys.
+  bool needsShuffle(NodeCP input, const ExprVector& keys) const {
+    if (isGathered(input)) {
+      return false;
+    }
+    if (keys.empty()) {
+      return true;
+    }
+    return !input->physicalProperties().globalPartition.coLocates(keys);
+  }
+
+  // Lowers an aggregate to partial → exchange → final so the remote shuffle
+  // carries the per-task partials (one row per group per task) rather than the
+  // whole input. The partial pre-aggregates per task and emits the grouping
+  // keys followed by one intermediate accumulator per aggregate; the exchange
+  // partitions those partials on the grouping keys (gather when there are none
+  // — the global case); the final combines them into the result.
+  //
+  // Every eligible aggregate two-stages, reducing or not. A non-reducing
+  // aggregate (e.g. array_agg) gains nothing and pays an extra hash pass; not
+  // splitting it needs a reducing/non-reducing classification that does not yet
+  // exist, so that pessimization is deferred.
+  NodeCP rewriteAggregateSplit(
+      const Aggregate* node,
+      NodeCP input,
+      bool remoteExchange) {
+    const size_t numKeys = node->groupingKeys().size();
+    const auto& finalColumns = node->outputColumns();
+
+    // The partial's output reuses the grouping-key columns and adds a fresh
+    // intermediate-typed accumulator column per aggregate, positionally aligned
+    // (keys first, then one accumulator per aggregate in aggregate order) so
+    // the final reads input column 'numKeys + i' as the i-th accumulator.
+    ColumnVector partialColumns;
+    partialColumns.reserve(finalColumns.size());
+    partialColumns.insert(
+        partialColumns.end(),
+        finalColumns.begin(),
+        finalColumns.begin() + numKeys);
+    for (size_t i = 0; i < node->aggregates().size(); ++i) {
+      ColumnCP finalColumn = finalColumns[numKeys + i];
+      partialColumns.push_back(
+          Column::create(
+              finalColumn->outputName(),
+              Value{
+                  node->aggregates()[i]->intermediateType(),
+                  finalColumn->value().cardinality}));
+    }
+
+    NodeCP partial = builder().make<Aggregate>(Aggregate::Key{
+        .input = input,
+        .groupingKeys = node->groupingKeys(),
+        .aggregates = node->aggregates(),
+        .outputColumns = std::move(partialColumns),
+        .step = AggregateStep::kPartial,
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+
+    // The final groups the exchanged partials by their output grouping-key
+    // columns (the partial already evaluated any compound grouping
+    // expression), so its keys are those plain columns, not the original
+    // expressions.
+    ExprVector finalKeys;
+    finalKeys.reserve(numKeys);
+    for (size_t i = 0; i < numKeys; ++i) {
+      finalKeys.push_back(finalColumns[i]);
+    }
+
+    // Without a remote exchange the partial and final share one fragment; the
+    // final's local repartition (added at emit for numDrivers > 1) co-locates
+    // each group's partials on one driver.
+    NodeCP finalInput = !remoteExchange ? partial
+        : finalKeys.empty()             ? gather(partial)
+                                        : partition(partial, finalKeys);
+
+    return builder().make<Aggregate>(Aggregate::Key{
+        .input = finalInput,
+        .groupingKeys = finalKeys,
+        .aggregates = node->aggregates(),
+        .outputColumns = finalColumns,
+        .step = AggregateStep::kFinal,
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+  }
+
+  // Rewrites an aggregate, co-locating its input on 'requiredCoLocation' when
+  // that is a non-empty subset of the grouping keys: such a subset still lands
+  // every group on one task, and choosing it lets a consumer that needs the
+  // coarser partition reuse it without a reshuffle. Otherwise co-locates on the
+  // grouping keys (empty for a global aggregate, which gathers).
+  NodeCP rewriteAggregateCoLocated(
+      const Aggregate* node,
+      NodeCP newInput,
+      const ExprVector& requiredCoLocation) {
+    ExprVector keys;
+    // A global () grouping set emits a default row over empty input; a
+    // single-stage aggregate must gather (empty keys) so that row is produced
+    // once, not once per worker.
+    if (node->globalGroupingSets().empty()) {
+      keys = !requiredCoLocation.empty() &&
+              isSubset(requiredCoLocation, node->groupingKeys())
+          ? requiredCoLocation
+          : node->groupingKeys();
+    }
+    NodeCP input = ensureCoLocated(newInput, keys);
+    if (input == node->input()) {
+      return node;
+    }
+    return builder().make<Aggregate>(Aggregate::Key{
+        .input = input,
+        .groupingKeys = node->groupingKeys(),
+        .aggregates = node->aggregates(),
+        .outputColumns = node->outputColumns(),
+        .step = node->step(),
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+  }
+
+  // Distributes a window: its input must be partitioned on the PARTITION BY
+  // keys so each partition is computed on one task (an unpartitioned window
+  // gathers to one task). Runs bottom-up, so the input is already physically
+  // planned.
+  NodeCP rewriteWindow(const Window* node, NoContext& context) override {
+    NodeCP input =
+        ensureCoLocated(rewrite(node->input(), context), node->partitionKeys());
+    if (input == node->input()) {
+      return node;
+    }
+    return builder().make<Window>(
+        {input,
+         node->functions(),
+         node->partitionKeys(),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->outputColumns()});
+  }
+
+  // Distributes a per-partition top-n (row_number / rank): like a window, its
+  // input must be partitioned on the PARTITION BY keys (gather when none).
+  NodeCP rewriteTopNRowNumber(const TopNRowNumber* node, NoContext& context)
+      override {
+    NodeCP input =
+        ensureCoLocated(rewrite(node->input(), context), node->partitionKeys());
+    if (input == node->input()) {
+      return node;
+    }
+    return builder().make<TopNRowNumber>(
+        {input,
+         node->rankFunction(),
+         node->partitionKeys(),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->limit(),
+         node->rankColumn(),
+         node->outputColumns()});
+  }
+
+  // Distributes a global ORDER BY (Sort). At numWorkers>1 each task sorts its
+  // own rows and an order-preserving merge gather (MergeExchange) combines the
+  // sorted streams onto one task, so the sort parallelizes across tasks instead
+  // of running on a single gathered task. A single worker, or an input already
+  // gathered onto one task, sorts in one pass. Runs bottom-up, so the input is
+  // already physically planned.
+  NodeCP rewriteSort(const Sort* node, NoContext& context) override {
+    NodeCP input = rewrite(node->input(), context);
+    if (numWorkers_ == 1 || isGathered(input)) {
+      if (input == node->input()) {
+        return node;
+      }
+      return builder().make<Sort>(
+          {input, node->orderKeys(), node->orderTypes()});
+    }
+    NodeCP partialSort =
+        builder().make<Sort>({input, node->orderKeys(), node->orderTypes()});
+    return gatherMerge(partialSort, node->orderKeys(), node->orderTypes());
+  }
+
+  // Distributes an EnforceSingleRow (scalar-subquery single-row assertion): it
+  // must see all rows on one task to assert the global count, so gather.
+  NodeCP rewriteEnforceSingleRow(
+      const EnforceSingleRow* node,
+      NoContext& context) override {
+    NodeCP input = ensureGathered(rewrite(node->input(), context));
+    if (input == node->input()) {
+      return node;
+    }
+    return builder().make<EnforceSingleRow>({input});
+  }
+
+  // Rewrites 'node' so its output is co-located on 'keys', pushing the
+  // requirement into a producer that can satisfy it by its own partition choice
+  // — an aggregate co-locating on a subset of its grouping keys — so no
+  // reshuffle is added above it. Other producers fall back to a co-locating
+  // exchange.
+  NodeCP
+  rewriteCoLocatedOn(NodeCP node, const ExprVector& keys, NoContext& context) {
+    if (numWorkers_ > 1 && node->is(NodeType::kAggregate)) {
+      const auto* aggregate = node->as<Aggregate>();
+      return ensureCoLocated(
+          rewriteAggregateCoLocated(
+              aggregate, rewrite(aggregate->input(), context), keys),
+          keys);
+    }
+    return ensureCoLocated(rewrite(node, context), keys);
+  }
+
+  // EnforceDistinct asserts at most one row per distinct key across all input.
+  // A per-task check only sees duplicates that share a task, so the input must
+  // be co-located on the distinct keys.
+  NodeCP rewriteEnforceDistinct(const EnforceDistinct* node, NoContext& context)
+      override {
+    NodeCP input =
+        rewriteCoLocatedOn(node->input(), node->distinctKeys(), context);
+    if (input == node->input()) {
+      return node;
+    }
+    return builder().make<EnforceDistinct>(
+        {input, node->distinctKeys(), node->errorMessage()});
+  }
+
+  // Distributes a LIMIT: at numWorkers>1 a per-task partial keeps the first
+  // offset+count rows, the gather brings them to one task, and the full Limit
+  // applies offset/count there.
+  NodeCP rewriteLimit(const Limit* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (numWorkers_ == 1 || isGathered(newInput)) {
+      if (newInput == node->input()) {
+        return node;
+      }
+      return builder().make<Limit>({newInput, node->offset(), node->count()});
+    }
+
+    NodeCP partial = builder().make<Limit>(
+        {newInput, /*offset=*/0, node->offset() + node->count()});
+    return builder().make<Limit>(
+        {gather(partial), node->offset(), node->count()});
+  }
+
+  // Distributes a bounded ORDER BY (TopN, an ORDER BY + LIMIT): at numWorkers>1
+  // a per-task partial keeps its own top offset+count rows, the gather brings
+  // them to one task, and the full TopN produces the global top there.
+  NodeCP rewriteTopN(const TopN* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (numWorkers_ == 1 || isGathered(newInput)) {
+      if (newInput == node->input()) {
+        return node;
+      }
+      return builder().make<TopN>(
+          {newInput,
+           node->orderKeys(),
+           node->orderTypes(),
+           node->offset(),
+           node->count()});
+    }
+
+    NodeCP partial = builder().make<TopN>(
+        {newInput,
+         node->orderKeys(),
+         node->orderTypes(),
+         /*offset=*/0,
+         node->offset() + node->count()});
+    return builder().make<TopN>(
+        {gather(partial),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->offset(),
+         node->count()});
+  }
+
+  // Distributes a UNION ALL: at numWorkers>1 isolate each leg behind a remote
+  // exchange so a single-task leg (global aggregate, order/limit, Values) does
+  // not pin the union to one task and never shares a fragment with a parallel
+  // leg. Arbitrary partitioning
+  // suffices — the union only concatenates; a downstream operator that needs a
+  // partitioning establishes it on the union's output itself.
+  NodeCP rewriteUnionAll(const UnionAll* node, NoContext& context) override {
+    NodeVector newInputs;
+    newInputs.reserve(node->inputs().size());
+    bool changed = false;
+    for (NodeCP input : node->inputs()) {
+      NodeCP newInput = rewrite(input, context);
+      changed = changed || newInput != input;
+      newInputs.push_back(newInput);
+    }
+
+    if (numWorkers_ > 1) {
+      // Keep the legs un-shuffled when they co-bucket: the union derives a
+      // bucketed partitioning iff every leg is bucketed on leg columns mapping
+      // to the same output columns with copartitionable types, and then all
+      // legs share one grouped fragment. Otherwise each leg distributes
+      // independently (arbitrary / round-robin).
+      NodeCP coBucketed = builder().make<UnionAll>(
+          {newInputs, node->legColumns(), node->outputColumns()});
+      if (coBucketed->physicalProperties().globalPartition.is(
+              PartitionKind::kPartitioned)) {
+        return coBucketed;
+      }
+      for (NodeCP& newInput : newInputs) {
+        newInput = arbitrary(newInput);
+      }
+      changed = true;
+    }
+
+    if (!changed) {
+      return node;
+    }
+    return builder().make<UnionAll>(
+        {std::move(newInputs), node->legColumns(), node->outputColumns()});
+  }
+
+  // A write to a bucketed/partitioned layout needs each partition (bucket) on a
+  // single worker, else workers race to create the same bucket file.
+  // Repartition the input on the target's partition columns using the target's
+  // connector partitioning, unless the input is already compatibly bucketed (a
+  // collocated write) or the query runs on one worker. The within-worker split
+  // is added at emit.
+  NodeCP rewriteTableWrite(const TableWrite* node, NoContext& context)
+      override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (numWorkers_ > 1) {
+      const auto* layout = node->table()->layouts().front();
+      const auto& partitionColumns = layout->partitionColumns();
+      if (!partitionColumns.empty()) {
+        const auto* targetType = layout->partitionType().get();
+        const auto& schema = node->table()->type();
+        ExprVector keys;
+        keys.reserve(partitionColumns.size());
+        for (const auto* partitionColumn : partitionColumns) {
+          keys.push_back(node->columnExprs().at(
+              schema->getChildIdx(partitionColumn->name())));
+        }
+        const auto& partition = newInput->physicalProperties().globalPartition;
+        if (!partition.isBucketedCompatibleWith(keys, *targetType)) {
+          newInput = partitionTo(newInput, keys, targetType);
+        }
+      }
+    }
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder().make<TableWrite>(
+        {newInput, node->table(), node->kind(), node->columnExprs()});
+  }
+
+ private:
+  const OptimizerOptions& options_;
+  // A per-plan property, not an OptimizerOptions field, so it is held
+  // separately.
+  const int32_t numWorkers_;
+  const int32_t numDrivers_;
+
+  // Shared across all clusters of this query so a leaf (or hash-consed
+  // duplicate) subtree is estimated once.
+  EstimateProvider estimateProvider_;
+};
+
+} // namespace
+
+NodeCP PlanPhysicalPass::run(
+    NodeCP root,
+    Builder& builder,
+    const OptimizerOptions& options,
+    int32_t numWorkers,
+    int32_t numDrivers) {
+  PhysicalPlanRewriter rewriter{builder, options, numWorkers, numDrivers};
+  return rewriter.rewrite(root);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PlanPhysicalPass.h
+++ b/axiom/optimizer/v2/PlanPhysicalPass.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/OptimizerOptions.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Turns the logical tree into a distributed physical plan.
+class PlanPhysicalPass {
+ public:
+  /// Returns the distributed physical plan for `root`. In one bottom-up walk it
+  /// chooses cost-based join order (DPhyp over maximal chains of reorderable
+  /// equi-joins) and the distribution of aggregations and order/limit
+  /// operators, inserting remote exchanges so each operator's input satisfies
+  /// its required partitioning.
+  ///
+  /// Cross joins, theta and decorrelated-subquery joins, and joins whose keys
+  /// do not resolve to leaf columns keep their written shape; at
+  /// `numWorkers > 1` they still get a valid distributed input combination
+  /// (broadcast build).
+  ///
+  /// When `options.syntacticJoinOrder` is true, cost-based reordering is
+  /// disabled and every join keeps the order written in the query. The same
+  /// query-order fallback also kicks in per cluster when DPhyp cannot cost a
+  /// plan (a relation or join key lacked statistics).
+  /// `options.dphypEnumerationBudget` caps DPhyp's enumeration before it falls
+  /// back to greedy join ordering; <= 0 means unlimited. `numWorkers` is the
+  /// target task count; when > 1 the walk generates remote-exchange candidates
+  /// so operators co-partition, gather, or broadcast their inputs. `numDrivers`
+  /// is the per-worker driver (local pipeline) count; when > 1, an aggregate
+  /// whose input is already co-located on its grouping keys still needs a local
+  /// exchange to bring each group to one driver, so it two-stages (partial →
+  /// local exchange → final). `numWorkers` and `numDrivers` are per-plan
+  /// properties, not `OptimizerOptions` fields, so they are passed separately.
+  static NodeCP run(
+      NodeCP root,
+      Builder& builder,
+      const OptimizerOptions& options,
+      int32_t numWorkers,
+      int32_t numDrivers);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PlanSet.cpp
+++ b/axiom/optimizer/v2/PlanSet.cpp
@@ -1,0 +1,212 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PlanSet.h"
+
+#include <tuple>
+
+#include "axiom/optimizer/v2/CostModel.h"
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// Total order over plans so dominance and selection are independent of memo
+// insertion order. Plans in one set cover the same relation set; the tuple
+// distinguishes a join, an exchange wrapping a plan, or a lone leaf.
+using TieKey = std::tuple<uint64_t, uint64_t, size_t, int, int>;
+TieKey tieKey(MemoOpCP op) {
+  if (op->is(MemoOpKind::kJoin)) {
+    const auto* join = op->as<JoinOp>();
+    return {
+        join->left->cover().bits(),
+        join->right->cover().bits(),
+        join->edgeIndex,
+        static_cast<int>(join->joinType),
+        static_cast<int>(join->reversedAnti)};
+  }
+  if (op->is(MemoOpKind::kExchange)) {
+    const auto* exchange = op->as<ExchangeOp>();
+    const auto& partitioning = exchange->outputPartitioning();
+    return {
+        exchange->input->cover().bits(),
+        0,
+        partitioning.keys.size(),
+        static_cast<int>(partitioning.kind),
+        1};
+  }
+  return {static_cast<uint64_t>(op->as<LeafOp>()->relationId), 0, 0, 0, 0};
+}
+
+// Cost of producing `target` partitioning from `op`: `op`'s own cost when it is
+// already in `target`, else plus a remote shuffle. nullopt when the shuffle
+// cost is unknown (so the conversion cannot be ranked). `op`'s cost is known by
+// the PlanSet precondition (uncostable candidates never enter the set).
+std::optional<float> costAsPartitioning(
+    MemoOpCP op,
+    const Partitioning& target,
+    const JoinHypergraph& graph,
+    const CostModel& costModel) {
+  const float base = *op->cost.cost;
+  if (op->outputPartitioning().sameClassAs(target)) {
+    return base;
+  }
+  const std::optional<float> shuffle = costModel.shuffleCost(op, graph);
+  if (!shuffle.has_value()) {
+    return std::nullopt;
+  }
+  return base + *shuffle;
+}
+
+} // namespace
+
+void PlanSet::addPlan(
+    std::unique_ptr<MemoOp> candidate,
+    const JoinHypergraph& graph,
+    const CostModel& costModel) {
+  // An uncostable plan cannot be ranked. Only a leaf with unknown cardinality
+  // reaches here (uncostable joins are dropped before insertion), and a
+  // relation has exactly one leaf, so keep it as the lone incomparable entry;
+  // downstream cardinality checks then bail on the unknown cost.
+  if (!candidate->cost.cost.has_value()) {
+    plans_.push_back(std::move(candidate));
+    return;
+  }
+
+  const Partitioning& candidatePartition = candidate->outputPartitioning();
+  const float candidateCost = *candidate->cost.cost;
+  const TieKey candidateKey = tieKey(candidate.get());
+
+  // Drop the candidate if an existing plan reaches the candidate's partitioning
+  // at no greater cost (cheaper, or equal with a smaller tiebreak).
+  for (const auto& existing : plans_) {
+    const std::optional<float> asCandidate = costAsPartitioning(
+        existing.get(), candidatePartition, graph, costModel);
+    if (!asCandidate.has_value()) {
+      continue;
+    }
+    if (*asCandidate < candidateCost ||
+        (*asCandidate == candidateCost &&
+         tieKey(existing.get()) <= candidateKey)) {
+      return;
+    }
+  }
+
+  // The candidate survives; drop every existing plan it now dominates.
+  std::erase_if(plans_, [&](const std::unique_ptr<MemoOp>& existing) {
+    const std::optional<float> asExisting = costAsPartitioning(
+        candidate.get(), existing->outputPartitioning(), graph, costModel);
+    if (!asExisting.has_value()) {
+      return false;
+    }
+    const float existingCost = *existing->cost.cost;
+    return *asExisting < existingCost ||
+        (*asExisting == existingCost && candidateKey < tieKey(existing.get()));
+  });
+
+  plans_.push_back(std::move(candidate));
+}
+
+PlanSet::Selection PlanSet::best(
+    const RequiredProperties& required,
+    const JoinHypergraph& graph,
+    const CostModel& costModel) const {
+  Selection result;
+  std::optional<float> bestCost;
+  TieKey bestKey;
+  for (const auto& plan : plans_) {
+    std::optional<float> effective;
+    if (!required.globalPartition.has_value() ||
+        plan->outputPartitioning().sameClassAs(*required.globalPartition)) {
+      effective = plan->cost.cost;
+    } else if (plan->cost.cost.has_value()) {
+      const std::optional<float> shuffle =
+          costModel.shuffleCost(plan.get(), graph);
+      if (shuffle.has_value()) {
+        effective = *plan->cost.cost + *shuffle;
+      }
+    }
+    if (!effective.has_value()) {
+      continue;
+    }
+    const TieKey key = tieKey(plan.get());
+    if (result.plan == nullptr || *effective < *bestCost ||
+        (*effective == *bestCost && key < bestKey)) {
+      bestCost = effective;
+      bestKey = key;
+      result.plan = plan.get();
+      result.cost = plan->cost;
+      result.cost.cost = effective;
+    }
+  }
+  return result;
+}
+
+MemoOpCP PlanSet::cheapest() const {
+  // Hot path: until exchange candidates create differing partitionings every
+  // set holds one plan, so skip the ranking scan. Returns the lone plan even if
+  // uncostable (a leaf with unknown cardinality), matching the all-uncostable
+  // fallback below.
+  if (plans_.size() == 1) {
+    return plans_.front().get();
+  }
+  MemoOpCP result = nullptr;
+  std::optional<float> bestCost;
+  TieKey bestKey;
+  for (const auto& plan : plans_) {
+    if (!plan->cost.cost.has_value()) {
+      continue;
+    }
+    const float cost = *plan->cost.cost;
+    const TieKey key = tieKey(plan.get());
+    if (result == nullptr || cost < *bestCost ||
+        (cost == *bestCost && key < bestKey)) {
+      bestCost = cost;
+      bestKey = key;
+      result = plan.get();
+    }
+  }
+  // All entries uncostable: a lone leaf with unknown cardinality. Return it so
+  // callers can build on it and drop the result as uncostable.
+  if (result == nullptr && !plans_.empty()) {
+    return plans_.front().get();
+  }
+  return result;
+}
+
+MemoOpCP PlanSet::bestBucketed(const ExprVector& keys) const {
+  MemoOpCP result{nullptr};
+  for (const auto& plan : plans_) {
+    if (!plan->cost.cost.has_value() ||
+        !plan->outputPartitioning().isBucketedOn(keys)) {
+      continue;
+    }
+    if (result == nullptr || *plan->cost.cost < *result->cost.cost) {
+      result = plan.get();
+    }
+  }
+  return result;
+}
+
+std::optional<float> PlanSet::cardinality() const {
+  if (plans_.empty()) {
+    return std::nullopt;
+  }
+  return plans_.front()->cost.cardinality;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PlanSet.h
+++ b/axiom/optimizer/v2/PlanSet.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "axiom/optimizer/v2/MemoOp.h"
+#include "axiom/optimizer/v2/PhysicalProperties.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+class CostModel;
+class JoinHypergraph;
+
+/// Physical properties a memo consumer requires of the plan it selects from a
+/// `PlanSet`. A nullopt field means the consumer accepts any value for it.
+///
+/// Carries only global partitioning today. Ordering will join it when its first
+/// consumer (merge join / merging gather) lands; until then no consumer
+/// requires an input order — a top-level `ORDER BY` is a structural `Sort`, and
+/// streaming aggregation reads the emitted node's local property — so the slot
+/// is omitted rather than left unused.
+struct RequiredProperties {
+  /// Required global (across-tasks) partitioning, or nullopt for "any".
+  std::optional<Partitioning> globalPartition;
+};
+
+/// The value the property-aware memo keeps per relation set: a set of physical
+/// plans (each a `MemoOp`) that are *non-dominated* on global partitioning. A
+/// plan that is pricier on cost survives if it is already partitioned a way a
+/// downstream consumer needs, so converting another plan to that partitioning
+/// (a remote shuffle) would cost more than the difference.
+///
+/// At a single worker, candidates carry no partitioning, so the set holds one
+/// plan and behaves as the single-best memo. At `numWorkers > 1`, exchange
+/// candidate generation creates plans of differing partitioning, which is what
+/// exercises the cross-partitioning paths (`addPlan` dominance across classes,
+/// `best` enforcement).
+///
+/// Usage:
+///   PlanSet& set = memo[relationSet];
+///   set.addPlan(std::move(candidate), graph, costModel);   // shuffle-aware
+///   auto [plan, cost] =
+///       set.best({.globalPartition = keys}, graph, costModel);   // select
+class PlanSet {
+ public:
+  /// A selected plan together with its cost after any enforcement (a shuffle to
+  /// meet the requirement) folded in. `plan` is null when the set is empty.
+  struct Selection {
+    MemoOpCP plan{nullptr};
+    Cost cost;
+  };
+
+  /// Inserts `candidate`, keeping the set non-dominated: drops `candidate` if
+  /// an existing plan dominates it (cheaper even after a shuffle to convert
+  /// into `candidate`'s partitioning), and drops any existing plan `candidate`
+  /// dominates. Takes ownership; a dropped `candidate` is freed on return.
+  void addPlan(
+      std::unique_ptr<MemoOp> candidate,
+      const JoinHypergraph& graph,
+      const CostModel& costModel);
+
+  /// Selects the plan with the least cost after folding in any shuffle needed
+  /// to meet `required` — a plan already in the required partitioning pays
+  /// nothing, one in another partitioning pays a remote shuffle. With no
+  /// requirement, the cheapest plan. Returns a null `plan` when the set is
+  /// empty.
+  Selection best(
+      const RequiredProperties& required,
+      const JoinHypergraph& graph,
+      const CostModel& costModel) const;
+
+  /// Cheapest plan regardless of partitioning, or nullptr when empty.
+  MemoOpCP cheapest() const;
+
+  /// Cheapest plan whose output is connector-bucketed (`kPartitioned` with a
+  /// non-null `partitionType`) on exactly `keys`, or nullptr when none. Used by
+  /// the co-bucketed join strategy to find an input that can join co-located
+  /// without a shuffle.
+  MemoOpCP bestBucketed(const ExprVector& keys) const;
+
+  /// Output cardinality of this relation set — a relation-set fact, identical
+  /// across the set's plans. nullopt when empty or unknown.
+  std::optional<float> cardinality() const;
+
+  bool empty() const {
+    return plans_.empty();
+  }
+
+ private:
+  std::vector<std::unique_ptr<MemoOp>> plans_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -1,0 +1,437 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PrecomputeProjectionsPass.h"
+
+#include <folly/container/F14Map.h>
+#include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+namespace {
+
+// Per-consumer builder that lifts compound sub-expressions into a Project
+// inserted between the consumer and its existing input.
+class PrecomputeProjections {
+ public:
+  // When `projectAllInputs` is true (the default, for pass-through consumers
+  // like Window/Sort/Exchange), the project preserves every input column
+  // alongside the lifted ones. When false (for narrowing consumers like
+  // Aggregate/Unnest/Join), the project outputs only the columns passed to
+  // `toColumn` — so an input column kept solely to feed a lifted expression is
+  // dropped instead of passed through. The caller must `toColumn` every column
+  // the consumer reads.
+  PrecomputeProjections(
+      NodeCP input,
+      Builder& builder,
+      bool projectAllInputs = true);
+
+  // Returns the ExprCP that the consumer should reference in place of
+  // 'expr'. Pass-throughs:
+  //   - 'expr' is a Column: returned unchanged.
+  //   - 'expr' is a Literal and 'allowConstant' is true: returned unchanged.
+  // Otherwise lifts 'expr' into a projected column. If 'alias' is
+  // non-null, that exact Column is used as the projection's output;
+  // otherwise a fresh `__pXX` column is synthesized.
+  ExprCP
+  toColumn(ExprCP expr, ColumnCP alias = nullptr, bool allowConstant = false);
+
+  // Returns the input unchanged if no projections were added, otherwise the
+  // input wrapped in a fresh `Project`. With `projectAllInputs` the project
+  // adds the lifted columns alongside all input columns; without it the
+  // project outputs only the columns passed to `toColumn`.
+  NodeCP node() &&;
+
+ private:
+  void addToProject(ExprCP expr, ColumnCP column);
+
+  NodeCP input_;
+  Builder& builder_;
+  const bool projectAllInputs_;
+  ColumnVector outColumns_;
+  ExprVector outExprs_;
+  folly::F14FastMap<ExprCP, ColumnCP> seen_;
+  bool needsProject_{false};
+};
+
+PrecomputeProjections::PrecomputeProjections(
+    NodeCP input,
+    Builder& builder,
+    bool projectAllInputs)
+    : input_(input), builder_(builder), projectAllInputs_(projectAllInputs) {
+  if (!projectAllInputs_) {
+    return;
+  }
+  const auto& inputColumns = input->outputColumns();
+  outColumns_.reserve(inputColumns.size());
+  outExprs_.reserve(inputColumns.size());
+  for (ColumnCP column : inputColumns) {
+    addToProject(column, column);
+  }
+}
+
+ExprCP PrecomputeProjections::toColumn(
+    ExprCP expr,
+    ColumnCP alias,
+    bool allowConstant) {
+  if (allowConstant && expr->is(PlanType::kLiteralExpr)) {
+    return expr;
+  }
+  if (expr->is(PlanType::kColumnExpr)) {
+    // In narrowing mode the project is not seeded with the input columns, so a
+    // referenced passthrough column must be added explicitly. This is not a
+    // lifted expression, so it does not by itself require a project.
+    if (!projectAllInputs_ && !seen_.contains(expr)) {
+      addToProject(expr, expr->as<Column>());
+    }
+    return expr;
+  }
+  // Lambdas are consumed by their parent higher-order function directly
+  // and cannot be evaluated by a Project node.
+  if (expr->is(PlanType::kLambdaExpr)) {
+    return expr;
+  }
+  if (auto it = seen_.find(expr); it != seen_.end()) {
+    return it->second;
+  }
+  if (alias != nullptr) {
+    addToProject(expr, alias);
+    needsProject_ = true;
+    return alias;
+  }
+  // A compound expression materializes into a column named after its id, so the
+  // same expression always lifts to the same name. If a column of that name is
+  // already in the input — e.g. an exchange below this consumer lifted the same
+  // join/grouping key — reuse it instead of projecting a second column with the
+  // same name (which would be a duplicate output column).
+  const auto name = toName(fmt::format("__p{}", expr->id()));
+  for (ColumnCP column : input_->outputColumns()) {
+    if (column->name() == name) {
+      seen_.emplace(expr, column);
+      return column;
+    }
+  }
+  ColumnCP column = make<Column>(name, nullptr, expr->value());
+  addToProject(expr, column);
+  needsProject_ = true;
+  return column;
+}
+
+NodeCP PrecomputeProjections::node() && {
+  if (!needsProject_) {
+    return input_;
+  }
+  return builder_.make<Project>(
+      {input_, std::move(outExprs_), std::move(outColumns_)});
+}
+
+void PrecomputeProjections::addToProject(ExprCP expr, ColumnCP column) {
+  VELOX_DCHECK(!seen_.contains(expr));
+  seen_.emplace(expr, column);
+  outColumns_.emplace_back(column);
+  outExprs_.emplace_back(expr);
+}
+
+// Returns a new ColumnVector with the first `oldPrefixLength` elements
+// of `oldOutputColumns` replaced by `newPrefix`.
+ColumnVector replacePrefix(
+    const ColumnVector& oldOutputColumns,
+    size_t oldPrefixLength,
+    const ColumnVector& newPrefix) {
+  VELOX_DCHECK_LE(oldPrefixLength, oldOutputColumns.size());
+  ColumnVector result;
+  result.reserve(newPrefix.size() + oldOutputColumns.size() - oldPrefixLength);
+  for (ColumnCP column : newPrefix) {
+    result.push_back(column);
+  }
+  for (size_t i = oldPrefixLength; i < oldOutputColumns.size(); ++i) {
+    result.push_back(oldOutputColumns[i]);
+  }
+  return result;
+}
+
+// Lifts compound expressions at restricted positions of Aggregate /
+// Window / Sort / Unnest into a Project below the consumer.
+class Rewriter : public NodeRewriter<> {
+ public:
+  using NodeRewriter::NodeRewriter;
+
+ protected:
+  NodeCP rewriteAggregate(const Aggregate* aggregate, NoContext& context)
+      override;
+  NodeCP rewriteWindow(const Window* window, NoContext& context) override;
+  NodeCP rewriteSort(const Sort* sort, NoContext& context) override;
+  NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
+  NodeCP rewriteJoin(const Join* join, NoContext& context) override;
+  NodeCP rewriteExchange(const Exchange* exchange, NoContext& context) override;
+  NodeCP rewriteApply(const Apply* /*apply*/, NoContext& /*context*/) override {
+    VELOX_UNREACHABLE(
+        "Apply must be removed by decorrelate before PrecomputeProjections");
+  }
+};
+
+NodeCP Rewriter::rewriteAggregate(
+    const Aggregate* aggregate,
+    NoContext& context) {
+  NodeCP newInput = rewrite(aggregate->input(), context);
+  // An Aggregate reads only its grouping keys and aggregate inputs, so the
+  // lifting project outputs just those — dropping any input column kept solely
+  // to feed a lifted aggregate expression.
+  PrecomputeProjections precompute{
+      newInput, builder(), /*projectAllInputs=*/false};
+
+  ExprVector newGroupingKeys;
+  newGroupingKeys.reserve(aggregate->groupingKeys().size());
+  for (size_t i = 0; i < aggregate->groupingKeys().size(); ++i) {
+    // Reuse the existing output column as the projection alias so the
+    // Aggregate's outputColumns identity is preserved.
+    newGroupingKeys.push_back(precompute.toColumn(
+        aggregate->groupingKeys()[i], aggregate->outputColumns()[i]));
+  }
+
+  // A kFinal aggregate's args reference the Partial's raw inputs, which are
+  // absent at the Final's input (it consumes intermediate accumulators), so
+  // leave them untouched rather than precompute them here.
+  AggregateCallVector newAggregates;
+  if (aggregate->step() == AggregateStep::kFinal) {
+    newAggregates = aggregate->aggregates();
+  } else {
+    newAggregates.reserve(aggregate->aggregates().size());
+    for (const auto* call : aggregate->aggregates()) {
+      ExprVector newArgs;
+      newArgs.reserve(call->args().size());
+      for (ExprCP arg : call->args()) {
+        newArgs.push_back(precompute.toColumn(
+            arg, /*alias=*/nullptr, /*allowConstant=*/true));
+      }
+      ExprCP newCondition = call->condition() != nullptr
+          ? precompute.toColumn(
+                call->condition(), /*alias=*/nullptr, /*allowConstant=*/true)
+          : nullptr;
+      ExprVector newOrderKeys;
+      newOrderKeys.reserve(call->orderKeys().size());
+      for (ExprCP key : call->orderKeys()) {
+        newOrderKeys.push_back(precompute.toColumn(key));
+      }
+      newAggregates.push_back(
+          builder().makeAggregate(
+              call->name(),
+              call->value(),
+              std::move(newArgs),
+              call->functions(),
+              call->isDistinct(),
+              newCondition,
+              call->intermediateType(),
+              std::move(newOrderKeys),
+              call->orderTypes()));
+    }
+  }
+
+  return builder().make<Aggregate>(Aggregate::Key{
+      .input = std::move(precompute).node(),
+      .groupingKeys = std::move(newGroupingKeys),
+      .aggregates = std::move(newAggregates),
+      .outputColumns = aggregate->outputColumns(),
+      .step = aggregate->step(),
+      .groupId = aggregate->groupId(),
+      .globalGroupingSets = aggregate->globalGroupingSets()});
+}
+
+NodeCP Rewriter::rewriteWindow(const Window* window, NoContext& context) {
+  NodeCP newInput = rewrite(window->input(), context);
+  PrecomputeProjections precompute{newInput, builder()};
+
+  ExprVector newPartitionKeys;
+  newPartitionKeys.reserve(window->partitionKeys().size());
+  for (ExprCP key : window->partitionKeys()) {
+    newPartitionKeys.push_back(precompute.toColumn(key));
+  }
+  ExprVector newOrderKeys;
+  newOrderKeys.reserve(window->orderKeys().size());
+  for (ExprCP key : window->orderKeys()) {
+    newOrderKeys.push_back(precompute.toColumn(key));
+  }
+
+  // Frame bounds must be FieldAccess or Constant in Velox.
+  auto liftBound = [&](ExprCP value) -> ExprCP {
+    return value != nullptr
+        ? precompute.toColumn(value, /*alias=*/nullptr, /*allowConstant=*/true)
+        : nullptr;
+  };
+
+  WindowFunctions newFunctions;
+  newFunctions.reserve(window->functions().size());
+  for (const WindowFunction& windowFunction : window->functions()) {
+    const auto* call = windowFunction.call->as<Call>();
+    ExprVector newArgs;
+    newArgs.reserve(call->args().size());
+    for (ExprCP arg : call->args()) {
+      newArgs.push_back(
+          precompute.toColumn(arg, /*alias=*/nullptr, /*allowConstant=*/true));
+    }
+    auto* newCall = builder().makeCall(
+        call->name(), call->value(), std::move(newArgs), call->functions());
+    const Frame& frame = windowFunction.frame;
+    Frame newFrame{
+        frame.type,
+        frame.startType,
+        liftBound(frame.startValue),
+        frame.endType,
+        liftBound(frame.endValue),
+    };
+    newFunctions.push_back({newCall, newFrame, windowFunction.ignoreNulls});
+  }
+
+  const size_t oldPrefixLength = window->input()->outputColumns().size();
+  newInput = std::move(precompute).node();
+  ColumnVector newOutputColumns = replacePrefix(
+      window->outputColumns(), oldPrefixLength, newInput->outputColumns());
+  return builder().make<Window>(
+      {newInput,
+       std::move(newFunctions),
+       std::move(newPartitionKeys),
+       std::move(newOrderKeys),
+       window->orderTypes(),
+       std::move(newOutputColumns)});
+}
+
+NodeCP Rewriter::rewriteSort(const Sort* sort, NoContext& context) {
+  NodeCP newInput = rewrite(sort->input(), context);
+  PrecomputeProjections precompute{newInput, builder()};
+  ExprVector newOrderKeys;
+  newOrderKeys.reserve(sort->orderKeys().size());
+  for (ExprCP key : sort->orderKeys()) {
+    newOrderKeys.push_back(precompute.toColumn(key));
+  }
+  return builder().make<Sort>(
+      {std::move(precompute).node(),
+       std::move(newOrderKeys),
+       sort->orderTypes()});
+}
+
+NodeCP Rewriter::rewriteExchange(const Exchange* exchange, NoContext& context) {
+  NodeCP newInput = rewrite(exchange->input(), context);
+  const Partitioning& partitioning = exchange->partitioning();
+  // Only hash partitioning carries keys, and emit requires them to be column
+  // references; lift any compound key expression into a projected column.
+  if (partitioning.kind != PartitionKind::kPartitioned) {
+    if (newInput == exchange->input()) {
+      return exchange;
+    }
+    return builder().make<Exchange>({newInput, partitioning});
+  }
+  PrecomputeProjections precompute{newInput, builder()};
+  ExprVector newKeys;
+  newKeys.reserve(partitioning.keys.size());
+  for (ExprCP key : partitioning.keys) {
+    newKeys.push_back(precompute.toColumn(key));
+  }
+  Partitioning newPartitioning = partitioning;
+  newPartitioning.keys = std::move(newKeys);
+  return builder().make<Exchange>(
+      {std::move(precompute).node(), std::move(newPartitioning)});
+}
+
+NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
+  NodeCP newLeft = rewrite(join->left(), context);
+  NodeCP newRight = rewrite(join->right(), context);
+
+  // A join reads only its keys, filter, and the columns it outputs, so each
+  // side's lifting project outputs just those — dropping any input column kept
+  // solely to feed a lifted join key.
+  PrecomputeProjections leftPrecompute{
+      newLeft, builder(), /*projectAllInputs=*/false};
+  PrecomputeProjections rightPrecompute{
+      newRight, builder(), /*projectAllInputs=*/false};
+  ExprVector newLeftKeys;
+  newLeftKeys.reserve(join->leftKeys().size());
+  for (ExprCP key : join->leftKeys()) {
+    newLeftKeys.push_back(leftPrecompute.toColumn(key));
+  }
+  ExprVector newRightKeys;
+  newRightKeys.reserve(join->rightKeys().size());
+  for (ExprCP key : join->rightKeys()) {
+    newRightKeys.push_back(rightPrecompute.toColumn(key));
+  }
+
+  // Keep each side's passthrough columns: those it contributes to the join
+  // output or references in the join filter. A column produced by the join
+  // itself (e.g. a semijoin mark) belongs to neither input and is skipped.
+  const auto leftColumns = PlanObjectSet::fromObjects(newLeft->outputColumns());
+  const auto rightColumns =
+      PlanObjectSet::fromObjects(newRight->outputColumns());
+  auto keepPassthrough = [&](ColumnCP column) {
+    if (leftColumns.contains(column)) {
+      leftPrecompute.toColumn(column);
+    } else if (rightColumns.contains(column)) {
+      rightPrecompute.toColumn(column);
+    }
+  };
+  for (ColumnCP column : join->outputColumns()) {
+    keepPassthrough(column);
+  }
+  for (ExprCP conjunct : join->filter()) {
+    conjunct->columns().forEach<Column>(keepPassthrough);
+  }
+
+  return builder().make<Join>(
+      {std::move(leftPrecompute).node(),
+       std::move(rightPrecompute).node(),
+       join->joinType(),
+       std::move(newLeftKeys),
+       std::move(newRightKeys),
+       join->filter(),
+       join->nullAware(),
+       join->nullAsValue(),
+       join->outputColumns()});
+}
+
+NodeCP Rewriter::rewriteUnnest(const Unnest* unnest, NoContext& context) {
+  NodeCP newInput = rewrite(unnest->input(), context);
+  // An Unnest reads only its unnest expressions and the columns it replicates,
+  // so the lifting project outputs just those — dropping any input column kept
+  // solely to feed a lifted unnest expression.
+  PrecomputeProjections precompute{
+      newInput, builder(), /*projectAllInputs=*/false};
+  ExprVector newUnnestExprs;
+  newUnnestExprs.reserve(unnest->unnestExpressions().size());
+  for (ExprCP expr : unnest->unnestExpressions()) {
+    newUnnestExprs.push_back(precompute.toColumn(expr));
+  }
+  // Keep the replicated (passthrough) columns in the project's output.
+  for (ColumnCP column : unnest->replicatedColumns()) {
+    precompute.toColumn(column);
+  }
+  newInput = std::move(precompute).node();
+  // Structured fields (replicatedColumns / unnestColumns / ordinalityColumn)
+  // are by Column*; precompute preserves Column identity so they stay valid.
+  return builder().make<Unnest>(
+      {newInput,
+       std::move(newUnnestExprs),
+       unnest->replicatedColumns(),
+       unnest->unnestColumns(),
+       unnest->ordinalityColumn(),
+       unnest->outputColumns()});
+}
+
+} // namespace
+
+NodeCP PrecomputeProjectionsPass::run(NodeCP node, Builder& builder) {
+  return Rewriter{builder}.rewrite(node);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.h
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Lifts compound expressions into `Project`s wherever Velox requires a column
+/// or literal.
+class PrecomputeProjectionsPass {
+ public:
+  /// Returns the tree rooted at 'node' rewritten so every position where Velox
+  /// demands a `FieldAccessTypedExpr` (or, where allowed, a constant) carries a
+  /// `Column` (or `Literal`) instead of a compound expression. Such compound
+  /// expressions are lifted into a `Project` inserted between the consumer and
+  /// its input, and the consumer is rebuilt to reference the projected column.
+  /// Affected consumer kinds and positions:
+  ///   - Aggregate: grouping keys, aggregate args, FILTER mask, ORDER BY keys
+  ///   - Window:    partition keys, order keys, function args
+  ///   - Sort:      order keys
+  ///   - Unnest:    unnest expressions
+  /// Returns the original tree unchanged when no lifting is required.
+  static NodeCP run(NodeCP node, Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -1,0 +1,1449 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/PushdownAndPrunePass.h"
+
+#include <limits>
+#include <optional>
+
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "axiom/optimizer/v2/ExprSimplifier.h"
+#include "axiom/optimizer/v2/JoinCondition.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+namespace {
+
+// Per-call state for the pushdown visitor.
+struct PushdownContext {
+  // Conjuncts collected from the path above this node that the visitor
+  // will try to push further down.
+  ExprVector pending;
+
+  // Columns the consumer above this node actually reads. Used to narrow
+  // each node's `outputColumns` (and to drop unused exprs / aggregates
+  // / window functions / leg columns). Seeded at the root with
+  // `root->outputColumns()` so the root's output schema is preserved.
+  // Includes columns referenced by `pending` (they must survive to where
+  // a conjunct lands).
+  PlanObjectSet required;
+
+  // Subset of `required` demanded by consumers strictly above this node,
+  // i.e. `required` without the columns folded in for `pending`. A
+  // kLeftSemiProject mark in this set is live above and must not be
+  // fused away. Conservatively defaults to `required` on paths that do
+  // not refine it, which only blocks (never wrongly enables) fusion.
+  PlanObjectSet requiredAbove;
+
+  // `Column*`s whose values are guaranteed non-NULL in the current
+  // subtree (derived from default-null-behavior equi-keys of an
+  // ancestor inner join). Never inserted into the plan.
+  PlanObjectSet nonNullColumns;
+};
+
+// Returns true if `conjunct` references at least one column in
+// `columns` and contains no non-default-null-behavior sub-expression.
+// Conservative — a true result implies null-rejection; a false result
+// does not imply the opposite.
+bool isNullRejecting(ExprCP conjunct, const PlanObjectSet& columns) {
+  return conjunct->columns().hasIntersection(columns) &&
+      !conjunct->functions().contains(FunctionSet::kNonDefaultNullBehavior);
+}
+
+// Returns the demoted join kind if a pending conjunct or an
+// ancestor-proven non-NULL column rejects nulls on the
+// null-padded side(s), otherwise `joinType` unchanged.
+velox::core::JoinType demoteOuterToInner(
+    velox::core::JoinType joinType,
+    const ExprVector& pending,
+    const PlanObjectSet& nonNullColumns,
+    const PlanObjectSet& leftColumns,
+    const PlanObjectSet& rightColumns) {
+  auto anyRejects = [&](const PlanObjectSet& columns) {
+    for (ExprCP conjunct : pending) {
+      if (isNullRejecting(conjunct, columns)) {
+        return true;
+      }
+    }
+    return columns.hasIntersection(nonNullColumns);
+  };
+  switch (joinType) {
+    case velox::core::JoinType::kLeft:
+      return anyRejects(rightColumns) ? velox::core::JoinType::kInner
+                                      : joinType;
+    case velox::core::JoinType::kRight:
+      return anyRejects(leftColumns) ? velox::core::JoinType::kInner : joinType;
+    case velox::core::JoinType::kFull: {
+      const bool rejectsLeft = anyRejects(leftColumns);
+      const bool rejectsRight = anyRejects(rightColumns);
+      if (rejectsLeft && rejectsRight) {
+        return velox::core::JoinType::kInner;
+      }
+      if (rejectsLeft) {
+        return velox::core::JoinType::kRight;
+      }
+      if (rejectsRight) {
+        return velox::core::JoinType::kLeft;
+      }
+      return joinType;
+    }
+    case velox::core::JoinType::kInner:
+    case velox::core::JoinType::kLeftSemiFilter:
+    case velox::core::JoinType::kCountingLeftSemiFilter:
+    case velox::core::JoinType::kLeftSemiProject:
+    case velox::core::JoinType::kRightSemiFilter:
+    case velox::core::JoinType::kRightSemiProject:
+    case velox::core::JoinType::kAnti:
+    case velox::core::JoinType::kCountingAnti:
+      return joinType;
+    case velox::core::JoinType::kNumJoinTypes:
+      break;
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Result of fusing a consuming mark filter into a kLeftSemiProject
+// join. `joinType` is the filtering type the join switches to; `conjunct`
+// is the pending conjunct that gets consumed (removed from `pending`).
+struct MarkFusion {
+  velox::core::JoinType joinType;
+  ExprCP conjunct;
+};
+
+// Returns true if `expr` is syntactically `not(arg)`.
+bool isNot(ExprCP expr, ExprCP& arg) {
+  if (!expr->is(PlanType::kCallExpr)) {
+    return false;
+  }
+  const Call* call = expr->as<Call>();
+  if (call->name() != toName(FunctionRegistry::instance()->negation()) ||
+      call->args().size() != 1) {
+    return false;
+  }
+  arg = call->args()[0];
+  return true;
+}
+
+// Attempts to fuse a consuming mark filter on a `kLeftSemiProject` join
+// into a filtering `kLeftSemiFilter` / `kAnti`. Returns the fusion when a
+// pending conjunct is syntactically exactly the mark (→ kLeftSemiFilter)
+// or exactly `not(mark)` (→ kAnti), and the mark is dead above except for
+// that conjunct. Returns nullopt otherwise (leaving the join a
+// kLeftSemiProject).
+//
+// Correctness preconditions, all required:
+//  - Shape: the conjunct is exactly `mark` or `not(mark)`; a conjunct
+//    that merely references the mark (`mark IS NULL`, `mark OR x`,
+//    `coalesce(mark, false)`) is not a semi/anti and must not fuse.
+//  - Three-valued mark: the kLeftSemiProject mark is three-valued for
+//    null-aware IN. `Filter(not(mark))` keeps exactly `mark = false`
+//    rows, which is correct NOT IN by 3VL. The match is against the raw
+//    conjunct, preserving the negated nullable mark's null behavior.
+//  - Liveness: the mark must not be required by any consumer other than
+//    the fused conjunct. The mark is a fresh column produced only by this
+//    join, so its consumers are pending conjuncts (the fused one plus any
+//    others, checked here) and consumers strictly above carried in
+//    `requiredAbove`. A mark live above is not fused: dropping it would
+//    leave a dangling output-column demand.
+std::optional<MarkFusion> fuseMarkFilter(
+    JoinCP node,
+    const ExprVector& pending,
+    const PlanObjectSet& requiredAbove) {
+  if (node->joinType() != velox::core::JoinType::kLeftSemiProject) {
+    return std::nullopt;
+  }
+  // The mark is the last output column of a kLeftSemiProject join.
+  VELOX_CHECK(
+      !node->outputColumns().empty(),
+      "kLeftSemiProject join must produce a mark column");
+  ColumnCP mark = node->outputColumns().back();
+
+  // A consumer strictly above keeps the mark live; fusion drops it.
+  if (requiredAbove.contains(mark)) {
+    return std::nullopt;
+  }
+
+  ExprCP fused{nullptr};
+  velox::core::JoinType fusedType{};
+  for (ExprCP conjunct : pending) {
+    if (conjunct == mark) {
+      fused = conjunct;
+      fusedType = velox::core::JoinType::kLeftSemiFilter;
+      break;
+    }
+    ExprCP negated{nullptr};
+    if (isNot(conjunct, negated) && negated == mark) {
+      fused = conjunct;
+      fusedType = velox::core::JoinType::kAnti;
+      break;
+    }
+  }
+  if (fused == nullptr) {
+    return std::nullopt;
+  }
+
+  // Any other pending conjunct that references the mark keeps it live.
+  for (ExprCP conjunct : pending) {
+    if (conjunct != fused && conjunct->columns().contains(mark)) {
+      return std::nullopt;
+    }
+  }
+  return MarkFusion{fusedType, fused};
+}
+
+// Returns true if a `leftOnly` conjunct that arrived from above the join
+// may be pushed to the left input of a join of `joinType`. An above-join
+// conjunct is an extra restriction on the join output; this differs from a
+// conjunct in the join's own match condition (see joinFilterTarget).
+bool canPushLeft(velox::core::JoinType joinType, bool leftOnly) {
+  if (!leftOnly) {
+    return false;
+  }
+  switch (joinType) {
+    case velox::core::JoinType::kInner:
+    case velox::core::JoinType::kLeft:
+    case velox::core::JoinType::kLeftSemiFilter:
+    case velox::core::JoinType::kCountingLeftSemiFilter:
+    case velox::core::JoinType::kLeftSemiProject:
+    case velox::core::JoinType::kAnti:
+    case velox::core::JoinType::kCountingAnti:
+      return true;
+    case velox::core::JoinType::kRight:
+    case velox::core::JoinType::kFull:
+    case velox::core::JoinType::kRightSemiFilter:
+    case velox::core::JoinType::kRightSemiProject:
+      return false;
+    case velox::core::JoinType::kNumJoinTypes:
+      break;
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Returns the cross-side `Column == Column` equi-pairs reachable on
+// `node` — either explicitly via `leftKeys`/`rightKeys` or as
+// `eq(Column, Column)` conjuncts in the join's filter. The returned
+// pair has equal-length `first` (left columns) and `second` (right
+// columns) vectors.
+std::pair<ColumnVector, ColumnVector> collectEquiColumnPairs(
+    JoinCP node,
+    const PlanObjectSet& leftColumns,
+    const PlanObjectSet& rightColumns) {
+  ColumnVector leftKeys;
+  ColumnVector rightKeys;
+  for (size_t i = 0; i < node->leftKeys().size(); ++i) {
+    ExprCP leftKey = node->leftKeys()[i];
+    ExprCP rightKey = node->rightKeys()[i];
+    if (leftKey->is(PlanType::kColumnExpr) &&
+        rightKey->is(PlanType::kColumnExpr)) {
+      leftKeys.push_back(leftKey->as<Column>());
+      rightKeys.push_back(rightKey->as<Column>());
+    }
+  }
+  if (node->filter().empty()) {
+    return {std::move(leftKeys), std::move(rightKeys)};
+  }
+
+  const Name equalityName = toName(FunctionRegistry::instance()->equality());
+  for (ExprCP conjunct : node->filter()) {
+    if (!conjunct->is(PlanType::kCallExpr)) {
+      continue;
+    }
+    const Call* call = conjunct->as<Call>();
+    if (call->name() != equalityName) {
+      continue;
+    }
+    ExprCP first = call->args()[0];
+    ExprCP second = call->args()[1];
+    if (!first->is(PlanType::kColumnExpr) ||
+        !second->is(PlanType::kColumnExpr)) {
+      continue;
+    }
+    ColumnCP firstColumn = first->as<Column>();
+    ColumnCP secondColumn = second->as<Column>();
+    if (leftColumns.contains(firstColumn) &&
+        rightColumns.contains(secondColumn)) {
+      leftKeys.push_back(firstColumn);
+      rightKeys.push_back(secondColumn);
+    } else if (
+        leftColumns.contains(secondColumn) &&
+        rightColumns.contains(firstColumn)) {
+      leftKeys.push_back(secondColumn);
+      rightKeys.push_back(firstColumn);
+    }
+  }
+  return {std::move(leftKeys), std::move(rightKeys)};
+}
+
+// Returns per-side necessary-condition filters derived from `orExpr`:
+// for each side, an OR of the per-disjunct AND-chunks of conjuncts
+// referencing only that side's columns. Returns nullptr for a side
+// when any disjunct contributes no conjunct on that side (the per-
+// side OR would be trivially true), and returns nullptr for both
+// sides when `orExpr` is not an OR call or contains non-deterministic
+// expressions.
+std::pair<ExprCP, ExprCP> deriveSideFiltersFromOr(
+    ExprCP orExpr,
+    const PlanObjectSet& leftColumns,
+    const PlanObjectSet& rightColumns,
+    ExprFactory& factory) {
+  if (!orExpr->is(PlanType::kCallExpr) ||
+      orExpr->as<Call>()->name() != SpecialFormCallNames::kOr) {
+    return {nullptr, nullptr};
+  }
+  if (orExpr->containsNonDeterministic()) {
+    return {nullptr, nullptr};
+  }
+  ExprVector disjuncts = ExprFactory::flattenOr(orExpr);
+  ExprVector leftSideDisjuncts;
+  ExprVector rightSideDisjuncts;
+  bool leftValid = true;
+  bool rightValid = true;
+  for (ExprCP disjunct : disjuncts) {
+    ExprVector conjuncts = ExprFactory::flattenAnd(disjunct);
+    ExprVector leftOnly;
+    ExprVector rightOnly;
+    for (ExprCP conjunct : conjuncts) {
+      const auto& columns = conjunct->columns();
+      if (columns.empty()) {
+        continue;
+      }
+      if (columns.isSubset(leftColumns)) {
+        leftOnly.push_back(conjunct);
+      }
+      if (columns.isSubset(rightColumns)) {
+        rightOnly.push_back(conjunct);
+      }
+    }
+    if (leftOnly.empty()) {
+      leftValid = false;
+    } else if (leftValid) {
+      leftSideDisjuncts.push_back(factory.andAll(leftOnly));
+    }
+    if (rightOnly.empty()) {
+      rightValid = false;
+    } else if (rightValid) {
+      rightSideDisjuncts.push_back(factory.andAll(rightOnly));
+    }
+    if (!leftValid && !rightValid) {
+      return {nullptr, nullptr};
+    }
+  }
+  return {
+      leftValid ? factory.orAll(leftSideDisjuncts) : nullptr,
+      rightValid ? factory.orAll(rightSideDisjuncts) : nullptr};
+}
+
+// Splits `expressions` by whether each one's column set overlaps
+// `columns`. Returns `{noOverlap, overlap}`.
+std::pair<ExprVector, ExprVector> partition(
+    const ExprVector& expressions,
+    const PlanObjectSet& columns) {
+  ExprVector noOverlap;
+  ExprVector overlap;
+  for (ExprCP expression : expressions) {
+    if (expression->columns().hasIntersection(columns)) {
+      overlap.push_back(expression);
+    } else {
+      noOverlap.push_back(expression);
+    }
+  }
+  return {std::move(noOverlap), std::move(overlap)};
+}
+
+// Mirror of canPushLeft for the right input (from-above conjuncts).
+bool canPushRight(velox::core::JoinType joinType, bool rightOnly) {
+  if (!rightOnly) {
+    return false;
+  }
+  switch (joinType) {
+    case velox::core::JoinType::kInner:
+    case velox::core::JoinType::kRight:
+    case velox::core::JoinType::kRightSemiFilter:
+    case velox::core::JoinType::kRightSemiProject:
+      return true;
+    case velox::core::JoinType::kLeft:
+    case velox::core::JoinType::kFull:
+    case velox::core::JoinType::kLeftSemiFilter:
+    case velox::core::JoinType::kCountingLeftSemiFilter:
+    case velox::core::JoinType::kLeftSemiProject:
+    case velox::core::JoinType::kAnti:
+    case velox::core::JoinType::kCountingAnti:
+      return false;
+    case velox::core::JoinType::kNumJoinTypes:
+      break;
+  }
+  VELOX_UNREACHABLE();
+}
+
+// Where a conjunct from a join's own match condition (its filter) that
+// references only one input may move.
+enum class FilterTarget { kKeep, kLeft, kRight };
+
+// Returns the target for a single-input match conjunct. This differs from
+// canPushLeft/canPushRight, which govern conjuncts arriving from above the
+// join (an extra restriction on the output). A match conjunct may move to:
+//  - kInner: either referenced input.
+//  - kLeft / kRight: only the non-preserved input; pushing the preserved
+//    input would drop rows that must be NULL-padded.
+//  - semi / anti: only the existence-check input. Pre-filtering the match
+//    rows preserves which output rows have (semi) or lack (anti) a match.
+//    The output side is row-preserving for anti / project / counting, so
+//    pushing a conjunct into it would drop rows that must survive.
+//  - kFull: neither.
+FilterTarget joinFilterTarget(
+    velox::core::JoinType joinType,
+    bool leftOnly,
+    bool rightOnly) {
+  switch (joinType) {
+    case velox::core::JoinType::kInner:
+      if (leftOnly) {
+        return FilterTarget::kLeft;
+      }
+      return rightOnly ? FilterTarget::kRight : FilterTarget::kKeep;
+    case velox::core::JoinType::kLeft:
+      return rightOnly ? FilterTarget::kRight : FilterTarget::kKeep;
+    case velox::core::JoinType::kRight:
+      return leftOnly ? FilterTarget::kLeft : FilterTarget::kKeep;
+    case velox::core::JoinType::kFull:
+      return FilterTarget::kKeep;
+    // Existence-check input is the right side for these.
+    case velox::core::JoinType::kLeftSemiFilter:
+    case velox::core::JoinType::kCountingLeftSemiFilter:
+    case velox::core::JoinType::kLeftSemiProject:
+    case velox::core::JoinType::kAnti:
+    case velox::core::JoinType::kCountingAnti:
+      return rightOnly ? FilterTarget::kRight : FilterTarget::kKeep;
+    // ...and the left side for right-semi.
+    case velox::core::JoinType::kRightSemiFilter:
+    case velox::core::JoinType::kRightSemiProject:
+      return leftOnly ? FilterTarget::kLeft : FilterTarget::kKeep;
+    case velox::core::JoinType::kNumJoinTypes:
+      break;
+  }
+  VELOX_UNREACHABLE();
+}
+
+// A recognized `Filter(rankColumn <op> n)` over a single-ranking-function
+// `Window`, to be fused into a `TopNRowNumber`.
+struct RankFusion {
+  // The consumed predicate conjunct.
+  ExprCP predicate;
+  // The window function's output column (the rank value).
+  ColumnCP rankColumn;
+  velox::core::TopNRowNumberNode::RankFunction rankFunction;
+  int32_t limit;
+};
+
+// Detects a single ranking function (row_number / rank / dense_rank) bounded by
+// a per-partition row limit, returning the fusion when one of the 'pending'
+// conjuncts bounds the rank column.
+std::optional<RankFusion> detectRankFusion(
+    const Window* node,
+    const ExprVector& pending,
+    const FunctionNames& names) {
+  if (node->functions().size() != 1 || node->orderKeys().empty()) {
+    return std::nullopt;
+  }
+  const ExprCP call = node->functions()[0].call;
+  if (!call->is(PlanType::kCallExpr)) {
+    return std::nullopt;
+  }
+  const Name functionName = call->as<Call>()->name();
+  velox::core::TopNRowNumberNode::RankFunction rankFunction;
+  if (functionName == names.rowNumber) {
+    rankFunction = velox::core::TopNRowNumberNode::RankFunction::kRowNumber;
+  } else if (functionName == names.rank) {
+    rankFunction = velox::core::TopNRowNumberNode::RankFunction::kRank;
+  } else if (functionName == names.denseRank) {
+    rankFunction = velox::core::TopNRowNumberNode::RankFunction::kDenseRank;
+  } else {
+    return std::nullopt;
+  }
+
+  const size_t numInputColumns = node->input()->outputColumns().size();
+  const ColumnCP rankColumn = node->outputColumns()[numInputColumns];
+
+  for (ExprCP conjunct : pending) {
+    if (!conjunct->is(PlanType::kCallExpr)) {
+      continue;
+    }
+    const Call* comparison = conjunct->as<Call>();
+    if (comparison->args().size() != 2 || comparison->args()[0] != rankColumn ||
+        !comparison->args()[1]->is(PlanType::kLiteralExpr)) {
+      continue;
+    }
+    const int64_t bound =
+        integerValue(&comparison->args()[1]->as<Literal>()->literal());
+    const Name name = comparison->name();
+    int64_t limit;
+    if (name == names.lte && bound > 0) {
+      limit = bound;
+    } else if (name == names.lt && bound > 1) {
+      limit = bound - 1;
+    } else if (name == names.equality && bound == 1) {
+      limit = 1;
+    } else {
+      continue;
+    }
+    if (limit > std::numeric_limits<int32_t>::max()) {
+      continue;
+    }
+    return RankFusion{
+        conjunct, rankColumn, rankFunction, static_cast<int32_t>(limit)};
+  }
+  return std::nullopt;
+}
+
+// Top-down filter pushdown visitor. Every node kind is overridden
+// explicitly so each kind decides whether and how to propagate pending
+// conjuncts.
+class Pushdown : public NodeRewriter<PushdownContext> {
+ public:
+  Pushdown(Builder& builder, velox::core::ExpressionEvaluator& evaluator)
+      : NodeRewriter(builder),
+        exprs_(builder),
+        simplifier_(builder, evaluator) {}
+
+ protected:
+  // Filter conjuncts (flattened across AND trees) join `pending`; the
+  // Filter node itself is dropped.
+  NodeCP rewriteFilter(const Filter* node, PushdownContext& context) override {
+    for (ExprCP predicate : node->predicates()) {
+      ExprFactory::flattenAnd(predicate, context.pending);
+    }
+    return rewrite(node->input(), context);
+  }
+
+  // Project: substitute pending output-column references through aliases
+  // whose backing expression is deterministic. Conjuncts that reference a
+  // non-deterministic output are blocked above the Project.
+  NodeCP rewriteProject(const Project* node, PushdownContext& context)
+      override {
+    PlanObjectSet blockedOutputs;
+    for (size_t i = 0; i < node->exprs().size(); ++i) {
+      if (node->exprs()[i]->functions().contains(
+              FunctionSet::kNonDeterministic)) {
+        blockedOutputs.add(node->outputColumns()[i]);
+      }
+    }
+
+    auto [substitutable, blocked] = partition(context.pending, blockedOutputs);
+    ExprVector pushable;
+    pushable.reserve(substitutable.size());
+    for (ExprCP conjunct : substitutable) {
+      ExprCP substituted =
+          exprs_.substitute(conjunct, node->outputColumns(), node->exprs());
+      if (simplifier_.simplifyFilter(substituted, pushable)) {
+        return makeEmptyValues(node);
+      }
+    }
+
+    PlanObjectSet outputsKept = context.required;
+    outputsKept.unionColumns(blocked);
+    ExprVector survivingExprs;
+    ColumnVector survivingOutputs;
+    survivingExprs.reserve(node->exprs().size());
+    survivingOutputs.reserve(node->outputColumns().size());
+    for (size_t i = 0; i < node->exprs().size(); ++i) {
+      if (outputsKept.contains(node->outputColumns()[i])) {
+        survivingExprs.push_back(node->exprs()[i]);
+        survivingOutputs.push_back(node->outputColumns()[i]);
+      }
+    }
+
+    PushdownContext childContext;
+    childContext.pending = std::move(pushable);
+    childContext.required.unionColumns(survivingExprs);
+    // Demand from above the child excludes the conjuncts pushed into
+    // `pending`; it is exactly what the surviving projections read.
+    childContext.requiredAbove = childContext.required;
+    childContext.required.unionColumns(childContext.pending);
+    childContext.nonNullColumns = context.nonNullColumns;
+    NodeCP newInput = rewrite(node->input(), childContext);
+
+    // Drop the Project when its surviving outputs are a pure pass-through of
+    // the (rewritten) input's output columns. Pushdown can make a Project
+    // identity by pruning columns below it — e.g. a semi-project join fused
+    // to a semi-filter no longer emits the mark this Project dropped. An
+    // empty-output Project is never identity: it eliminates all columns (the
+    // semi-join EXISTS gate), which the input does not guarantee on its own.
+    const ColumnVector& inputColumns = newInput->outputColumns();
+    bool isIdentity{
+        !survivingOutputs.empty() &&
+        survivingOutputs.size() == inputColumns.size()};
+    for (size_t i = 0; isIdentity && i < survivingOutputs.size(); ++i) {
+      isIdentity = survivingOutputs[i] == inputColumns[i] &&
+          survivingExprs[i] == inputColumns[i];
+    }
+
+    NodeCP newProject;
+    if (isIdentity) {
+      newProject = newInput;
+    } else if (
+        newInput == node->input() &&
+        survivingExprs.size() == node->exprs().size()) {
+      newProject = node;
+    } else {
+      newProject = builder().make<Project>(
+          {newInput, std::move(survivingExprs), std::move(survivingOutputs)});
+    }
+    return maybeWrapFilter(newProject, std::move(blocked));
+  }
+
+  // Aggregate: conjuncts referencing only grouping-key outputs push below
+  // (substituted to the grouping-key expressions); conjuncts referencing
+  // any aggregate output stay above as a HAVING-equivalent Filter.
+  //
+  // An aggregate that emits a row on empty input — a global aggregate (no
+  // grouping keys), or one with a global (empty) grouping set — blocks
+  // pushdown entirely: the aggregate manufactures that row regardless of its
+  // input, so a filter pushed below it can't suppress the row it was meant to
+  // remove. A predicate on a key that GroupId NULLs for some set is handled by
+  // the GroupId barrier (see rewriteGroupId), not here.
+  //
+  // Grouping keys stay; dropping one would re-shape the groups.
+  NodeCP rewriteAggregate(const Aggregate* node, PushdownContext& context)
+      override {
+    const bool emitsRowOnEmptyInput =
+        node->groupingKeys().empty() || !node->globalGroupingSets().empty();
+    if (emitsRowOnEmptyInput) {
+      PushdownContext childContext;
+      childContext.required = context.required;
+      childContext.required.unionColumns(context.pending);
+      childContext.required.unionColumns(node->groupingKeys());
+      for (const auto* aggregate : node->aggregates()) {
+        childContext.required.unionColumns(aggregate);
+      }
+      childContext.requiredAbove = childContext.required;
+      childContext.nonNullColumns = context.nonNullColumns;
+      NodeCP newInput = rewrite(node->input(), childContext);
+      NodeCP newAggregate = (newInput == node->input())
+          ? static_cast<NodeCP>(node)
+          : builder().make<Aggregate>(Aggregate::Key{
+                .input = newInput,
+                .groupingKeys = node->groupingKeys(),
+                .aggregates = node->aggregates(),
+                .outputColumns = node->outputColumns(),
+                .step = node->step(),
+                .groupId = node->groupId(),
+                .globalGroupingSets = node->globalGroupingSets()});
+      return maybeWrapFilter(newAggregate, std::move(context.pending));
+    }
+
+    const size_t numKeys = node->groupingKeys().size();
+    ColumnVector groupingKeyOutputs(
+        node->outputColumns().begin(), node->outputColumns().begin() + numKeys);
+    PlanObjectSet aggregateOutputs;
+    for (size_t i = numKeys; i < node->outputColumns().size(); ++i) {
+      aggregateOutputs.add(node->outputColumns()[i]);
+    }
+
+    auto [substitutable, blocked] =
+        partition(context.pending, aggregateOutputs);
+    ExprVector pushable;
+    pushable.reserve(substitutable.size());
+    for (ExprCP conjunct : substitutable) {
+      ExprCP substituted =
+          exprs_.substitute(conjunct, groupingKeyOutputs, node->groupingKeys());
+      if (simplifier_.simplifyFilter(substituted, pushable)) {
+        return makeEmptyValues(node);
+      }
+    }
+
+    PlanObjectSet outputsKept = context.required;
+    outputsKept.unionColumns(blocked);
+    AggregateCallVector survivingAggregates;
+    ColumnVector survivingOutputs(groupingKeyOutputs);
+    survivingAggregates.reserve(node->aggregates().size());
+    survivingOutputs.reserve(node->outputColumns().size());
+    for (size_t i = 0; i < node->aggregates().size(); ++i) {
+      const ColumnCP outputColumn = node->outputColumns()[numKeys + i];
+      if (outputsKept.contains(outputColumn)) {
+        survivingAggregates.push_back(node->aggregates()[i]);
+        survivingOutputs.push_back(outputColumn);
+      }
+    }
+
+    PushdownContext childContext;
+    childContext.pending = std::move(pushable);
+    childContext.required.unionColumns(node->groupingKeys());
+    for (const auto* aggregate : survivingAggregates) {
+      childContext.required.unionColumns(aggregate);
+    }
+    childContext.requiredAbove = childContext.required;
+    childContext.required.unionColumns(childContext.pending);
+    childContext.nonNullColumns = context.nonNullColumns;
+    NodeCP newInput = rewrite(node->input(), childContext);
+
+    const bool unchanged = newInput == node->input() &&
+        survivingAggregates.size() == node->aggregates().size();
+    NodeCP newAggregate = unchanged
+        ? static_cast<NodeCP>(node)
+        : builder().make<Aggregate>(Aggregate::Key{
+              .input = newInput,
+              .groupingKeys = node->groupingKeys(),
+              .aggregates = std::move(survivingAggregates),
+              .outputColumns = std::move(survivingOutputs),
+              .step = node->step(),
+              .groupId = node->groupId(),
+              .globalGroupingSets = node->globalGroupingSets()});
+    return maybeWrapFilter(newAggregate, std::move(blocked));
+  }
+
+  // Join: demote outer to inner when possible, then route each pending
+  // conjunct to one of: left input, right input, join filter, or
+  // stay-above.
+  NodeCP rewriteJoin(const Join* node, PushdownContext& context) override {
+    PlanObjectSet leftColumns =
+        PlanObjectSet::fromObjects(node->left()->outputColumns());
+    PlanObjectSet rightColumns =
+        PlanObjectSet::fromObjects(node->right()->outputColumns());
+
+    // Fuse a consuming mark filter on a kLeftSemiProject into a filtering
+    // kLeftSemiFilter / kAnti, dropping the mark. kLeftSemiFilter is never
+    // null-aware; kAnti carries the node's flag (true for NOT IN).
+    ColumnCP fusedMark{nullptr};
+    bool fusedNullAware{false};
+    velox::core::JoinType newKind;
+    if (auto fusion =
+            fuseMarkFilter(node, context.pending, context.requiredAbove)) {
+      newKind = fusion->joinType;
+      fusedMark = node->outputColumns().back();
+      fusedNullAware =
+          newKind == velox::core::JoinType::kAnti && node->nullAware();
+      ExprVector remaining;
+      remaining.reserve(context.pending.size() - 1);
+      for (ExprCP conjunct : context.pending) {
+        if (conjunct != fusion->conjunct) {
+          remaining.push_back(conjunct);
+        }
+      }
+      context.pending = std::move(remaining);
+    } else {
+      newKind = demoteOuterToInner(
+          node->joinType(),
+          context.pending,
+          context.nonNullColumns,
+          leftColumns,
+          rightColumns);
+    }
+
+    // Inner-join equi-key pairs let pending conjuncts cross to the
+    // other side. If derivation produces a literal-false conjunct, the
+    // join can't yield any rows.
+    if (newKind == velox::core::JoinType::kInner) {
+      if (deriveTransitive(node, leftColumns, rightColumns, context.pending)) {
+        return makeEmptyValues(node);
+      }
+    }
+
+    ExprVector leftPending;
+    ExprVector rightPending;
+    ExprVector inFilter;
+    ExprVector above;
+    for (ExprCP conjunct : context.pending) {
+      const auto& columns = conjunct->columns();
+      // Pushable to a side only if every referenced column lives on
+      // that side's input. The `!empty()` guard excludes constant
+      // predicates — `isSubset` is vacuously true on an empty set, so
+      // without it a constant would push to both sides.
+      const bool leftOnly = !columns.empty() && columns.isSubset(leftColumns);
+      const bool rightOnly = !columns.empty() && columns.isSubset(rightColumns);
+
+      if (canPushLeft(newKind, leftOnly)) {
+        leftPending.push_back(conjunct);
+      } else if (canPushRight(newKind, rightOnly)) {
+        rightPending.push_back(conjunct);
+      } else if (newKind == velox::core::JoinType::kInner) {
+        inFilter.push_back(conjunct);
+      } else {
+        above.push_back(conjunct);
+      }
+    }
+    context.pending.clear();
+
+    // Redistribute the join's own match conjuncts: a conjunct referencing
+    // only one input moves into that input when sound for the kind (see
+    // joinFilterTarget); the rest stay as the join filter.
+    ExprVector keptFilter;
+    keptFilter.reserve(node->filter().size());
+    for (ExprCP conjunct : node->filter()) {
+      const auto& columns = conjunct->columns();
+      const bool leftOnly = !columns.empty() && columns.isSubset(leftColumns);
+      const bool rightOnly = !columns.empty() && columns.isSubset(rightColumns);
+      switch (joinFilterTarget(newKind, leftOnly, rightOnly)) {
+        case FilterTarget::kLeft:
+          leftPending.push_back(conjunct);
+          break;
+        case FilterTarget::kRight:
+          rightPending.push_back(conjunct);
+          break;
+        case FilterTarget::kKeep:
+          keptFilter.push_back(conjunct);
+          break;
+      }
+    }
+
+    // An OR conjunct spanning both sides yields per-side derived
+    // pre-filters; the original OR stays on the join. Push a derived
+    // filter only to the non-preserved side: pushing into the
+    // preserved side would drop rows that should be NULL-padded.
+    const bool pushLeftSide = newKind == velox::core::JoinType::kInner ||
+        newKind == velox::core::JoinType::kRight;
+    const bool pushRightSide = newKind == velox::core::JoinType::kInner ||
+        newKind == velox::core::JoinType::kLeft;
+    if (pushLeftSide || pushRightSide) {
+      ExprFactory factory(builder());
+      auto deriveAndPush = [&](ExprCP conjunct) {
+        auto [leftSide, rightSide] = deriveSideFiltersFromOr(
+            conjunct, leftColumns, rightColumns, factory);
+        if (pushLeftSide && leftSide != nullptr) {
+          leftPending.push_back(leftSide);
+        }
+        if (pushRightSide && rightSide != nullptr) {
+          rightPending.push_back(rightSide);
+        }
+      };
+      for (ExprCP conjunct : keptFilter) {
+        deriveAndPush(conjunct);
+      }
+      for (ExprCP conjunct : inFilter) {
+        deriveAndPush(conjunct);
+      }
+    }
+
+    ExprVector newLeftKeys = node->leftKeys();
+    ExprVector newRightKeys = node->rightKeys();
+    if (!inFilter.empty()) {
+      JoinCondition::Split split =
+          JoinCondition::splitEquiKeys(inFilter, leftColumns, rightColumns);
+      appendAll(newLeftKeys, split.leftKeys);
+      appendAll(newRightKeys, split.rightKeys);
+      inFilter = std::move(split.residual);
+    }
+
+    ExprVector newFilter = std::move(keptFilter);
+    appendAll(newFilter, inFilter);
+
+    // The join's own output is what consumers above demand plus columns
+    // read by a Filter fused above it; keys and filter columns are
+    // demanded of the children via `sideRequired`.
+    PlanObjectSet outputsKept = context.requiredAbove;
+    outputsKept.unionColumns(above);
+    ColumnVector newOutputColumns;
+    newOutputColumns.reserve(node->outputColumns().size());
+    for (ColumnCP column : node->outputColumns()) {
+      // Drop the fused mark: its only consumer was the conjunct that just
+      // became the filtering join's semantics.
+      if (column != fusedMark && outputsKept.contains(column)) {
+        newOutputColumns.push_back(column);
+      }
+    }
+
+    PlanObjectSet sideRequired = PlanObjectSet::fromObjects(newOutputColumns);
+    sideRequired.unionColumns(newLeftKeys);
+    sideRequired.unionColumns(newRightKeys);
+    sideRequired.unionColumns(newFilter);
+
+    // For inner joins, expose columns proven non-NULL by this
+    // join's equi-keys as hints to descendants so a deeper outer
+    // can be demoted. A key side contributes its columns only when
+    // its expression has default null behavior — otherwise null
+    // values can leak through it.
+    PlanObjectSet childNonNullColumns = context.nonNullColumns;
+    if (newKind == velox::core::JoinType::kInner) {
+      auto addIfDefaultNull = [&](ExprCP key) {
+        if (!key->functions().contains(FunctionSet::kNonDefaultNullBehavior)) {
+          childNonNullColumns.unionColumns(key);
+        }
+      };
+      for (size_t i = 0; i < newLeftKeys.size(); ++i) {
+        addIfDefaultNull(newLeftKeys[i]);
+        addIfDefaultNull(newRightKeys[i]);
+      }
+    }
+
+    PushdownContext leftContext;
+    leftContext.pending = std::move(leftPending);
+    leftContext.required = sideRequired;
+    // Demand from above each side excludes the conjuncts pushed into that
+    // side's `pending`; it is exactly `sideRequired` (this join's kept
+    // outputs, keys, and filter columns).
+    leftContext.requiredAbove = sideRequired;
+    leftContext.required.unionColumns(leftContext.pending);
+    leftContext.nonNullColumns = childNonNullColumns;
+    PushdownContext rightContext;
+    rightContext.pending = std::move(rightPending);
+    rightContext.required = sideRequired;
+    rightContext.requiredAbove = sideRequired;
+    rightContext.required.unionColumns(rightContext.pending);
+    rightContext.nonNullColumns = std::move(childNonNullColumns);
+
+    NodeCP newLeft = rewrite(node->left(), leftContext);
+    NodeCP newRight = rewrite(node->right(), rightContext);
+
+    NodeCP newJoin = (newLeft == node->left() && newRight == node->right() &&
+                      newFilter.size() == node->filter().size() &&
+                      newKind == node->joinType() &&
+                      newLeftKeys.size() == node->leftKeys().size() &&
+                      newOutputColumns.size() == node->outputColumns().size())
+        ? static_cast<NodeCP>(node)
+        : builder().make<Join>(
+              {newLeft,
+               newRight,
+               newKind,
+               std::move(newLeftKeys),
+               std::move(newRightKeys),
+               std::move(newFilter),
+               fusedMark != nullptr ? fusedNullAware : node->nullAware(),
+               node->nullAsValue(),
+               std::move(newOutputColumns)});
+    return maybeWrapFilter(newJoin, std::move(above));
+  }
+
+  // Scan: append pending conjuncts to `Scan.filters`; Emit decides
+  // what the connector absorbs. `outputColumns` is the strict consumer-
+  // required set; Emit folds in any columns referenced by retained
+  // filters and projects them away above the scan.
+  NodeCP rewriteScan(const Scan* node, PushdownContext& context) override {
+    ExprVector mergedFilters = node->filters();
+    appendAll(mergedFilters, context.pending);
+    context.pending.clear();
+
+    ColumnVector survivingOutputs;
+    survivingOutputs.reserve(node->outputColumns().size());
+    for (ColumnCP column : node->outputColumns()) {
+      if (context.requiredAbove.contains(column)) {
+        survivingOutputs.push_back(column);
+      }
+    }
+
+    const bool unchanged = mergedFilters.size() == node->filters().size() &&
+        survivingOutputs.size() == node->outputColumns().size();
+    if (unchanged) {
+      return node;
+    }
+    return builder().make<Scan>(
+        {node->baseTable(),
+         std::move(survivingOutputs),
+         std::move(mergedFilters)});
+  }
+
+  NodeCP rewriteValues(const Values* node, PushdownContext& context) override {
+    return maybeWrapFilter(node, std::move(context.pending));
+  }
+
+  // Internal nodes — recurse with empty pending via `blockAt`:
+  NodeCP rewriteLimit(const Limit* node, PushdownContext& context) override {
+    return blockAt(context, [&](PushdownContext& empty) {
+      return NodeRewriter::rewriteLimit(node, empty);
+    });
+  }
+
+  // Sort: pending passes through unchanged — order has no row-set
+  // effect. The sort keys must survive in the child's outputs.
+  NodeCP rewriteSort(const Sort* node, PushdownContext& context) override {
+    context.required.unionColumns(node->orderKeys());
+    context.requiredAbove.unionColumns(node->orderKeys());
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder().make<Sort>(
+        {newInput, node->orderKeys(), node->orderTypes()});
+  }
+
+  // TopN: a filter barrier like Limit (its bound depends on the row set), and
+  // its order keys must survive in the child like Sort.
+  NodeCP rewriteTopN(const TopN* node, PushdownContext& context) override {
+    return blockAt(context, [&](PushdownContext& empty) {
+      empty.required.unionColumns(node->orderKeys());
+      empty.requiredAbove.unionColumns(node->orderKeys());
+      return NodeRewriter::rewriteTopN(node, empty);
+    });
+  }
+
+  // GroupId is a barrier: a conjunct on a key GroupId NULLs for some set can't
+  // push below it. The input must supply the key expressions GroupId replicates
+  // on and the columns the aggregates read (passed through).
+  NodeCP rewriteGroupId(const GroupId* node, PushdownContext& context)
+      override {
+    return blockAt(context, [&](PushdownContext& empty) {
+      empty.required.unionColumns(node->groupingKeys());
+      empty.required.unionColumns(node->aggregationInputs());
+      empty.requiredAbove.unionColumns(node->groupingKeys());
+      empty.requiredAbove.unionColumns(node->aggregationInputs());
+      return NodeRewriter::rewriteGroupId(node, empty);
+    });
+  }
+
+  // MarkDistinct: conjuncts referencing only input columns push below.
+  // Conjuncts referencing any output marker stay above — the marker
+  // depends on the full input set, so pre-filtering changes which rows
+  // get marked.
+  NodeCP rewriteMarkDistinct(const MarkDistinct* node, PushdownContext& context)
+      override {
+    const PlanObjectSet markers = PlanObjectSet::fromObjects(node->markers());
+    auto [pushable, blocked] = partition(context.pending, markers);
+    // Drop the whole MarkDistinct when no consumer reads any marker.
+    // Partial-drop is unsafe: the constructor pairs markers with masks
+    // and requires the pairing.
+    PlanObjectSet markersKept = context.required;
+    markersKept.unionColumns(blocked);
+    bool anyMarkerNeeded = false;
+    for (ColumnCP marker : node->markers()) {
+      if (markersKept.contains(marker)) {
+        anyMarkerNeeded = true;
+        break;
+      }
+    }
+    PushdownContext childContext =
+        makeChildContext(std::move(pushable), context);
+    childContext.required.unionColumns(blocked);
+    if (!anyMarkerNeeded) {
+      childContext.requiredAbove = childContext.required;
+      NodeCP newInput = rewrite(node->input(), childContext);
+      return maybeWrapFilter(newInput, std::move(blocked));
+    }
+    childContext.required.unionColumns(node->distinctKeys());
+    childContext.required.unionObjects(node->masks());
+    childContext.requiredAbove = childContext.required;
+    NodeCP newInput = rewrite(node->input(), childContext);
+    NodeCP newNode = (newInput == node->input()) ? static_cast<NodeCP>(node)
+                                                 : builder().make<MarkDistinct>(
+                                                       {newInput,
+                                                        node->markers(),
+                                                        node->distinctKeys(),
+                                                        node->masks(),
+                                                        node->outputColumns()});
+    return maybeWrapFilter(newNode, std::move(blocked));
+  }
+
+  // Unnest: conjuncts referencing only replicated (pre-unnest) columns
+  // push below. Conjuncts that touch any unnest-produced column or the
+  // ordinality column stay above — those don't exist on the input.
+  NodeCP rewriteUnnest(const Unnest* node, PushdownContext& context) override {
+    PlanObjectSet outputOnlyColumns;
+    for (const ColumnVector& perExpression : node->unnestColumns()) {
+      outputOnlyColumns.unionObjects(perExpression);
+    }
+    if (node->ordinalityColumn() != nullptr) {
+      outputOnlyColumns.add(node->ordinalityColumn());
+    }
+    auto [pushable, blocked] = partition(context.pending, outputOnlyColumns);
+    PushdownContext childContext =
+        makeChildContext(std::move(pushable), context);
+    childContext.required.unionColumns(node->unnestExpressions());
+    childContext.required.unionObjects(node->replicatedColumns());
+    childContext.required.unionColumns(blocked);
+    childContext.requiredAbove = childContext.required;
+    NodeCP newInput = rewrite(node->input(), childContext);
+
+    // Unnest accepts a subset of structured-field outputs as
+    // `outputColumns`; drop entries the consumer doesn't need.
+    PlanObjectSet outputsKept = context.required;
+    outputsKept.unionColumns(blocked);
+    ColumnVector survivingOutputs;
+    survivingOutputs.reserve(node->outputColumns().size());
+    for (ColumnCP column : node->outputColumns()) {
+      if (outputsKept.contains(column)) {
+        survivingOutputs.push_back(column);
+      }
+    }
+
+    // TODO: Trim `replicatedColumns` against `outputsKept` to drop dead
+    // passthrough columns when the input carries more than the consumer needs.
+    const bool unchanged = newInput == node->input() &&
+        survivingOutputs.size() == node->outputColumns().size();
+    NodeCP newNode = unchanged ? static_cast<NodeCP>(node)
+                               : builder().make<Unnest>(
+                                     {newInput,
+                                      node->unnestExpressions(),
+                                      node->replicatedColumns(),
+                                      node->unnestColumns(),
+                                      node->ordinalityColumn(),
+                                      std::move(survivingOutputs)});
+    return maybeWrapFilter(newNode, std::move(blocked));
+  }
+
+  // UnionAll: each leg receives the same conjuncts rewritten in terms
+  // of that leg's input columns.
+  NodeCP rewriteUnionAll(const UnionAll* node, PushdownContext& context)
+      override {
+    // Positions to keep: outputColumns[i] required by the consumer.
+    std::vector<size_t> keptPositions;
+    keptPositions.reserve(node->outputColumns().size());
+    for (size_t i = 0; i < node->outputColumns().size(); ++i) {
+      if (context.required.contains(node->outputColumns()[i])) {
+        keptPositions.push_back(i);
+      }
+    }
+    ColumnVector newOutputColumns;
+    newOutputColumns.reserve(keptPositions.size());
+    for (size_t i : keptPositions) {
+      newOutputColumns.push_back(node->outputColumns()[i]);
+    }
+
+    NodeVector newInputs;
+    newInputs.reserve(node->inputs().size());
+    QGVector<ColumnVector> newLegColumns;
+    newLegColumns.reserve(node->inputs().size());
+    bool changed = keptPositions.size() != node->outputColumns().size();
+    for (size_t legIndex = 0; legIndex < node->inputs().size(); ++legIndex) {
+      const ColumnVector& legColumns = node->legColumns()[legIndex];
+      const ExprVector legAsExprs(legColumns.begin(), legColumns.end());
+      ExprVector legPending =
+          exprs_.substitute(context.pending, node->outputColumns(), legAsExprs);
+      ColumnVector newLegCols;
+      newLegCols.reserve(keptPositions.size());
+      for (size_t i : keptPositions) {
+        newLegCols.push_back(legColumns[i]);
+      }
+      newLegColumns.push_back(newLegCols);
+
+      PushdownContext legContext;
+      legContext.pending = std::move(legPending);
+      legContext.required.unionObjects(newLegCols);
+      legContext.required.unionColumns(legContext.pending);
+      legContext.requiredAbove = legContext.required;
+      legContext.nonNullColumns = context.nonNullColumns;
+      NodeCP newLeg = rewrite(node->inputs()[legIndex], legContext);
+      changed |= (newLeg != node->inputs()[legIndex]);
+      newInputs.push_back(newLeg);
+    }
+    context.pending.clear();
+    if (!changed) {
+      return node;
+    }
+    return builder().make<UnionAll>(
+        {std::move(newInputs),
+         std::move(newLegColumns),
+         std::move(newOutputColumns)});
+  }
+
+  // Window: conjuncts whose columns are all direct partition-key
+  // columns push below — within a partition those values are
+  // constant, so pre/post-filter are equivalent. All others stay
+  // above.
+  NodeCP rewriteWindow(const Window* node, PushdownContext& context) override {
+    // A `rankColumn <op> n` predicate over a single ranking function fuses the
+    // Window into a TopNRowNumber, consuming that predicate.
+    const std::optional<RankFusion> fusion =
+        detectRankFusion(node, context.pending, builder().functionNames());
+
+    PlanObjectSet partitionKeyColumns;
+    for (ExprCP key : node->partitionKeys()) {
+      if (key->is(PlanType::kColumnExpr)) {
+        partitionKeyColumns.add(key->as<Column>());
+      }
+    }
+
+    // Conjuncts referencing only partition keys push below; the rest stay above
+    // (or, for the fused ranking predicate, are consumed).
+    ExprVector pushable;
+    ExprVector blocked;
+    for (ExprCP conjunct : context.pending) {
+      if (fusion && conjunct == fusion->predicate) {
+        continue;
+      }
+      const auto& columns = conjunct->columns();
+      // Exclude constant predicates: `isSubset` is vacuously true on an
+      // empty set, so without `!empty()` a constant would push.
+      if (!columns.empty() && columns.isSubset(partitionKeyColumns)) {
+        pushable.push_back(conjunct);
+      } else {
+        blocked.push_back(conjunct);
+      }
+    }
+
+    PlanObjectSet outputsKept = context.required;
+    outputsKept.unionColumns(blocked);
+    const size_t numInputCols = node->input()->outputColumns().size();
+
+    PushdownContext childContext;
+    childContext.pending = std::move(pushable);
+    childContext.required = context.required;
+    childContext.required.unionColumns(node->partitionKeys());
+    childContext.required.unionColumns(node->orderKeys());
+    // Window/TopNRowNumber emit every input column; the child must keep
+    // producing them all.
+    childContext.required.unionObjects(node->input()->outputColumns());
+    childContext.required.unionColumns(blocked);
+    childContext.nonNullColumns = context.nonNullColumns;
+
+    if (fusion) {
+      childContext.required.unionColumns(childContext.pending);
+      childContext.requiredAbove = childContext.required;
+      NodeCP newInput = rewrite(node->input(), childContext);
+      // Emit the rank column only when a consumer above still needs it.
+      const ColumnCP rankColumn = outputsKept.contains(fusion->rankColumn)
+          ? fusion->rankColumn
+          : nullptr;
+      ColumnVector newOutputColumns;
+      appendAll(newOutputColumns, newInput->outputColumns());
+      if (rankColumn != nullptr) {
+        newOutputColumns.push_back(rankColumn);
+      }
+      NodeCP topN = builder().make<TopNRowNumber>(
+          {newInput,
+           fusion->rankFunction,
+           node->partitionKeys(),
+           node->orderKeys(),
+           node->orderTypes(),
+           fusion->limit,
+           rankColumn,
+           std::move(newOutputColumns)});
+      return maybeWrapFilter(topN, std::move(blocked));
+    }
+
+    WindowFunctions survivingFunctions;
+    ColumnVector survivingFunctionOutputs;
+    for (size_t i = 0; i < node->functions().size(); ++i) {
+      const ColumnCP funcOutput = node->outputColumns()[numInputCols + i];
+      if (outputsKept.contains(funcOutput)) {
+        survivingFunctions.push_back(node->functions()[i]);
+        survivingFunctionOutputs.push_back(funcOutput);
+      }
+    }
+    for (const auto& function : survivingFunctions) {
+      childContext.required.unionColumns(function.call);
+    }
+    childContext.required.unionColumns(childContext.pending);
+    childContext.requiredAbove = childContext.required;
+    NodeCP newInput = rewrite(node->input(), childContext);
+
+    ColumnVector newOutputColumns;
+    newOutputColumns.reserve(numInputCols + survivingFunctions.size());
+    appendAll(newOutputColumns, newInput->outputColumns());
+    appendAll(newOutputColumns, survivingFunctionOutputs);
+
+    const bool unchanged = newInput == node->input() &&
+        survivingFunctions.size() == node->functions().size();
+    NodeCP newWindow = unchanged ? static_cast<NodeCP>(node)
+                                 : builder().make<Window>(
+                                       {newInput,
+                                        std::move(survivingFunctions),
+                                        node->partitionKeys(),
+                                        node->orderKeys(),
+                                        node->orderTypes(),
+                                        std::move(newOutputColumns)});
+    return maybeWrapFilter(newWindow, std::move(blocked));
+  }
+
+  NodeCP rewriteApply(const Apply* /*node*/, PushdownContext& /*context*/)
+      override {
+    VELOX_FAIL("Apply must be removed by decorrelate before pushdown");
+  }
+
+  NodeCP rewriteEnforceSingleRow(
+      const EnforceSingleRow* node,
+      PushdownContext& context) override {
+    return blockAt(context, [&](PushdownContext& empty) {
+      return NodeRewriter::rewriteEnforceSingleRow(node, empty);
+    });
+  }
+
+  // AssignUniqueId: conjuncts on input columns push freely — the id
+  // sequence regenerates over the surviving rows. Conjuncts on the id
+  // column stay above. If no consumer reads the id, drop the node.
+  NodeCP rewriteAssignUniqueId(
+      const AssignUniqueId* node,
+      PushdownContext& context) override {
+    const PlanObjectSet idColumn = PlanObjectSet::single(node->idColumn());
+    auto [pushable, blocked] = partition(context.pending, idColumn);
+    PlanObjectSet outputsKept = context.required;
+    outputsKept.unionColumns(blocked);
+
+    PushdownContext childContext =
+        makeChildContext(std::move(pushable), context);
+    childContext.required.unionColumns(blocked);
+    childContext.requiredAbove = childContext.required;
+    if (!outputsKept.contains(node->idColumn())) {
+      NodeCP newInput = rewrite(node->input(), childContext);
+      return maybeWrapFilter(newInput, std::move(blocked));
+    }
+
+    NodeCP newInput = rewrite(node->input(), childContext);
+    NodeCP newNode = (newInput == node->input())
+        ? static_cast<NodeCP>(node)
+        : builder().make<AssignUniqueId>({newInput, node->idColumn()});
+    return maybeWrapFilter(newNode, std::move(blocked));
+  }
+
+  NodeCP rewriteEnforceDistinct(
+      const EnforceDistinct* node,
+      PushdownContext& context) override {
+    PushdownContext childContext;
+    childContext.required = context.required;
+    childContext.required.unionColumns(context.pending);
+    childContext.required.unionColumns(node->distinctKeys());
+    childContext.requiredAbove = childContext.required;
+    childContext.nonNullColumns = context.nonNullColumns;
+    NodeCP newInput = rewrite(node->input(), childContext);
+    NodeCP newNode = (newInput == node->input())
+        ? static_cast<NodeCP>(node)
+        : builder().make<EnforceDistinct>(
+              {newInput, node->distinctKeys(), node->errorMessage()});
+    return maybeWrapFilter(newNode, std::move(context.pending));
+  }
+
+  // A write is the plan root: nothing consumes its row-count output, so the
+  // only demand on its input is the columns the write's value expressions read.
+  // Recurse with exactly those required, or the input scan gets pruned to
+  // nothing. There is no pending predicate to route — a root carries none.
+  NodeCP rewriteTableWrite(const TableWrite* node, PushdownContext& context)
+      override {
+    VELOX_DCHECK(context.pending.empty());
+    PushdownContext child;
+    child.required.unionColumns(node->columnExprs());
+    child.requiredAbove = child.required;
+    child.nonNullColumns = context.nonNullColumns;
+    return NodeRewriter::rewriteTableWrite(node, child);
+  }
+
+ private:
+  // Builds a child `PushdownContext` whose required column set is
+  // `parent.required` plus the columns referenced by any conjunct in
+  // `pending`. Callers augment the result with the node's own column
+  // reads before recursing.
+  PushdownContext makeChildContext(
+      ExprVector pending,
+      const PushdownContext& parent) {
+    PushdownContext child;
+    child.pending = std::move(pending);
+    child.required = parent.required;
+    child.required.unionColumns(child.pending);
+    // Conservative: callers that push a fusable mark down refine this.
+    child.requiredAbove = parent.required;
+    child.nonNullColumns = parent.nonNullColumns;
+    return child;
+  }
+
+  // Invokes `recurse` with an empty-pending context — letting the
+  // subtree rewrite under its own clean pending state, while still
+  // propagating `required` — then wraps the caller's `context.pending`
+  // as a Filter above the recursed result.
+  template <typename Recurse>
+  NodeCP blockAt(PushdownContext& context, Recurse recurse) {
+    PushdownContext empty;
+    empty.required = context.required;
+    empty.required.unionColumns(context.pending);
+    // Blocked conjuncts wrap as a Filter above the recursed subtree, so
+    // everything is "above" it.
+    empty.requiredAbove = empty.required;
+    empty.nonNullColumns = context.nonNullColumns;
+    NodeCP recursed = recurse(empty);
+    return maybeWrapFilter(recursed, std::move(context.pending));
+  }
+
+  // Routes each pending conjunct to either the input (pushable) or a
+  // Filter above the rebuilt node (blocked), based on whether the
+  // conjunct touches any column in `outputOnlyColumns` — the set of
+  // columns the node produces that don't exist on its input. `rebuild`
+  // builds a new node from a rewritten input. Child required carries
+  // every input-side column read by blocked conjuncts or pushable.
+  template <typename SingleInputNode, typename Rebuild>
+  NodeCP splitOnOutputColumns(
+      const SingleInputNode* node,
+      const PushdownContext& parent,
+      const PlanObjectSet& outputOnlyColumns,
+      Rebuild rebuild) {
+    auto [pushable, blocked] = partition(parent.pending, outputOnlyColumns);
+    PushdownContext childContext =
+        makeChildContext(std::move(pushable), parent);
+    childContext.required.unionColumns(blocked);
+    childContext.requiredAbove = childContext.required;
+    NodeCP newInput = rewrite(node->input(), childContext);
+    NodeCP newNode = (newInput == node->input()) ? static_cast<NodeCP>(node)
+                                                 : rebuild(newInput);
+    return maybeWrapFilter(newNode, std::move(blocked));
+  }
+
+  NodeCP maybeWrapFilter(NodeCP body, ExprVector conjuncts) {
+    if (conjuncts.empty()) {
+      return body;
+    }
+    return builder().make<Filter>({body, std::move(conjuncts)});
+  }
+
+  // Builds an empty `Values` node with the same output schema as `node`.
+  // Used to short-circuit a subtree when pushdown discovers a predicate
+  // that folds to literal `false`.
+  NodeCP makeEmptyValues(NodeCP node) {
+    return builder().makeEmptyValues(node->outputColumns());
+  }
+
+  // Derives new pending conjuncts via each cross-side
+  // `Column == Column` equi-pair: a conjunct that references one side
+  // gets duplicated with that side's column substituted for the other
+  // side's equivalent column, exposing a push to the other side.
+  // Returns true if any derived conjunct simplifies to literal `false`,
+  // signalling the caller to short-circuit the join to an empty result.
+  bool deriveTransitive(
+      JoinCP node,
+      const PlanObjectSet& leftColumns,
+      const PlanObjectSet& rightColumns,
+      ExprVector& pending) {
+    auto [leftKeys, rightKeys] =
+        collectEquiColumnPairs(node, leftColumns, rightColumns);
+    if (leftKeys.empty()) {
+      return false;
+    }
+
+    const ExprVector leftAsExprs(leftKeys.begin(), leftKeys.end());
+    const ExprVector rightAsExprs(rightKeys.begin(), rightKeys.end());
+
+    ExprVector derived;
+    for (ExprCP conjunct : pending) {
+      ExprCP leftSubstituted =
+          exprs_.substitute(conjunct, rightKeys, leftAsExprs);
+      if (leftSubstituted != conjunct &&
+          simplifier_.simplifyFilter(leftSubstituted, derived)) {
+        return true;
+      }
+      ExprCP rightSubstituted =
+          exprs_.substitute(conjunct, leftKeys, rightAsExprs);
+      if (rightSubstituted != conjunct &&
+          simplifier_.simplifyFilter(rightSubstituted, derived)) {
+        return true;
+      }
+    }
+    appendAll(pending, derived);
+    return false;
+  }
+
+  ExprFactory exprs_;
+  ExprSimplifier simplifier_;
+};
+
+} // namespace
+
+NodeCP PushdownAndPrunePass::run(
+    NodeCP root,
+    Builder& builder,
+    velox::core::ExpressionEvaluator& evaluator) {
+  Pushdown pass{builder, evaluator};
+  PushdownContext context;
+  context.required = PlanObjectSet::fromObjects(root->outputColumns());
+  context.requiredAbove = context.required;
+  return pass.rewrite(root, context);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/PushdownAndPrunePass.h
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "velox/core/ExpressionEvaluator.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Single top-down pass over the tree IR that does two intertwined jobs in one
+/// traversal:
+///
+///  - Filter pushdown. Each `Filter`'s conjuncts are flattened into a `pending`
+///    set carried down the tree. At every node, conjuncts the node's rule
+///    allows continue downward; a conjunct that cannot pass is re-emitted as a
+///    `Filter` immediately above that node. Input `Filter` nodes thus dissolve
+///    and reappear as low as each conjunct can legally go.
+///  - Column pruning. A `required` column set is carried down from `root`'s
+///    output schema. Each node narrows its `outputColumns` to what consumers
+///    above still read, and drops the projections, aggregates, window
+///    functions, and union legs that produce only unused columns.
+///
+/// Both jobs share one traversal state (the internal `PushdownContext`):
+/// `pending` conjuncts, the `required` / `requiredAbove` column sets, and
+/// `nonNullColumns` (columns an ancestor inner join proves non-NULL).
+///
+/// Notable per-node behavior:
+///  - Join places each conjunct on the left input, the right input, or the
+///    join itself, and demotes an outer join to inner (or full to left/right)
+///    when a pending conjunct or a proven-non-NULL column rejects nulls on a
+///    padded side. It also fuses a consuming mark filter into a
+///    `kLeftSemiProject` join.
+///  - Window pushes conjuncts that reference only partition keys below the
+///    window (the rest stay above), prunes window functions no consumer reads,
+///    and fuses a `rankColumn <op> n` bound over a single ranking function
+///    (row_number / rank / dense_rank) into a `TopNRowNumber`, consuming that
+///    predicate.
+///  - `Apply` must already be gone: decorrelate removes every `Apply` before
+///    this pass, so encountering one is a logic error.
+class PushdownAndPrunePass {
+ public:
+  /// Returns `root` rewritten as described in the class doc. `evaluator` backs
+  /// the expression simplifier used to fold conjuncts after substitution (and
+  /// to detect ones that reduce to constant `false`).
+  static NodeCP run(
+      NodeCP root,
+      Builder& builder,
+      velox::core::ExpressionEvaluator& evaluator);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Relation.h
+++ b/axiom/optimizer/v2/Relation.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <utility>
+
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/RelationSet.h"
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// An atomic join input identified by `id`, wrapping a tree IR node
+/// whose rows feed the join.
+///
+/// Kinds of nodes:
+///   - Scan, Values: leaf nodes with no inputs.
+///   - Unnest: a deferred operator registered as its own relation;
+///     the cross-join-unnest edge built by `HypergraphBuilder`
+///     supplies connectivity to the relations whose subtree feeds
+///     the Unnest's input.
+///   - Root of an already-planned subtree past a barrier (Sort,
+///     Limit, Window, ...).
+///
+/// Invariants:
+///   - `id` in `[0, RelationSet::kMaxRelations)`.
+///   - `node` is non-null.
+class Relation {
+ public:
+  Relation(
+      int8_t id,
+      NodeCP node,
+      std::optional<float> cardinality,
+      PlanObjectSet columns)
+      : id_{id},
+        node_{node},
+        cardinality_{cardinality},
+        columns_{std::move(columns)} {
+    VELOX_CHECK_GE(id_, 0);
+    VELOX_CHECK_LT(id_, RelationSet::kMaxRelations);
+
+    VELOX_CHECK_NOT_NULL(node_);
+  }
+
+  int8_t id() const {
+    return id_;
+  }
+
+  NodeCP node() const {
+    return node_;
+  }
+
+  /// Estimated row count, or nullopt when unknown.
+  std::optional<float> cardinality() const {
+    return cardinality_;
+  }
+
+  const PlanObjectSet& columns() const {
+    return columns_;
+  }
+
+ private:
+  int8_t id_;
+  NodeCP node_;
+  std::optional<float> cardinality_;
+  PlanObjectSet columns_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/RelationSet.h
+++ b/axiom/optimizer/v2/RelationSet.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <bit>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Fixed-capacity set of small integer ids backed by a single
+/// 64-bit word. Used to identify subsets of a join cluster's
+/// relations during cost-based join enumeration.
+///
+/// Invariant: every id passed to `add`, `erase`, or `contains`
+/// must be in `[0, kMaxRelations)`. Violations are checked under
+/// `VELOX_DCHECK`.
+class RelationSet {
+ public:
+  /// Upper bound on representable ids (exclusive).
+  static constexpr int32_t kMaxRelations = 64;
+
+  RelationSet() = default;
+
+  /// Constructs a set from a raw word; bit `i` set means id `i` is
+  /// a member.
+  explicit constexpr RelationSet(uint64_t bits) : bits_{bits} {}
+
+  /// Returns a set containing only `id`.
+  static RelationSet singleton(int32_t id) {
+    RelationSet result;
+    result.add(id);
+    return result;
+  }
+
+  /// Returns the set of all ids up to and including `id`:
+  /// `{0, 1, ..., id}`.
+  static RelationSet prefixThrough(int32_t id) {
+    VELOX_DCHECK_GE(id, 0);
+    VELOX_DCHECK_LT(id, kMaxRelations);
+    if (id == kMaxRelations - 1) {
+      return RelationSet{~uint64_t{0}};
+    }
+    return RelationSet{(uint64_t{1} << (id + 1)) - 1};
+  }
+
+  bool contains(int32_t id) const {
+    return (bits_ & mask(id)) != 0;
+  }
+
+  void add(int32_t id) {
+    bits_ |= mask(id);
+  }
+
+  void erase(int32_t id) {
+    bits_ &= ~mask(id);
+  }
+
+  bool operator==(const RelationSet& other) const = default;
+
+  size_t hash() const {
+    return std::hash<uint64_t>{}(bits_);
+  }
+
+  bool empty() const {
+    return bits_ == 0;
+  }
+
+  void clear() {
+    bits_ = 0;
+  }
+
+  /// True if 'this' ⊆ 'super'.
+  bool isSubset(const RelationSet& super) const {
+    return (bits_ & ~super.bits_) == 0;
+  }
+
+  /// True if 'this' and 'other' share at least one id.
+  bool hasIntersection(const RelationSet& other) const {
+    return (bits_ & other.bits_) != 0;
+  }
+
+  /// Erases all ids not in 'other'.
+  void intersect(const RelationSet& other) {
+    bits_ &= other.bits_;
+  }
+
+  /// Adds all ids in 'other'.
+  void unionSet(const RelationSet& other) {
+    bits_ |= other.bits_;
+  }
+
+  /// Erases all ids present in 'other'.
+  void except(const RelationSet& other) {
+    bits_ &= ~other.bits_;
+  }
+
+  size_t size() const {
+    return std::popcount(bits_);
+  }
+
+  /// Returns the smallest id in the set. The set must be non-empty.
+  int32_t min() const {
+    VELOX_DCHECK(!empty());
+    return std::countr_zero(bits_);
+  }
+
+  /// Calls 'f(id)' for each set bit, in ascending id order.
+  template <typename Func>
+  void forEach(Func f) const {
+    uint64_t remaining{bits_};
+    while (remaining != 0) {
+      const int32_t id = std::countr_zero(remaining);
+      f(id);
+      remaining &= remaining - 1;
+    }
+  }
+
+  /// True if 'predicate(id)' returns true for any set bit.
+  /// Short-circuits at the first match.
+  template <typename Predicate>
+  bool anyOf(Predicate predicate) const {
+    uint64_t remaining{bits_};
+    while (remaining != 0) {
+      const int32_t id = std::countr_zero(remaining);
+      if (predicate(id)) {
+        return true;
+      }
+      remaining &= remaining - 1;
+    }
+    return false;
+  }
+
+  /// Raw 64-bit representation. Bit `i` set ⇔ id `i` is a member.
+  constexpr uint64_t bits() const {
+    return bits_;
+  }
+
+ private:
+  static uint64_t mask(int32_t id) {
+    VELOX_DCHECK_GE(id, 0);
+    VELOX_DCHECK_LT(id, kMaxRelations);
+    return uint64_t{1} << id;
+  }
+
+  uint64_t bits_{0};
+};
+
+} // namespace facebook::axiom::optimizer::v2
+
+namespace std {
+template <>
+struct hash<facebook::axiom::optimizer::v2::RelationSet> {
+  size_t operator()(
+      const facebook::axiom::optimizer::v2::RelationSet& set) const {
+    return set.hash();
+  }
+};
+} // namespace std

--- a/axiom/optimizer/v2/ScanHandle.cpp
+++ b/axiom/optimizer/v2/ScanHandle.cpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/ScanHandle.h"
+
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/ExprEmitter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+ScanHandle ScanHandle::build(
+    const Scan& scan,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator) {
+  const auto* baseTable = scan.baseTable();
+  const auto* layout = baseTable->schemaTable->columnGroups[0]->layout;
+  auto connectorSession =
+      session.toConnectorSession(layout->connector()->connectorId());
+
+  // Read schema is the consumer output columns plus the columns referenced
+  // only by filters; the latter keep their schema names.
+  folly::F14FastSet<Name> seenSchemaNames;
+  const ColumnVector& consumerColumns = scan.outputColumns();
+  for (ColumnCP column : consumerColumns) {
+    seenSchemaNames.insert(column->name());
+  }
+  ColumnVector filterOnlyColumns;
+  PlanObjectSet filterColumns;
+  filterColumns.unionColumns(scan.filters());
+  filterColumns.forEach<Column>([&](ColumnCP column) {
+    if (seenSchemaNames.insert(column->name()).second) {
+      filterOnlyColumns.push_back(column);
+    }
+  });
+
+  std::vector<velox::connector::ColumnHandlePtr> columnHandles;
+  columnHandles.reserve(consumerColumns.size() + filterOnlyColumns.size());
+  for (ColumnCP column : consumerColumns) {
+    columnHandles.push_back(layout->createColumnHandle(
+        connectorSession, column->name(), /*subfields=*/{}));
+  }
+  for (ColumnCP column : filterOnlyColumns) {
+    columnHandles.push_back(layout->createColumnHandle(
+        connectorSession, column->name(), /*subfields=*/{}));
+  }
+
+  ExprEmitter exprEmitter{evaluator.pool()};
+  std::vector<velox::core::TypedExprPtr> filters;
+  filters.reserve(scan.filters().size());
+  for (ExprCP filter : scan.filters()) {
+    filters.push_back(
+        exprEmitter.toTypedExpr(filter, ColumnNaming::kSchemaName));
+  }
+  std::vector<velox::core::TypedExprPtr> filterConjuncts = filters;
+
+  std::vector<velox::core::TypedExprPtr> rejectedFilters;
+  velox::connector::ConnectorTableHandlePtr tableHandle =
+      layout->createTableHandle(
+          connectorSession,
+          columnHandles,
+          evaluator,
+          std::move(filters),
+          rejectedFilters);
+
+  return ScanHandle{
+      .tableHandle = std::move(tableHandle),
+      .columnHandles = std::move(columnHandles),
+      .filterOnlyColumns = std::move(filterOnlyColumns),
+      .rejectedFilters = std::move(rejectedFilters),
+      .filterConjuncts = std::move(filterConjuncts),
+  };
+}
+
+const ScanHandle& ScanHandleCache::getOrBuild(
+    const Scan& scan,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator) {
+  const int32_t id = scan.baseTable()->id();
+  auto it = byBaseTableId_.find(id);
+  if (it != byBaseTableId_.end()) {
+    return it->second;
+  }
+  return byBaseTableId_.emplace(id, ScanHandle::build(scan, session, evaluator))
+      .first->second;
+}
+
+const ScanHandle* ScanHandleCache::find(const Scan& scan) const {
+  auto it = byBaseTableId_.find(scan.baseTable()->id());
+  return it != byBaseTableId_.end() ? &it->second : nullptr;
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ScanHandle.h
+++ b/axiom/optimizer/v2/ScanHandle.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "velox/connectors/Connector.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Connector access for a scanned leaf table, built once from a `Scan` and
+/// reused by both the filtered-stats pass (`estimateLeafStats`) and `emit`.
+/// Building the handle calls into the connector to push filters down, so it
+/// must not be repeated per consumer.
+struct ScanHandle {
+  /// Builds the connector handle for `scan`'s base table. Calls into the
+  /// connector to push filters down.
+  static ScanHandle build(
+      const Scan& scan,
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator);
+
+  /// Table handle with the accepted filters pushed into the connector.
+  velox::connector::ConnectorTableHandlePtr tableHandle;
+
+  /// Column handles for the connector read schema: the scan's consumer output
+  /// columns first (in `scan->outputColumns()` order), then `filterOnlyColumns`
+  /// (aligned with the tail).
+  std::vector<velox::connector::ColumnHandlePtr> columnHandles;
+
+  /// Columns referenced only by filters and not in the scan output. Read by the
+  /// connector but, unless referenced by a rejected filter, projected away.
+  ColumnVector filterOnlyColumns;
+
+  /// Filters the connector could not push down; applied as a `Filter` above the
+  /// `TableScan` at emit time.
+  std::vector<velox::core::TypedExprPtr> rejectedFilters;
+
+  /// All scan filters as `TypedExpr` (schema-named), in the order passed to
+  /// `createTableHandle`. Passed to `co_estimateStats` so the connector can
+  /// report which conjuncts it could not account for.
+  std::vector<velox::core::TypedExprPtr> filterConjuncts;
+};
+
+/// Caches one `ScanHandle` per base table, keyed by base-table id. `getOrBuild`
+/// is the writing path; `find` is read-only.
+///
+///   ScanHandleCache cache;
+///   const ScanHandle& handle = cache.getOrBuild(scan, session, evaluator);
+///   ...
+///   const ScanHandle* cached = cache.find(scan);
+class ScanHandleCache {
+ public:
+  /// Returns the cached `ScanHandle` for `scan`'s base table, building and
+  /// caching it on first access.
+  const ScanHandle& getOrBuild(
+      const Scan& scan,
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator);
+
+  /// Returns the cached handle for `scan`'s base table, or nullptr if none was
+  /// built.
+  const ScanHandle* find(const Scan& scan) const;
+
+ private:
+  folly::F14FastMap<int32_t, ScanHandle> byBaseTableId_;
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1,0 +1,2281 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/TranslatePass.h"
+
+#include <folly/container/F14Map.h>
+#include "axiom/optimizer/EstimateMath.h"
+#include "axiom/optimizer/Filters.h"
+#include "axiom/optimizer/FunctionRegistry.h"
+#include "axiom/optimizer/PlanUtils.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/AppendAll.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
+#include "axiom/optimizer/v2/ExprSimplifier.h"
+#include "axiom/optimizer/v2/JoinCondition.h"
+#include "velox/exec/Aggregate.h"
+#include "velox/exec/AggregateFunctionRegistry.h"
+
+namespace facebook::axiom::optimizer::v2 {
+namespace lp = logical_plan;
+
+namespace {
+
+// Set of LP-output column names the consumer needs from this translation.
+// Threaded top-down through `translateNode` so producers (Scan, Project,
+// Aggregate, etc.) can mint / keep only the columns downstream actually uses.
+using LpNameSet = folly::F14FastSet<std::string>;
+
+// Returns the set of every column name in `rowType`. Used as the "everything"
+// required-set when the consumer hasn't (yet) narrowed it.
+LpNameSet allNames(const velox::RowType& rowType) {
+  const auto& names = rowType.names();
+  return LpNameSet{names.begin(), names.end()};
+}
+
+void collectUsedNames(const logical_plan::Expr& expr, LpNameSet& out);
+void collectUsedNames(
+    const std::vector<logical_plan::ExprPtr>& exprs,
+    LpNameSet& out);
+
+// Walks every expression carried by `node` and its descendants and adds
+// every referenced `InputReferenceExpr::name` to `out`. Used to capture
+// correlated outer-column references inside subquery bodies — those names
+// are the ones the outer node must preserve in its child's required-set.
+void collectUsedNamesInPlan(
+    const logical_plan::LogicalPlanNode& node,
+    LpNameSet& out) {
+  switch (node.kind()) {
+    case lp::NodeKind::kFilter:
+      collectUsedNames(*node.as<lp::FilterNode>()->predicate(), out);
+      break;
+    case lp::NodeKind::kProject:
+      collectUsedNames(node.as<lp::ProjectNode>()->expressions(), out);
+      break;
+    case lp::NodeKind::kAggregate: {
+      const auto* agg = node.as<lp::AggregateNode>();
+      collectUsedNames(agg->groupingKeys(), out);
+      for (const auto& aggExpr : agg->aggregates()) {
+        collectUsedNames(*aggExpr, out);
+      }
+      break;
+    }
+    case lp::NodeKind::kJoin: {
+      const auto* join = node.as<lp::JoinNode>();
+      if (join->condition() != nullptr) {
+        collectUsedNames(*join->condition(), out);
+      }
+      break;
+    }
+    case lp::NodeKind::kSort:
+      for (const auto& field : node.as<lp::SortNode>()->ordering()) {
+        collectUsedNames(*field.expression, out);
+      }
+      break;
+    case lp::NodeKind::kUnnest:
+      collectUsedNames(node.as<lp::UnnestNode>()->unnestExpressions(), out);
+      break;
+    default:
+      // Scan, Limit, Values, Set, Output: no expression-bearing fields that
+      // could reference outer columns.
+      break;
+  }
+  for (const auto& input : node.inputs()) {
+    collectUsedNamesInPlan(*input, out);
+  }
+}
+
+// Collects every `InputReferenceExpr::name` referenced anywhere in `expr`.
+// Used by translate functions to compute the required-set their input must
+// supply, given the expressions the node itself reads. `WindowExpr`,
+// `AggregateExpr`, `LambdaExpr`, and `SubqueryExpr` carry sub-expressions
+// in side fields outside `inputs()`, so they need explicit handling.
+void collectUsedNames(const logical_plan::Expr& expr, LpNameSet& out) {
+  if (expr.isInputReference()) {
+    out.insert(expr.as<lp::InputReferenceExpr>()->name());
+    return;
+  }
+  for (const auto& child : expr.inputs()) {
+    collectUsedNames(*child, out);
+  }
+  if (expr.isWindow()) {
+    const auto* window = expr.as<lp::WindowExpr>();
+    for (const auto& key : window->partitionKeys()) {
+      collectUsedNames(*key, out);
+    }
+    for (const auto& field : window->ordering()) {
+      collectUsedNames(*field.expression, out);
+    }
+    if (window->frame().startValue != nullptr) {
+      collectUsedNames(*window->frame().startValue, out);
+    }
+    if (window->frame().endValue != nullptr) {
+      collectUsedNames(*window->frame().endValue, out);
+    }
+  } else if (expr.isAggregate()) {
+    const auto* agg = expr.as<lp::AggregateExpr>();
+    if (agg->filter() != nullptr) {
+      collectUsedNames(*agg->filter(), out);
+    }
+    for (const auto& field : agg->ordering()) {
+      collectUsedNames(*field.expression, out);
+    }
+  } else if (expr.kind() == lp::ExprKind::kLambda) {
+    // Lambda body may reference outer columns (captures). Recurse into the
+    // body, then subtract the lambda's signature names (those are
+    // introduced by the lambda itself, not consumed from the outer scope).
+    const auto* lambda = expr.as<lp::LambdaExpr>();
+    LpNameSet bodyNames;
+    collectUsedNames(*lambda->body(), bodyNames);
+    for (const auto& name : lambda->signature()->names()) {
+      bodyNames.erase(name);
+    }
+    out.insert(bodyNames.begin(), bodyNames.end());
+  } else if (expr.kind() == lp::ExprKind::kSubquery) {
+    // Walk the subquery body to surface any correlated outer-column
+    // references. Names not in the outer's outputType are silently ignored
+    // by the consumer (existing policy); names that match outer columns
+    // are the correlations the outer must keep so the body's translate
+    // can resolve them.
+    const auto* subquery = expr.as<lp::SubqueryExpr>();
+    collectUsedNamesInPlan(*subquery->subquery(), out);
+  }
+}
+
+void collectUsedNames(
+    const std::vector<logical_plan::ExprPtr>& exprs,
+    LpNameSet& out) {
+  for (const auto& expr : exprs) {
+    collectUsedNames(*expr, out);
+  }
+}
+
+// Appends columns from `extra` to `base`, skipping any that already
+// appear in `base` (by Column* identity).
+void appendUnique(ColumnVector& base, const ColumnVector& extra) {
+  PlanObjectSet seen = PlanObjectSet::fromObjects(base);
+  for (ColumnCP column : extra) {
+    if (!seen.contains(column)) {
+      seen.add(column);
+      base.push_back(column);
+    }
+  }
+}
+
+// True if 'expr' is or transitively contains an `lp::SubqueryExpr`.
+// Used to decide whether a parent node's IR shape needs adjusting to
+// give the subquery a relational input above which to lift Apply.
+//
+// TODO: walk side-channel children carried by Lambda body / Window
+// partition+order+frame / Aggregate filter+ordering — currently this
+// recursion only follows `Expr::inputs()`, so a subquery buried inside
+// `filter(arr, x -> x = (SELECT ...))` (or similar HOF) is missed. A
+// miss is safe — control falls through to the non-split path with
+// `applyTarget=nullptr` and `liftSubquery` throws NYI rather than
+// silently miscompiling — but coverage is incomplete.
+bool containsSubquery(const logical_plan::Expr& expr) {
+  if (expr.kind() == logical_plan::ExprKind::kSubquery) {
+    return true;
+  }
+  for (const auto& child : expr.inputs()) {
+    if (containsSubquery(*child)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Walks 'expr' as a top-level AND chain and appends each non-AND leaf
+// to 'out'.
+void flattenAndConjuncts(
+    const logical_plan::Expr& expr,
+    std::vector<const logical_plan::Expr*>& out) {
+  if (expr.isSpecialForm() &&
+      expr.as<logical_plan::SpecialFormExpr>()->form() ==
+          logical_plan::SpecialForm::kAnd) {
+    for (const auto& child : expr.inputs()) {
+      flattenAndConjuncts(*child, out);
+    }
+    return;
+  }
+  out.push_back(&expr);
+}
+
+// Resolution context for translating expressions in a fixed scope. Maps
+// output column name to the Column that produces it.
+using Scope = folly::F14FastMap<std::string, ColumnCP>;
+
+// Populates 'scope' with one entry per field of 'rowType' pointing at the
+// matching Column in 'columns'. 'columns' must align 1:1 with 'rowType'.
+void populateScope(
+    const velox::RowType& rowType,
+    const ColumnVector& columns,
+    Scope& scope) {
+  VELOX_CHECK_EQ(
+      rowType.size(), columns.size(), "Scope row type / columns mismatch");
+  for (size_t i = 0; i < rowType.size(); ++i) {
+    scope[rowType.nameOf(i)] = columns[i];
+  }
+}
+
+// Builds one fresh Column per field of 'rowType' and populates 'scope' to
+// map each field name to its column.
+ColumnVector makeOutputColumns(
+    const velox::RowType& rowType,
+    float cardinality,
+    Scope& scope) {
+  ColumnVector columns;
+  columns.reserve(rowType.size());
+  for (size_t i = 0; i < rowType.size(); ++i) {
+    Value value(toType(rowType.childAt(i)), cardinality);
+    columns.push_back(
+        Column::createForSymbol(toName(rowType.nameOf(i)), value));
+  }
+  populateScope(rowType, columns, scope);
+  return columns;
+}
+
+struct Translated {
+  NodeCP node;
+  Scope scope;
+};
+
+// Outer-scope chain used while translating subquery bodies, plus the
+// per-nesting-level set of correlated columns referenced so far.
+// `liftSubquery` consumes the captured correlations as `Apply.correlations`.
+//
+// Invariant: `outerScopes_.size() == correlationsStack_.size()`.
+class SubqueryContext {
+ public:
+  // Resolves 'name' against enclosing scopes, innermost-first. Returns
+  // nullptr if not found at any level. Records the hit as a correlation
+  // for the innermost in-flight subquery.
+  ColumnCP resolveOuter(std::string_view name);
+
+  // Enters/leaves the body of a subquery. `pop()` returns the correlated
+  // columns collected during that body, deduplicated.
+  void push(const Scope& outerScope);
+  ColumnVector pop();
+
+ private:
+  std::vector<const Scope*> outerScopes_;
+  std::vector<ColumnVector> correlationsStack_;
+};
+
+ColumnCP SubqueryContext::resolveOuter(std::string_view name) {
+  for (size_t i = outerScopes_.size(); i > 0; --i) {
+    const Scope& scope = *outerScopes_[i - 1];
+    auto found = scope.find(name);
+    if (found == scope.end()) {
+      continue;
+    }
+    VELOX_CHECK_GE(correlationsStack_.size(), i);
+    // Record on every in-flight subquery between the matching outer scope
+    // and the innermost so each intermediate Apply carries the column.
+    for (size_t j = i - 1; j < correlationsStack_.size(); ++j) {
+      correlationsStack_[j].push_back(found->second);
+    }
+    return found->second;
+  }
+  return nullptr;
+}
+
+void SubqueryContext::push(const Scope& outerScope) {
+  outerScopes_.push_back(&outerScope);
+  correlationsStack_.emplace_back();
+}
+
+ColumnVector SubqueryContext::pop() {
+  ColumnVector deduped;
+  folly::F14FastSet<ColumnCP> seen;
+  for (ColumnCP column : correlationsStack_.back()) {
+    if (seen.insert(column).second) {
+      deduped.push_back(column);
+    }
+  }
+  correlationsStack_.pop_back();
+  outerScopes_.pop_back();
+  return deduped;
+}
+
+class Translator {
+ public:
+  Translator(
+      optimizer::Schema& schema,
+      velox::core::ExpressionEvaluator& evaluator,
+      Builder& builder)
+      : schema_(schema),
+        builder_(builder),
+        exprFactory_(builder),
+        simplifier_(builder, evaluator) {}
+
+  TranslatePass::Result run(const lp::LogicalPlanNode& plan) {
+    if (plan.is(lp::NodeKind::kOutput)) {
+      const auto& output = *plan.as<lp::OutputNode>();
+      const auto& child = *output.onlyInput();
+      const auto& childOutputType = *child.outputType();
+      // Seed `required` with just the LP names the OutputNode references.
+      // Names not referenced flow as "unused" through the child translation
+      // and get pruned where producers honor the required-set.
+      LpNameSet required;
+      required.reserve(output.entries().size());
+      for (const auto& entry : output.entries()) {
+        VELOX_CHECK_LT(entry.index, childOutputType.size());
+        required.insert(childOutputType.nameOf(entry.index));
+      }
+      Translated inner = translateNode(child, required);
+      ColumnVector outputColumns;
+      std::vector<std::string> outputNames;
+      outputColumns.reserve(output.entries().size());
+      outputNames.reserve(output.entries().size());
+      for (const auto& entry : output.entries()) {
+        // Resolve via LP-name → Column* scope rather than positionally:
+        // the IR's outputColumns may be narrower than the LP child's
+        // outputType after dup-collapse, and the LP contract is that
+        // same-name == same-thing in a node's outputType.
+        const auto& name = childOutputType.nameOf(entry.index);
+        auto it = inner.scope.find(name);
+        VELOX_CHECK(
+            it != inner.scope.end(),
+            "OutputNode entry name not found in inner scope: {}",
+            name);
+        outputColumns.push_back(it->second);
+        outputNames.push_back(entry.name);
+      }
+      return {inner.node, std::move(outputColumns), std::move(outputNames)};
+    }
+    // Bare plan (no OutputNode): nothing has narrowed the required set, so
+    // request everything the root advertises.
+    Translated translated = translateNode(plan, allNames(*plan.outputType()));
+    std::vector<std::string> outputNames;
+    outputNames.reserve(translated.node->outputColumns().size());
+    for (ColumnCP column : translated.node->outputColumns()) {
+      outputNames.emplace_back(column->outputName());
+    }
+    return {
+        translated.node,
+        ColumnVector{translated.node->outputColumns()},
+        std::move(outputNames)};
+  }
+
+ private:
+  // 'required' is the set of LP-output column names the consumer needs from
+  // this node. Producers (Scan, Project, Aggregate, Window, Unnest, Values)
+  // may emit only outputs in `required`; intermediate nodes propagate it
+  // down, augmented with the names the node itself reads.
+  Translated translateNode(
+      const lp::LogicalPlanNode& node,
+      const LpNameSet& required);
+  Translated translateScan(
+      const lp::TableScanNode& scan,
+      const LpNameSet& required);
+  Translated translateFilter(
+      const lp::FilterNode& filter,
+      const LpNameSet& required);
+  Translated translateProject(
+      const lp::ProjectNode& project,
+      const LpNameSet& required);
+  Translated translateLimit(
+      const lp::LimitNode& limit,
+      const LpNameSet& required);
+  Translated translateSort(const lp::SortNode& sort, const LpNameSet& required);
+  Translated translateAggregate(
+      const lp::AggregateNode& aggregate,
+      const LpNameSet& required);
+  Translated translateValues(
+      const lp::ValuesNode& values,
+      const LpNameSet& required);
+  Translated translateUnnest(
+      const lp::UnnestNode& unnest,
+      const LpNameSet& required);
+  Translated translateSet(const lp::SetNode& set, const LpNameSet& required);
+  Translated translateJoin(const lp::JoinNode& join, const LpNameSet& required);
+  Translated translateTableWrite(
+      const lp::TableWriteNode& tableWrite,
+      const LpNameSet& required);
+  NodeCP maybeWrapInWindow(
+      NodeCP input,
+      const Scope& inputScope,
+      const std::vector<lp::ExprPtr>& projectExprs,
+      const std::vector<std::string>& projectNames,
+      Scope& windowScope);
+  Translated buildUnionAll(
+      const std::vector<lp::LogicalPlanNodePtr>& inputs,
+      const velox::RowTypePtr& outputType,
+      const LpNameSet& required);
+
+  // Translates `predicateExpr` against `scope` (lifting any subqueries
+  // above `input` via Apply) and lowers it onto `input`. Returns an
+  // empty `Values` of `input`'s schema when the predicate is
+  // statically `false`, `input` unchanged when statically `true`, or
+  // a `Filter` otherwise. `scope` is returned unchanged.
+  Translated
+  maybeWrapInFilter(NodeCP input, const lp::Expr& predicateExpr, Scope scope);
+
+  // Translates an lp expression against 'scope'. If the expression
+  // contains an `lp::SubqueryExpr` (bare, or wrapped in
+  // `kExists`/`kIn`/`kNot`), the subquery is materialized as an `Apply`
+  // node lifted above `*applyTarget`, and `*applyTarget` is updated to
+  // point to the new Apply. The returned `ExprCP` references the Apply's
+  // mark / value column at the subquery site.
+  //
+  // `applyTarget` must be non-null at any expression position that may
+  // contain a subquery. Passing `nullptr` declares "no lift possible
+  // here" and the lift path throws if a subquery is encountered
+  // (e.g., row-literal expressions in `VALUES`).
+  ExprCP
+  translateExpr(const lp::Expr& expr, const Scope& scope, NodeCP* applyTarget);
+  ExprCP translateInputReference(
+      const lp::InputReferenceExpr& expr,
+      const Scope& scope);
+  ExprCP translateConstant(const lp::ConstantExpr& expr);
+  ExprCP translateCall(
+      const lp::CallExpr& expr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+  ExprCP translateSpecialForm(
+      const lp::SpecialFormExpr& expr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Translates an EXISTS special form by lifting an `Apply(kLeftSemiProject)`,
+  // with a fast path that folds EXISTS over a scalar Aggregate to constant
+  // TRUE.
+  ExprCP translateExists(
+      const lp::SpecialFormExpr& expr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Normalizes an IN list. Folds a single-element IN to equality (`a IN (b)` ->
+  // `a = b`, `a IN (NULL)` -> null boolean literal). For a multi-element
+  // constant list, drops duplicate constants from 'args' in place and returns a
+  // folded equality when a single distinct constant remains. Returns nullptr to
+  // let the caller build the (deduplicated) IN through the generic path,
+  // leaving 'args' unchanged when a multi-element list has any non-constant
+  // element.
+  ExprCP normalizeInList(ExprVector& args);
+
+  // Translates a DEREFERENCE special form, resolving a varchar field name to a
+  // numeric field index against the input row type.
+  ExprCP
+  translateDereference(ExprVector args, Name callName, const Value& value);
+
+  ExprCP translateLambda(const lp::LambdaExpr& expr, const Scope& scope);
+
+  // Translates a subquery body, captures correlations, and lifts an
+  // `Apply` above `*applyTarget`. Updates `*applyTarget` to point to
+  // the new Apply (with an `EnforceSingleRow` wrap for uncorrelated
+  // scalar). Returns Apply's result column.
+  //
+  // `kind` is the `Apply.kind` to emit. `inLhs` is the IN expression's
+  // left-hand side, non-null only when shaping an IN-form Apply
+  // (`liftSubquery` stores it together with the body's single output
+  // column as `Apply.inLhs` / `Apply.inBodyKey`). Throws if
+  // `applyTarget` is null.
+  ColumnCP liftSubquery(
+      const lp::SubqueryExpr& subqueryExpr,
+      velox::core::JoinType kind,
+      ExprCP inLhs,
+      const Scope& outerScope,
+      NodeCP* applyTarget);
+
+  // Translates each lp expression in 'expressions' against 'scope'.
+  ExprVector translateAll(
+      const std::vector<lp::ExprPtr>& expressions,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Translates an lp window frame against 'scope'.
+  Frame toFrame(const lp::WindowExpr::Frame& frame, const Scope& scope);
+
+  // Translates an lp aggregate expression into a QueryGraph `Aggregate`
+  // call. Resolves args / FILTER mask / ORDER BY keys against 'scope'.
+  // `applyTarget` (if non-null) lifts Apply nodes for any subquery in
+  // args / FILTER / ORDER BY above the Aggregate's input.
+  const optimizer::Aggregate* toAggregateCall(
+      const lp::AggregateExpr& aggregateExpr,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
+  // Translates each expression in 'exprRows' and, if every one folds to a
+  // `Literal`, returns the row-wise `Variant`s. Returns nullopt if any
+  // entry doesn't fold. `VALUES` expressions cannot reference input
+  // columns, so translation runs against an empty scope.
+  std::optional<std::vector<velox::Variant>> foldExprRowsToVariants(
+      const lp::ValuesNode::Exprs& exprRows);
+
+  SubqueryContext subqueries_;
+  Schema& schema_;
+  Builder& builder_;
+  ExprFactory exprFactory_;
+  ExprSimplifier simplifier_;
+  int32_t baseTableCounter_{0};
+};
+
+Translated Translator::translateTableWrite(
+    const lp::TableWriteNode& tableWrite,
+    const LpNameSet& /*required*/) {
+  const auto kind = static_cast<connector::WriteKind>(tableWrite.writeKind());
+  if (kind != connector::WriteKind::kInsert &&
+      kind != connector::WriteKind::kCreate) {
+    VELOX_NYI(
+        "TableWrite supports only INSERT and CREATE, got {}",
+        connector::WriteKindName::toName(kind));
+  }
+
+  const auto* schemaTable =
+      schema_.findTable(tableWrite.connectorId(), tableWrite.tableName());
+  VELOX_CHECK_NOT_NULL(
+      schemaTable,
+      "Table not found: {} via connector {}",
+      tableWrite.tableName().toString(),
+      tableWrite.connectorId());
+  const auto* connectorTable = schemaTable->connectorTable;
+  VELOX_CHECK_NOT_NULL(connectorTable);
+  const auto& tableSchema = *connectorTable->type();
+
+  // The child must supply every column a write expression reads.
+  LpNameSet childRequired;
+  for (const auto& columnExpr : tableWrite.columnExpressions()) {
+    collectUsedNames(*columnExpr, childRequired);
+  }
+  Translated input = translateNode(*tableWrite.onlyInput(), childRequired);
+  NodeCP currentInput = input.node;
+
+  // One expression per target column, in table-schema order: the statement's
+  // expression where the column is written, else the column's schema default.
+  const auto& writtenNames = tableWrite.columnNames();
+  ExprVector columnExprs;
+  columnExprs.reserve(tableSchema.size());
+  for (uint32_t i = 0; i < tableSchema.size(); ++i) {
+    const auto& columnName = tableSchema.nameOf(i);
+    auto it = std::find(writtenNames.begin(), writtenNames.end(), columnName);
+    if (it != writtenNames.end()) {
+      const auto nth = it - writtenNames.begin();
+      columnExprs.push_back(translateExpr(
+          *tableWrite.columnExpressions()[nth], input.scope, &currentInput));
+    } else {
+      const auto* tableColumn = connectorTable->findColumn(columnName);
+      VELOX_CHECK_NOT_NULL(tableColumn);
+      columnExprs.push_back(builder_.makeLiteral(
+          velox::Variant(tableColumn->defaultValue()),
+          toType(tableColumn->type())));
+    }
+    VELOX_DCHECK(
+        *tableSchema.childAt(i) == *toTypePtr(columnExprs.back()->value().type),
+        "TableWrite column type does not match schema: column {}, schema {}, expr {}",
+        columnName,
+        tableSchema.childAt(i)->toString(),
+        toTypePtr(columnExprs.back()->value().type)->toString());
+  }
+
+  NodeCP writeNode = builder_.make<TableWrite>(
+      {currentInput, connectorTable, kind, std::move(columnExprs)});
+
+  // The single output column is the written row count.
+  Scope scope;
+  const auto& outputType = *tableWrite.outputType();
+  if (outputType.size() == 1) {
+    scope[outputType.nameOf(0)] = writeNode->outputColumns()[0];
+  }
+  return {writeNode, std::move(scope)};
+}
+
+Translated Translator::translateNode(
+    const lp::LogicalPlanNode& node,
+    const LpNameSet& required) {
+  switch (node.kind()) {
+    case lp::NodeKind::kTableScan:
+      return translateScan(*node.as<lp::TableScanNode>(), required);
+    case lp::NodeKind::kFilter:
+      return translateFilter(*node.as<lp::FilterNode>(), required);
+    case lp::NodeKind::kProject:
+      return translateProject(*node.as<lp::ProjectNode>(), required);
+    case lp::NodeKind::kLimit:
+      return translateLimit(*node.as<lp::LimitNode>(), required);
+    case lp::NodeKind::kSort:
+      return translateSort(*node.as<lp::SortNode>(), required);
+    case lp::NodeKind::kAggregate:
+      return translateAggregate(*node.as<lp::AggregateNode>(), required);
+    case lp::NodeKind::kValues:
+      return translateValues(*node.as<lp::ValuesNode>(), required);
+    case lp::NodeKind::kUnnest:
+      return translateUnnest(*node.as<lp::UnnestNode>(), required);
+    case lp::NodeKind::kSet:
+      return translateSet(*node.as<lp::SetNode>(), required);
+    case lp::NodeKind::kJoin:
+      return translateJoin(*node.as<lp::JoinNode>(), required);
+    case lp::NodeKind::kTableWrite:
+      return translateTableWrite(*node.as<lp::TableWriteNode>(), required);
+    case lp::NodeKind::kOutput:
+      VELOX_UNREACHABLE();
+    default:
+      VELOX_NYI(
+          "Unsupported logical plan node kind: {}",
+          lp::NodeKindName::toName(node.kind()));
+  }
+}
+
+Translated Translator::translateScan(
+    const lp::TableScanNode& scan,
+    const LpNameSet& required) {
+  const auto* schemaTable =
+      schema_.findTable(scan.connectorId(), scan.tableName());
+  VELOX_CHECK_NOT_NULL(schemaTable);
+
+  auto* baseTable = make<BaseTable>();
+  baseTable->cname = toName(fmt::format("t{}", baseTableCounter_++));
+  baseTable->schemaTable = schemaTable;
+  // filteredCardinality stays 0 until estimateLeafStats populates it from
+  // connector stats; cardinality estimation falls back to constraint-based
+  // selectivity while it is unset.
+
+  const auto& columnNames = scan.columnNames();
+  const auto& outputType = scan.outputType();
+  ColumnVector outputColumns;
+  outputColumns.reserve(columnNames.size());
+  Scope scope;
+  for (size_t i = 0; i < columnNames.size(); ++i) {
+    const auto& outName = outputType->nameOf(i);
+    if (!required.contains(outName)) {
+      continue;
+    }
+    Name inTableName = toName(columnNames[i]);
+    Name outNameInterned = toName(outName);
+    ColumnCP schemaColumn = schemaTable->findColumn(inTableName);
+    VELOX_CHECK_NOT_NULL(schemaColumn);
+    auto* column = make<Column>(
+        inTableName,
+        baseTable,
+        schemaColumn->value(),
+        outNameInterned,
+        schemaColumn->name());
+    baseTable->columns.push_back(column);
+    outputColumns.push_back(column);
+    scope[outName] = column;
+  }
+  ScanCP scanNode = builder_.make<Scan>(
+      {baseTable, std::move(outputColumns), /*filters=*/{}});
+  return {scanNode, std::move(scope)};
+}
+
+Translated Translator::translateFilter(
+    const lp::FilterNode& filter,
+    const LpNameSet& required) {
+  // Filter is a pass-through: its outputType equals the child's. Forward
+  // `required` plus the names the predicate reads from the child.
+  LpNameSet childRequired = required;
+  collectUsedNames(*filter.predicate(), childRequired);
+  Translated input = translateNode(*filter.onlyInput(), childRequired);
+
+  // Split conjuncts so no-subquery ones land in a Filter below the
+  // Apply, where PushdownAndPrune can carry them into the input
+  // subtree. Subquery-bearing conjuncts must stay above the Apply
+  // (and any decorrelation aggregate atop it).
+  std::vector<const lp::Expr*> conjuncts;
+  flattenAndConjuncts(*filter.predicate(), conjuncts);
+  std::vector<const lp::Expr*> noSubquery;
+  std::vector<const lp::Expr*> withSubquery;
+  noSubquery.reserve(conjuncts.size());
+  withSubquery.reserve(conjuncts.size());
+  for (const auto* conjunct : conjuncts) {
+    if (containsSubquery(*conjunct)) {
+      withSubquery.push_back(conjunct);
+    } else {
+      noSubquery.push_back(conjunct);
+    }
+  }
+  if (noSubquery.empty() || withSubquery.empty()) {
+    return maybeWrapInFilter(
+        input.node, *filter.predicate(), std::move(input.scope));
+  }
+
+  // Translates 'conjuncts' and accumulates simplified results.
+  // Returns nullopt if any conjunct simplifies to constant false.
+  auto translateConjuncts =
+      [&](const std::vector<const lp::Expr*>& conjuncts,
+          NodeCP* applyTarget) -> std::optional<ExprVector> {
+    ExprVector result;
+    result.reserve(conjuncts.size());
+    for (const auto* conjunct : conjuncts) {
+      ExprCP translated = translateExpr(*conjunct, input.scope, applyTarget);
+      if (simplifier_.simplifyFilter(translated, result)) {
+        return std::nullopt;
+      }
+    }
+    return result;
+  };
+
+  auto innerConjuncts = translateConjuncts(noSubquery, /*applyTarget=*/nullptr);
+  if (!innerConjuncts.has_value()) {
+    return {
+        builder_.makeEmptyValues(input.node->outputColumns()),
+        std::move(input.scope)};
+  }
+  NodeCP inner = innerConjuncts->empty()
+      ? input.node
+      : builder_.make<Filter>({input.node, std::move(*innerConjuncts)});
+
+  auto outerConjuncts = translateConjuncts(withSubquery, &inner);
+  if (!outerConjuncts.has_value()) {
+    return {
+        builder_.makeEmptyValues(inner->outputColumns()),
+        std::move(input.scope)};
+  }
+  if (outerConjuncts->empty()) {
+    return {inner, std::move(input.scope)};
+  }
+  return {
+      builder_.make<Filter>({inner, std::move(*outerConjuncts)}),
+      std::move(input.scope)};
+}
+
+Translated Translator::maybeWrapInFilter(
+    NodeCP input,
+    const lp::Expr& predicateExpr,
+    Scope scope) {
+  ExprCP predicate = translateExpr(predicateExpr, scope, &input);
+
+  ExprVector conjuncts;
+  if (simplifier_.simplifyFilter(predicate, conjuncts)) {
+    return {builder_.makeEmptyValues(input->outputColumns()), std::move(scope)};
+  }
+
+  if (conjuncts.empty()) {
+    return {input, std::move(scope)};
+  }
+
+  return {
+      builder_.make<Filter>({input, std::move(conjuncts)}), std::move(scope)};
+}
+
+Translated Translator::translateProject(
+    const lp::ProjectNode& project,
+    const LpNameSet& required) {
+  const auto& names = project.names();
+  const auto& exprs = project.expressions();
+  VELOX_CHECK_EQ(names.size(), exprs.size());
+
+  // Drop output positions not in `required` and compute the names the kept
+  // expressions read from the child.
+  std::vector<size_t> keptIndices;
+  keptIndices.reserve(names.size());
+  LpNameSet childRequired;
+  for (size_t i = 0; i < names.size(); ++i) {
+    if (!required.contains(names[i])) {
+      continue;
+    }
+    keptIndices.push_back(i);
+    collectUsedNames(*exprs[i], childRequired);
+  }
+
+  Translated input = translateNode(*project.onlyInput(), childRequired);
+
+  // maybeWrapInWindow only needs the kept window-function exprs.
+  std::vector<lp::ExprPtr> keptExprs;
+  std::vector<std::string> keptNames;
+  keptExprs.reserve(keptIndices.size());
+  keptNames.reserve(keptIndices.size());
+  for (size_t idx : keptIndices) {
+    keptExprs.push_back(exprs[idx]);
+    keptNames.push_back(names[idx]);
+  }
+  Scope windowScope = input.scope;
+  NodeCP currentInput = maybeWrapInWindow(
+      input.node, input.scope, keptExprs, keptNames, windowScope);
+
+  ColumnVector outputColumns;
+  outputColumns.reserve(keptIndices.size());
+  ExprVector translatedExprs;
+  translatedExprs.reserve(keptIndices.size());
+  Scope newScope;
+  // Output positions producing the same canonical expression collapse to one
+  // output entry; both LP names still resolve to that Column via `newScope`.
+  folly::F14FastMap<ExprCP, ColumnCP> exprToOutput;
+  exprToOutput.reserve(keptIndices.size());
+  for (size_t idx : keptIndices) {
+    const auto& name = names[idx];
+    ExprCP translatedExpr;
+    if (exprs[idx]->isWindow()) {
+      auto it = windowScope.find(name);
+      VELOX_CHECK(it != windowScope.end());
+      translatedExpr = it->second;
+    } else {
+      translatedExpr = translateExpr(*exprs[idx], input.scope, &currentInput);
+    }
+    if (auto seenIt = exprToOutput.find(translatedExpr);
+        seenIt != exprToOutput.end()) {
+      newScope[name] = seenIt->second;
+      continue;
+    }
+    ColumnCP column;
+    if (translatedExpr->is(PlanType::kColumnExpr)) {
+      column = translatedExpr->as<Column>();
+    } else {
+      Name outName = toName(name);
+      column = make<Column>(
+          queryCtx()->newName(outName),
+          /*relation=*/nullptr,
+          translatedExpr->value(),
+          /*alias=*/outName);
+    }
+    exprToOutput.emplace(translatedExpr, column);
+    newScope[name] = column;
+    outputColumns.push_back(column);
+    translatedExprs.push_back(translatedExpr);
+  }
+
+  // Identity Project: pass-through outputs in input order. Skip allocating;
+  // `newScope` carries any LP renames.
+  if (outputColumns.size() == currentInput->outputColumns().size()) {
+    bool identity = true;
+    for (size_t i = 0; i < outputColumns.size(); ++i) {
+      if (outputColumns[i] != currentInput->outputColumns()[i]) {
+        identity = false;
+        break;
+      }
+    }
+    if (identity) {
+      return {currentInput, std::move(newScope)};
+    }
+  }
+
+  ProjectCP projectNode = builder_.make<Project>(
+      {currentInput, std::move(translatedExprs), std::move(outputColumns)});
+  return {projectNode, std::move(newScope)};
+}
+
+OrderType toOrderType(const logical_plan::SortOrder& order) {
+  if (order.isAscending()) {
+    return order.isNullsFirst() ? OrderType::kAscNullsFirst
+                                : OrderType::kAscNullsLast;
+  }
+  return order.isNullsFirst() ? OrderType::kDescNullsFirst
+                              : OrderType::kDescNullsLast;
+}
+
+// Max NDV across 'exprs', propagating unknown: if any operand's NDV is
+// unknown, the derived NDV is unknown (nullopt) rather than a fabricated
+// floor. An empty input has no operand to derive from and is treated as a
+// known 1 (the prior floor), matching a nullary call's degenerate NDV.
+std::optional<float> maxCardinality(const ExprVector& exprs) {
+  std::optional<float> result{1.0f};
+  for (const auto* expr : exprs) {
+    result = optimizer::maxOf(result, expr->value().cardinality);
+  }
+  return result;
+}
+
+ExprVector Translator::translateAll(
+    const std::vector<lp::ExprPtr>& expressions,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector result;
+  result.reserve(expressions.size());
+  for (const auto& expression : expressions) {
+    result.push_back(translateExpr(*expression, scope, applyTarget));
+  }
+  return result;
+}
+
+Frame Translator::toFrame(
+    const lp::WindowExpr::Frame& frame,
+    const Scope& scope) {
+  // Frame bounds are scalar literals (rows/range offsets); no subquery
+  // can appear here, so no lift target needed.
+  return Frame{
+      frame.type,
+      frame.startType,
+      frame.startValue ? translateExpr(*frame.startValue, scope, nullptr)
+                       : nullptr,
+      frame.endType,
+      frame.endValue ? translateExpr(*frame.endValue, scope, nullptr) : nullptr,
+  };
+}
+
+const optimizer::Aggregate* Translator::toAggregateCall(
+    const lp::AggregateExpr& aggregateExpr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector arguments =
+      translateAll(aggregateExpr.inputs(), scope, applyTarget);
+
+  std::vector<velox::TypePtr> argTypes;
+  argTypes.reserve(aggregateExpr.inputs().size());
+  for (const auto& input : aggregateExpr.inputs()) {
+    argTypes.push_back(input->type());
+  }
+
+  TypeCP intermediateType = toType(
+      velox::exec::resolveIntermediateType(aggregateExpr.name(), argTypes));
+
+  ExprCP condition = aggregateExpr.filter() != nullptr
+      ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
+      : nullptr;
+
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+  orderKeys.reserve(aggregateExpr.ordering().size());
+  orderTypes.reserve(aggregateExpr.ordering().size());
+  for (const auto& field : aggregateExpr.ordering()) {
+    orderKeys.push_back(translateExpr(*field.expression, scope, applyTarget));
+    orderTypes.push_back(toOrderType(field.order));
+  }
+  Value value(toType(aggregateExpr.type()));
+
+  Name aggName = toName(aggregateExpr.name());
+  const auto& metadata =
+      velox::exec::getAggregateFunctionMetadata(aggregateExpr.name());
+
+  FunctionSet funcs = Call::unionArgFunctions(FunctionSet{}, arguments);
+  if (metadata.ignoreDuplicates) {
+    funcs = funcs | FunctionSet::kIgnoreDuplicatesAggregate;
+  } else if (
+      (aggName == toName("min") || aggName == toName("max")) &&
+      arguments.size() == 1) {
+    // min(x)/max(x) ignore duplicates; min(x, n)/max(x, n) do not.
+    // TODO: Push this distinction into per-signature metadata.
+    funcs = funcs | FunctionSet::kIgnoreDuplicatesAggregate;
+  }
+  if (metadata.orderSensitive) {
+    funcs = funcs | FunctionSet::kOrderSensitiveAggregate;
+  }
+
+  const bool isDistinct =
+      !metadata.ignoreDuplicates && aggregateExpr.isDistinct();
+
+  return builder_.makeAggregate(
+      aggName,
+      value,
+      std::move(arguments),
+      funcs,
+      isDistinct,
+      condition,
+      intermediateType,
+      std::move(orderKeys),
+      std::move(orderTypes));
+}
+
+NodeCP Translator::maybeWrapInWindow(
+    NodeCP input,
+    const Scope& inputScope,
+    const std::vector<lp::ExprPtr>& projectExprs,
+    const std::vector<std::string>& projectNames,
+    Scope& windowScope) {
+  std::vector<size_t> windowIndices;
+  for (size_t i = 0; i < projectExprs.size(); ++i) {
+    if (projectExprs[i]->isWindow()) {
+      windowIndices.push_back(i);
+    }
+  }
+  if (windowIndices.empty()) {
+    return input;
+  }
+
+  // Pre-translate each lp WindowExpr into its effective spec (partition
+  // keys, order keys). Drop sort keys that duplicate a partition key (every
+  // row in a partition shares that value) or repeat an earlier sort key —
+  // both are redundant. Grouping below compares the effective specs, so two
+  // windows that differ only in a dropped order key — or only in frame, which
+  // is per-function — still share a single `Window` node.
+  struct Spec {
+    ExprVector partitionKeys;
+    ExprVector orderKeys;
+    OrderTypeVector orderTypes;
+
+    bool operator==(const Spec&) const = default;
+  };
+  std::vector<Spec> specs(windowIndices.size());
+  for (size_t i = 0; i < windowIndices.size(); ++i) {
+    const auto* windowExpr =
+        projectExprs[windowIndices[i]]->as<lp::WindowExpr>();
+    Spec& spec = specs[i];
+    // Subqueries in window partition / order keys / frame bounds would
+    // need lifting above the Window's input — left as nullptr until
+    // that wiring lands. lp's surface allows them; rare in practice.
+    spec.partitionKeys = translateAll(
+        windowExpr->partitionKeys(), inputScope, /*applyTarget=*/nullptr);
+
+    folly::F14FastSet<ExprCP> seenKeys(
+        spec.partitionKeys.begin(), spec.partitionKeys.end());
+    spec.orderKeys.reserve(windowExpr->ordering().size());
+    spec.orderTypes.reserve(windowExpr->ordering().size());
+    for (const auto& field : windowExpr->ordering()) {
+      ExprCP key =
+          translateExpr(*field.expression, inputScope, /*applyTarget=*/nullptr);
+      if (!seenKeys.insert(key).second) {
+        continue;
+      }
+      spec.orderKeys.push_back(key);
+      spec.orderTypes.push_back(toOrderType(field.order));
+    }
+  }
+
+  // Group windows by their effective spec so each group produces one
+  // `Window` node. Multiple groups are chained.
+  std::vector<std::vector<size_t>> groups;
+  for (size_t i = 0; i < windowIndices.size(); ++i) {
+    bool placed = false;
+    for (auto& group : groups) {
+      if (specs[group.front()] == specs[i]) {
+        group.push_back(i);
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      groups.push_back({i});
+    }
+  }
+
+  NodeCP current = input;
+  for (const auto& group : groups) {
+    const Spec& spec = specs[group.front()];
+
+    WindowFunctions functions;
+    functions.reserve(group.size());
+    ColumnVector outputColumns;
+    outputColumns.reserve(current->outputColumns().size() + group.size());
+    for (ColumnCP column : current->outputColumns()) {
+      outputColumns.push_back(column);
+    }
+    for (size_t i : group) {
+      const size_t projectIndex = windowIndices[i];
+      const auto* windowExpr = projectExprs[projectIndex]->as<lp::WindowExpr>();
+      Value value(toType(windowExpr->type()));
+      Name windowName = toName(windowExpr->name());
+      ExprVector windowArgs = translateAll(
+          windowExpr->inputs(), inputScope, /*applyTarget=*/nullptr);
+      // Window functions are non-deterministic with non-default null behavior.
+      FunctionSet windowFuncs =
+          Call::unionArgFunctions(FunctionSet{}, windowArgs) |
+          FunctionSet::kNonDeterministic | FunctionSet::kNonDefaultNullBehavior;
+      auto* call = builder_.makeCall(
+          windowName, value, std::move(windowArgs), windowFuncs);
+      Frame frame = toFrame(windowExpr->frame(), inputScope);
+      functions.push_back(
+          WindowFunction{call, frame, windowExpr->ignoreNulls()});
+
+      const auto& name = projectNames[projectIndex];
+      auto* column = Column::createForSymbol(toName(name), value);
+      outputColumns.push_back(column);
+      windowScope[name] = column;
+    }
+
+    current = builder_.make<Window>(
+        {current,
+         std::move(functions),
+         spec.partitionKeys,
+         spec.orderKeys,
+         spec.orderTypes,
+         std::move(outputColumns)});
+  }
+  return current;
+}
+
+Translated Translator::translateLimit(
+    const lp::LimitNode& limit,
+    const LpNameSet& required) {
+  if (limit.count() == 0) {
+    // LIMIT 0 returns no rows. Skip translating the input entirely and
+    // replace with an empty `Values` carrying the same schema.
+    Scope scope;
+    ColumnVector outputColumns =
+        makeOutputColumns(*limit.outputType(), /*cardinality=*/0, scope);
+    ValuesCP valuesNode =
+        builder_.make<Values>({nullptr, nullptr, std::move(outputColumns)});
+    return {valuesNode, std::move(scope)};
+  }
+  // Limit is a pass-through with no expressions of its own.
+  Translated input = translateNode(*limit.onlyInput(), required);
+  LimitCP limitNode =
+      builder_.make<Limit>({input.node, limit.offset(), limit.count()});
+  return {limitNode, std::move(input.scope)};
+}
+
+Translated Translator::translateSort(
+    const lp::SortNode& sort,
+    const LpNameSet& required) {
+  // Sort is a pass-through; forward `required` plus the names its order keys
+  // read from the child.
+  LpNameSet childRequired = required;
+  for (const auto& field : sort.ordering()) {
+    collectUsedNames(*field.expression, childRequired);
+  }
+  Translated input = translateNode(*sort.onlyInput(), childRequired);
+
+  NodeCP currentInput = input.node;
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+  orderKeys.reserve(sort.ordering().size());
+  orderTypes.reserve(sort.ordering().size());
+  for (const auto& field : sort.ordering()) {
+    orderKeys.push_back(
+        translateExpr(*field.expression, input.scope, &currentInput));
+    orderTypes.push_back(toOrderType(field.order));
+  }
+
+  SortCP sortNode = builder_.make<Sort>(
+      {currentInput, std::move(orderKeys), std::move(orderTypes)});
+  return {sortNode, std::move(input.scope)};
+}
+
+Translated Translator::translateAggregate(
+    const lp::AggregateNode& aggregate,
+    const LpNameSet& required) {
+  const auto& names = aggregate.outputNames();
+  const auto& groupingKeyExpressions = aggregate.groupingKeys();
+  const auto& groupingSets = aggregate.groupingSets();
+  const auto& aggregateExpressions = aggregate.aggregates();
+  const size_t groupIdSlots = groupingSets.empty() ? 0 : 1;
+  VELOX_CHECK_EQ(
+      names.size(),
+      groupingKeyExpressions.size() + aggregateExpressions.size() +
+          groupIdSlots);
+
+  // Decide which aggregates to keep (output not in `required`). Grouping keys
+  // and groupId always stay: dropping them would change group cardinality.
+  std::vector<size_t> keptAggregateIndices;
+  keptAggregateIndices.reserve(aggregateExpressions.size());
+  for (size_t i = 0; i < aggregateExpressions.size(); ++i) {
+    if (required.contains(names[groupingKeyExpressions.size() + i])) {
+      keptAggregateIndices.push_back(i);
+    }
+  }
+
+  // Child must supply: every column read by the grouping keys, plus every
+  // column read by the kept aggregates (args, FILTER, ORDER BY).
+  LpNameSet childRequired;
+  collectUsedNames(groupingKeyExpressions, childRequired);
+  for (size_t idx : keptAggregateIndices) {
+    collectUsedNames(*aggregateExpressions[idx], childRequired);
+  }
+  Translated input = translateNode(*aggregate.onlyInput(), childRequired);
+
+  ExprVector groupingKeys;
+  groupingKeys.reserve(groupingKeyExpressions.size());
+  ColumnVector outputColumns;
+  outputColumns.reserve(
+      groupingKeyExpressions.size() + keptAggregateIndices.size() +
+      groupIdSlots);
+  Scope newScope;
+  // Grouping-sets case keeps positional alignment between groupingKeys and
+  // the set indices; only the simple GROUP BY case can dedup safely here.
+  const bool canDedupGroupingKeys = groupingSets.empty();
+  folly::F14FastSet<ColumnCP> seenGroupingOutputs;
+  if (canDedupGroupingKeys) {
+    seenGroupingOutputs.reserve(groupingKeyExpressions.size());
+  }
+
+  NodeCP currentInput = input.node;
+  for (size_t i = 0; i < groupingKeyExpressions.size(); ++i) {
+    ExprCP keyExpr =
+        translateExpr(*groupingKeyExpressions[i], input.scope, &currentInput);
+    // Reuse the input column when the grouping key is a column reference:
+    // Velox `AggregationNode` emits grouping-key output under the input
+    // field-access name. For grouping sets, `GroupIdNode` requires output
+    // names distinct from the input columns for the NULL-padded copies, so
+    // mint a fresh column rather than reusing the (possibly colliding) LP
+    // symbol.
+    ColumnCP column;
+    if (groupingSets.empty() && keyExpr->is(PlanType::kColumnExpr)) {
+      column = keyExpr->as<Column>();
+    } else if (groupingSets.empty()) {
+      column = Column::createForSymbol(toName(names[i]), keyExpr->value());
+    } else {
+      column = Column::create(toName(names[i]), keyExpr->value());
+    }
+    newScope[names[i]] = column;
+    if (canDedupGroupingKeys && !seenGroupingOutputs.insert(column).second) {
+      continue;
+    }
+    groupingKeys.push_back(keyExpr);
+    outputColumns.push_back(column);
+  }
+
+  AggregateCallVector aggregates;
+  aggregates.reserve(keptAggregateIndices.size());
+  folly::F14FastMap<const optimizer::Aggregate*, ColumnCP> aggregateToOutput;
+  aggregateToOutput.reserve(keptAggregateIndices.size());
+  for (size_t idx : keptAggregateIndices) {
+    const auto* aggregateCall =
+        toAggregateCall(*aggregateExpressions[idx], input.scope, &currentInput);
+    const auto& aggregateName = names[groupingKeyExpressions.size() + idx];
+    if (auto it = aggregateToOutput.find(aggregateCall);
+        it != aggregateToOutput.end()) {
+      newScope[aggregateName] = it->second;
+      continue;
+    }
+    aggregates.push_back(aggregateCall);
+    auto* column =
+        Column::createForSymbol(toName(aggregateName), aggregateCall->value());
+    aggregateToOutput.emplace(aggregateCall, column);
+    outputColumns.push_back(column);
+    newScope[aggregateName] = column;
+  }
+
+  if (groupingSets.empty()) {
+    AggregateCP aggNode = builder_.make<Aggregate>(Aggregate::Key{
+        .input = currentInput,
+        .groupingKeys = std::move(groupingKeys),
+        .aggregates = std::move(aggregates),
+        .outputColumns = std::move(outputColumns)});
+    return {aggNode, std::move(newScope)};
+  }
+
+  // GROUPING SETS / ROLLUP / CUBE lower to GroupId + a plain aggregate keyed on
+  // an explicit group-id column: a mechanical translation that lets physical
+  // planning treat the aggregate like any other.
+  // Grouping sets keep positional alignment with the set indices (no key
+  // dedup), so `outputColumns` is exactly the key output columns followed by
+  // the aggregate result columns.
+  const size_t numKeys = groupingKeys.size();
+  ColumnVector keyOutputColumns(
+      outputColumns.begin(), outputColumns.begin() + numKeys);
+  ColumnVector aggResultColumns(
+      outputColumns.begin() + numKeys, outputColumns.end());
+
+  // Columns the aggregates read pass through GroupId unchanged.
+  PlanObjectSet aggInputSet;
+  for (const auto* call : aggregates) {
+    for (ExprCP arg : call->args()) {
+      aggInputSet.unionSet(arg->columns());
+    }
+    if (call->condition() != nullptr) {
+      aggInputSet.unionSet(call->condition()->columns());
+    }
+    for (ExprCP orderKey : call->orderKeys()) {
+      aggInputSet.unionSet(orderKey->columns());
+    }
+  }
+
+  // GroupId groups on columns; materialize any non-column key into a Project.
+  ExprVector groupIdInputKeys;
+  groupIdInputKeys.reserve(numKeys);
+  ColumnVector materializedColumns;
+  ExprVector materializedExprs;
+  for (ExprCP keyExpr : groupingKeys) {
+    if (keyExpr->is(PlanType::kColumnExpr)) {
+      groupIdInputKeys.push_back(keyExpr);
+    } else {
+      ColumnCP keyColumn = Column::create("groupingKey", keyExpr->value());
+      materializedColumns.push_back(keyColumn);
+      materializedExprs.push_back(keyExpr);
+      groupIdInputKeys.push_back(keyColumn);
+    }
+  }
+
+  NodeCP groupIdInput = currentInput;
+  if (!materializedExprs.empty()) {
+    PlanObjectSet passthrough = aggInputSet;
+    for (ExprCP keyExpr : groupingKeys) {
+      if (keyExpr->is(PlanType::kColumnExpr)) {
+        passthrough.add(keyExpr->as<Column>());
+      }
+    }
+    ExprVector projectExprs = passthrough.toObjects<Expr>();
+    ColumnVector projectColumns;
+    projectColumns.reserve(projectExprs.size() + materializedColumns.size());
+    for (ExprCP expr : projectExprs) {
+      projectColumns.push_back(expr->as<Column>());
+    }
+    appendAll(projectExprs, materializedExprs);
+    appendAll(projectColumns, materializedColumns);
+    groupIdInput = builder_.make<Project>(
+        {currentInput, std::move(projectExprs), std::move(projectColumns)});
+  }
+
+  ExprVector aggregationInputs = aggInputSet.toObjects<Expr>();
+
+  const auto& groupIdName = names.back();
+  Value groupIdValue(
+      toType(aggregate.outputType()->childAt(names.size() - 1)),
+      static_cast<float>(groupingSets.size()));
+  ColumnCP groupIdColumn =
+      Column::createForSymbol(toName(groupIdName), groupIdValue);
+  newScope[groupIdName] = groupIdColumn;
+
+  ColumnVector groupIdOutputs;
+  groupIdOutputs.reserve(
+      keyOutputColumns.size() + aggregationInputs.size() + 1);
+  appendAll(groupIdOutputs, keyOutputColumns);
+  for (ExprCP expr : aggregationInputs) {
+    groupIdOutputs.push_back(expr->as<Column>());
+  }
+  groupIdOutputs.push_back(groupIdColumn);
+
+  QGVector<QGVector<int32_t>> setsCopy;
+  setsCopy.reserve(groupingSets.size());
+  for (const auto& set : groupingSets) {
+    setsCopy.emplace_back(set.begin(), set.end());
+  }
+
+  NodeCP groupIdNode = builder_.make<GroupId>(GroupId::Key{
+      groupIdInput,
+      groupIdInputKeys,
+      aggregationInputs,
+      setsCopy,
+      keyOutputColumns,
+      groupIdColumn,
+      groupIdOutputs});
+
+  // Aggregate keys: the GroupId key output columns plus the group-id column.
+  ExprVector aggGroupingKeys;
+  aggGroupingKeys.reserve(numKeys + 1);
+  appendAll(aggGroupingKeys, keyOutputColumns);
+  aggGroupingKeys.push_back(groupIdColumn);
+
+  // Empty sets are the global () sets whose group-id values must emit a default
+  // row over empty input; groupId is coupled with them (set together or not).
+  QGVector<int32_t> globalGroupingSets;
+  for (size_t i = 0; i < setsCopy.size(); ++i) {
+    if (setsCopy[i].empty()) {
+      globalGroupingSets.push_back(static_cast<int32_t>(i));
+    }
+  }
+  ColumnCP aggGroupId = globalGroupingSets.empty() ? nullptr : groupIdColumn;
+
+  // Physical output order: keys, group-id, aggregate results.
+  ColumnVector aggOutputColumns;
+  aggOutputColumns.reserve(numKeys + 1 + aggResultColumns.size());
+  appendAll(aggOutputColumns, keyOutputColumns);
+  aggOutputColumns.push_back(groupIdColumn);
+  appendAll(aggOutputColumns, aggResultColumns);
+
+  AggregateCP aggNode = builder_.make<Aggregate>(Aggregate::Key{
+      .input = groupIdNode,
+      .groupingKeys = std::move(aggGroupingKeys),
+      .aggregates = std::move(aggregates),
+      .outputColumns = std::move(aggOutputColumns),
+      .step = AggregateStep::kSingle,
+      .groupId = aggGroupId,
+      .globalGroupingSets = std::move(globalGroupingSets)});
+  return {aggNode, std::move(newScope)};
+}
+
+std::optional<std::vector<velox::Variant>> Translator::foldExprRowsToVariants(
+    const lp::ValuesNode::Exprs& exprRows) {
+  Scope emptyScope;
+  std::vector<velox::Variant> rows;
+  rows.reserve(exprRows.size());
+  for (const auto& exprRow : exprRows) {
+    std::vector<velox::Variant> rowValues;
+    rowValues.reserve(exprRow.size());
+    for (const auto& expr : exprRow) {
+      // VALUES literal expressions have no relational input above; lift
+      // forbidden. Subqueries inside VALUES are NYI.
+      ExprCP translated =
+          translateExpr(*expr, emptyScope, /*applyTarget=*/nullptr);
+      if (!translated->is(PlanType::kLiteralExpr)) {
+        return std::nullopt;
+      }
+      rowValues.emplace_back(translated->as<Literal>()->literal());
+    }
+    rows.emplace_back(velox::Variant::row(std::move(rowValues)));
+  }
+  return rows;
+}
+
+Translated Translator::translateValues(
+    const lp::ValuesNode& values,
+    const LpNameSet& /*required*/) {
+  Scope scope;
+  ColumnVector outputColumns =
+      makeOutputColumns(*values.outputType(), values.cardinality(), scope);
+
+  // Fold `Exprs` data to a single `Variant::array(rows)` at translate
+  // time. Constant-foldable rows arrive here as `Literal`s (Call /
+  // SpecialForm translation has already simplified). If any entry
+  // isn't a literal, fall back to passing the source through — emit
+  // will fail loudly on the unsupported shape.
+  const velox::Variant* foldedRows = nullptr;
+  if (const auto* exprRows =
+          std::get_if<lp::ValuesNode::Exprs>(&values.data())) {
+    auto rows = foldExprRowsToVariants(*exprRows);
+    if (rows.has_value()) {
+      foldedRows = queryCtx()->registerVariant(
+          std::make_unique<velox::Variant>(
+              velox::Variant::array(std::move(*rows))));
+    }
+  }
+
+  const lp::ValuesNode* passthrough = foldedRows == nullptr ? &values : nullptr;
+  ValuesCP valuesNode = builder_.make<Values>(
+      {passthrough, foldedRows, std::move(outputColumns)});
+  return {valuesNode, std::move(scope)};
+}
+
+Translated Translator::translateUnnest(
+    const lp::UnnestNode& unnest,
+    const LpNameSet& required) {
+  // Child must supply: every column the unnest expressions read, plus any
+  // replicated input column the consumer still needs.
+  LpNameSet childRequired;
+  collectUsedNames(unnest.unnestExpressions(), childRequired);
+  const auto& inputType = *unnest.onlyInput()->outputType();
+  for (size_t i = 0; i < inputType.size(); ++i) {
+    const auto& name = inputType.nameOf(i);
+    if (required.contains(name)) {
+      childRequired.insert(name);
+    }
+  }
+  Translated input = translateNode(*unnest.onlyInput(), childRequired);
+
+  NodeCP currentInput = input.node;
+  ExprVector unnestExprs =
+      translateAll(unnest.unnestExpressions(), input.scope, &currentInput);
+
+  // TODO: Cardinality of unnested columns also should be multiplied by the
+  // average expected number of elements per unnested row. Other Value
+  // properties also should be computed.
+  const std::optional<float> unnestCardinality = maxCardinality(unnestExprs);
+  const auto& outputType = unnest.outputType();
+  Scope newScope;
+
+  // LP UnnestNode's outputType layout is
+  // [input.outputType ⊕ per-expression unnested-names ⊕ optional ordinality].
+  // Walk in that order, dropping replicated input columns the consumer
+  // doesn't need; always emit unnest-expression outputs and ordinality.
+  ColumnVector replicatedColumns;
+  replicatedColumns.reserve(inputType.size());
+  for (size_t i = 0; i < inputType.size(); ++i) {
+    const auto& name = inputType.nameOf(i);
+    if (!required.contains(name)) {
+      continue;
+    }
+    auto it = input.scope.find(name);
+    VELOX_CHECK(it != input.scope.end());
+    replicatedColumns.push_back(it->second);
+    newScope[name] = it->second;
+  }
+
+  QGVector<ColumnVector> unnestColumns;
+  unnestColumns.reserve(unnest.unnestExpressions().size());
+  size_t outputIndex = inputType.size();
+  for (const auto& names : unnest.unnestedNames()) {
+    ColumnVector perExpr;
+    perExpr.reserve(names.size());
+    for (const auto& name : names) {
+      Value value = clampCardinality(
+          Value{toType(outputType->childAt(outputIndex)), unnestCardinality});
+      auto* column = Column::createForSymbol(toName(name), value);
+      perExpr.push_back(column);
+      newScope[name] = column;
+      ++outputIndex;
+    }
+    unnestColumns.push_back(std::move(perExpr));
+  }
+
+  ColumnCP ordinalityColumn = nullptr;
+  if (unnest.ordinalityName().has_value()) {
+    const auto& name = unnest.ordinalityName().value();
+    Value value(toType(outputType->childAt(outputIndex)), unnestCardinality);
+    ordinalityColumn = Column::createForSymbol(toName(name), value);
+    newScope[name] = ordinalityColumn;
+  }
+
+  ColumnVector outputColumns = replicatedColumns;
+  for (const auto& perExpr : unnestColumns) {
+    for (ColumnCP column : perExpr) {
+      outputColumns.push_back(column);
+    }
+  }
+  if (ordinalityColumn != nullptr) {
+    outputColumns.push_back(ordinalityColumn);
+  }
+
+  UnnestCP unnestNode = builder_.make<Unnest>(
+      {currentInput,
+       std::move(unnestExprs),
+       std::move(replicatedColumns),
+       std::move(unnestColumns),
+       ordinalityColumn,
+       std::move(outputColumns)});
+  return {unnestNode, std::move(newScope)};
+}
+
+Translated Translator::buildUnionAll(
+    const std::vector<lp::LogicalPlanNodePtr>& inputs,
+    const velox::RowTypePtr& outputType,
+    const LpNameSet& required) {
+  NodeVector inputNodes;
+  inputNodes.reserve(inputs.size());
+  QGVector<ColumnVector> legColumns;
+  legColumns.reserve(inputs.size());
+  // Union output positions parent doesn't require are dropped from the union
+  // node entirely. Build a list of kept positions once and reuse it for every
+  // leg's column mapping.
+  std::vector<size_t> keptPositions;
+  keptPositions.reserve(outputType->size());
+  for (size_t j = 0; j < outputType->size(); ++j) {
+    if (required.contains(outputType->nameOf(j))) {
+      keptPositions.push_back(j);
+    }
+  }
+  for (const auto& in : inputs) {
+    // Each leg's required-set is the kept union output names, mapped to that
+    // leg's positional outputType names (legs align 1:1 with the union's
+    // outputType by SQL semantics).
+    LpNameSet legRequired;
+    legRequired.reserve(keptPositions.size());
+    for (size_t j : keptPositions) {
+      legRequired.insert(in->outputType()->nameOf(j));
+    }
+    Translated translated = translateNode(*in, legRequired);
+    ColumnVector cols;
+    cols.reserve(keptPositions.size());
+    for (size_t j : keptPositions) {
+      // Resolve LP-name → IR Column* via the leg's scope; the leg's IR
+      // `outputColumns` may be narrower than its LP outputType after
+      // dup-collapse, but the same Column may legitimately repeat.
+      const auto& legName = in->outputType()->nameOf(j);
+      auto it = translated.scope.find(legName);
+      VELOX_CHECK(
+          it != translated.scope.end(),
+          "UnionAll leg scope missing column: {}",
+          legName);
+      cols.push_back(it->second);
+    }
+    legColumns.push_back(std::move(cols));
+    inputNodes.push_back(translated.node);
+  }
+  Scope scope;
+  ColumnVector outputColumns;
+  outputColumns.reserve(keptPositions.size());
+  for (size_t j : keptPositions) {
+    Value value(toType(outputType->childAt(j)));
+    auto* column =
+        Column::createForSymbol(toName(outputType->nameOf(j)), value);
+    outputColumns.push_back(column);
+    scope[outputType->nameOf(j)] = column;
+  }
+  UnionAllCP unionNode = builder_.make<UnionAll>(
+      {std::move(inputNodes), std::move(legColumns), std::move(outputColumns)});
+  return {unionNode, std::move(scope)};
+}
+
+// Set-op outputs reuse the upstream `Column*`s (left side for
+// INTERSECT/EXCEPT, UnionAll for UNION). Two distinct nodes' `outputColumns`
+// can share Column identity; downstream passes must not assume freshness.
+Translated Translator::translateSet(
+    const lp::SetNode& set,
+    const LpNameSet& required) {
+  switch (set.operation()) {
+    case lp::SetOperation::kUnionAll:
+      return buildUnionAll(set.inputs(), set.outputType(), required);
+    case lp::SetOperation::kUnion: {
+      Translated all = buildUnionAll(
+          set.inputs(), set.outputType(), allNames(*set.outputType()));
+      const ColumnVector& cols = all.node->outputColumns();
+      Scope newScope;
+      populateScope(*set.outputType(), cols, newScope);
+      AggregateCP aggNode = builder_.make<Aggregate>(
+          {all.node,
+           ExprVector{cols.begin(), cols.end()},
+           AggregateCallVector{},
+           ColumnVector{cols}});
+      return {aggNode, std::move(newScope)};
+    }
+    case lp::SetOperation::kIntersect:
+    case lp::SetOperation::kIntersectAll:
+    case lp::SetOperation::kExcept:
+    case lp::SetOperation::kExceptAll: {
+      const bool isAnti = set.operation() == lp::SetOperation::kExcept ||
+          set.operation() == lp::SetOperation::kExceptAll;
+      const bool isDistinct = set.operation() == lp::SetOperation::kIntersect ||
+          set.operation() == lp::SetOperation::kExcept;
+      const velox::core::JoinType joinType = isAnti
+          ? (isDistinct ? velox::core::JoinType::kAnti
+                        : velox::core::JoinType::kCountingAnti)
+          : (isDistinct ? velox::core::JoinType::kLeftSemiFilter
+                        : velox::core::JoinType::kCountingLeftSemiFilter);
+
+      // Set-op via Join: each leg's columns become join keys, so all of each
+      // leg's outputType is consumed.
+      Translated current = {
+          translateNode(
+              *set.inputs().front(),
+              allNames(*set.inputs().front()->outputType()))
+              .node,
+          {}};
+      for (size_t i = 1; i < set.inputs().size(); ++i) {
+        Translated other = {
+            translateNode(
+                *set.inputs()[i], allNames(*set.inputs()[i]->outputType()))
+                .node,
+            {}};
+        const auto& leftColumns = current.node->outputColumns();
+        const auto& rightColumns = other.node->outputColumns();
+        VELOX_CHECK_EQ(leftColumns.size(), rightColumns.size());
+        ExprVector leftKeys;
+        ExprVector rightKeys;
+        leftKeys.reserve(leftColumns.size());
+        rightKeys.reserve(leftColumns.size());
+        for (size_t columnIndex = 0; columnIndex < leftColumns.size();
+             ++columnIndex) {
+          leftKeys.push_back(leftColumns[columnIndex]);
+          rightKeys.push_back(rightColumns[columnIndex]);
+        }
+        ColumnVector outputColumns{leftColumns};
+        current.node = builder_.make<Join>(
+            {current.node,
+             other.node,
+             joinType,
+             std::move(leftKeys),
+             std::move(rightKeys),
+             /*filter=*/ExprVector{},
+             /*nullAware=*/false,
+             /*nullAsValue=*/true,
+             std::move(outputColumns)});
+      }
+
+      // Output schema is the left side's columns flowing through the Join
+      // unchanged.
+      const ColumnVector& outputColumns = current.node->outputColumns();
+      Scope scope;
+      populateScope(*set.outputType(), outputColumns, scope);
+
+      if (isDistinct) {
+        AggregateCP aggNode = builder_.make<Aggregate>(
+            {current.node,
+             ExprVector{outputColumns.begin(), outputColumns.end()},
+             AggregateCallVector{},
+             outputColumns});
+        return {aggNode, std::move(scope)};
+      }
+      return {current.node, std::move(scope)};
+    }
+  }
+  VELOX_UNREACHABLE();
+}
+
+velox::core::JoinType toVeloxJoinType(lp::JoinType type) {
+  switch (type) {
+    case lp::JoinType::kInner:
+      return velox::core::JoinType::kInner;
+    case lp::JoinType::kLeft:
+      return velox::core::JoinType::kLeft;
+    case lp::JoinType::kRight:
+      return velox::core::JoinType::kRight;
+    case lp::JoinType::kFull:
+      return velox::core::JoinType::kFull;
+  }
+  VELOX_UNREACHABLE();
+}
+
+Translated Translator::translateJoin(
+    const lp::JoinNode& join,
+    const LpNameSet& required) {
+  // Names the join condition reads need to be in both side's scopes; partition
+  // them by which side each name belongs to.
+  LpNameSet conditionNames;
+  if (join.condition() != nullptr) {
+    collectUsedNames(*join.condition(), conditionNames);
+  }
+  const auto& leftType = *join.left()->outputType();
+  const auto& rightType = *join.right()->outputType();
+  LpNameSet leftRequired;
+  LpNameSet rightRequired;
+  for (size_t i = 0; i < leftType.size(); ++i) {
+    const auto& name = leftType.nameOf(i);
+    if (required.contains(name) || conditionNames.contains(name)) {
+      leftRequired.insert(name);
+    }
+  }
+  for (size_t i = 0; i < rightType.size(); ++i) {
+    const auto& name = rightType.nameOf(i);
+    if (required.contains(name) || conditionNames.contains(name)) {
+      rightRequired.insert(name);
+    }
+  }
+  Translated left = translateNode(*join.left(), leftRequired);
+  Translated right = translateNode(*join.right(), rightRequired);
+
+  Scope merged = left.scope;
+  for (auto& [name, column] : right.scope) {
+    merged[name] = column;
+  }
+
+  const velox::core::JoinType joinType = toVeloxJoinType(join.joinType());
+  const bool isInner = joinType == velox::core::JoinType::kInner;
+  const bool conditionHasSubquery =
+      join.condition() != nullptr && containsSubquery(*join.condition());
+
+  // A subquery in the condition can't run inside the join operator;
+  // lift it into a Filter above the join. The lifted Filter reads
+  // condition columns from the join's output, so when lifting keep
+  // the full left+right union as `outputColumns`.
+  const bool liftConditionAbove = isInner && conditionHasSubquery;
+
+  PlanObjectSet requiredColumns;
+  if (!liftConditionAbove) {
+    auto collect = [&](const velox::RowType& type, const Scope& scope) {
+      for (size_t i = 0; i < type.size(); ++i) {
+        const auto& name = type.nameOf(i);
+        if (!required.contains(name)) {
+          continue;
+        }
+        auto it = scope.find(name);
+        VELOX_DCHECK(it != scope.end());
+        requiredColumns.add(it->second);
+      }
+    };
+    collect(leftType, left.scope);
+    collect(rightType, right.scope);
+  }
+
+  ColumnVector outputColumns;
+  for (ColumnCP column : left.node->outputColumns()) {
+    if (liftConditionAbove || requiredColumns.contains(column)) {
+      outputColumns.push_back(column);
+    }
+  }
+  for (ColumnCP column : right.node->outputColumns()) {
+    if (liftConditionAbove || requiredColumns.contains(column)) {
+      outputColumns.push_back(column);
+    }
+  }
+
+  if (liftConditionAbove) {
+    JoinCP joinNode = builder_.make<Join>(
+        {left.node,
+         right.node,
+         joinType,
+         /*leftKeys=*/ExprVector{},
+         /*rightKeys=*/ExprVector{},
+         /*filter=*/ExprVector{},
+         /*nullAware=*/false,
+         /*nullAsValue=*/false,
+         std::move(outputColumns)});
+    return maybeWrapInFilter(joinNode, *join.condition(), std::move(merged));
+  }
+
+  JoinCondition::Split split;
+  if (join.condition() != nullptr) {
+    ExprCP condition =
+        translateExpr(*join.condition(), merged, /*applyTarget=*/nullptr);
+    split = JoinCondition::splitEquiKeys(
+        ExprFactory::flattenAnd(condition),
+        PlanObjectSet::fromObjects(left.node->outputColumns()),
+        PlanObjectSet::fromObjects(right.node->outputColumns()));
+  }
+
+  JoinCP joinNode = builder_.make<Join>(
+      {left.node,
+       right.node,
+       joinType,
+       std::move(split.leftKeys),
+       std::move(split.rightKeys),
+       std::move(split.residual),
+       /*nullAware=*/false,
+       /*nullAsValue=*/false,
+       std::move(outputColumns)});
+  return {joinNode, std::move(merged)};
+}
+
+ExprCP Translator::translateExpr(
+    const lp::Expr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  switch (expr.kind()) {
+    case lp::ExprKind::kInputReference:
+      return translateInputReference(*expr.as<lp::InputReferenceExpr>(), scope);
+    case lp::ExprKind::kConstant:
+      return translateConstant(*expr.as<lp::ConstantExpr>());
+    case lp::ExprKind::kCall:
+      return translateCall(*expr.as<lp::CallExpr>(), scope, applyTarget);
+    case lp::ExprKind::kSpecialForm:
+      return translateSpecialForm(
+          *expr.as<lp::SpecialFormExpr>(), scope, applyTarget);
+    case lp::ExprKind::kLambda:
+      return translateLambda(*expr.as<lp::LambdaExpr>(), scope);
+    case lp::ExprKind::kSubquery: {
+      // Bare subquery in scalar position. `liftSubquery` decides the
+      // lowered shape: uncorrelated → cross-join + EnforceSingleRow
+      // (no Apply), correlated → kLeft Apply. Scalar shape is signaled
+      // by a null `inLhs` (no IN equi to build).
+      const auto& subquery = *expr.as<lp::SubqueryExpr>();
+      return liftSubquery(
+          subquery,
+          velox::core::JoinType::kLeft,
+          /*inLhs=*/nullptr,
+          scope,
+          applyTarget);
+    }
+    default:
+      VELOX_NYI(
+          "Unsupported expression kind: {}", static_cast<int>(expr.kind()));
+  }
+}
+
+ExprCP Translator::translateInputReference(
+    const lp::InputReferenceExpr& expr,
+    const Scope& scope) {
+  const auto& name = expr.name();
+  auto it = scope.find(name);
+  if (it != scope.end()) {
+    return it->second;
+  }
+  if (ColumnCP outer = subqueries_.resolveOuter(name)) {
+    return outer;
+  }
+  VELOX_FAIL("Column not found in scope or outer scopes: {}", name);
+}
+
+ExprCP Translator::translateConstant(const lp::ConstantExpr& expr) {
+  auto* variant = queryCtx()->registerVariant(
+      std::make_unique<velox::Variant>(*expr.value()));
+  Value value(toType(expr.type()), 1);
+  return builder_.makeLiteral(value, variant);
+}
+
+ExprCP Translator::translateCall(
+    const lp::CallExpr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector args = translateAll(expr.inputs(), scope, applyTarget);
+  Value value =
+      clampCardinality(Value{toType(expr.type()), maxCardinality(args)});
+  Name name = toName(expr.name());
+  FunctionSet funcs =
+      Call::unionArgFunctions(functionBits(name, /*specialForm=*/false), args);
+  auto* call = builder_.makeCall(name, value, std::move(args), funcs);
+  return simplifier_.simplify(call);
+}
+
+// True if 'expr' is `lp::SpecialFormExpr(kIn, [value, SubqueryExpr])` —
+// i.e., the IN-subquery form that lifts to Apply, distinguished from
+// `IN (literal_list)` which lowers as an ordinary in-list expression.
+bool isInSubqueryForm(const lp::Expr& expr) {
+  if (!expr.isSpecialForm()) {
+    return false;
+  }
+  const auto& sf = *expr.as<lp::SpecialFormExpr>();
+  return sf.form() == lp::SpecialForm::kIn && sf.inputs().size() == 2 &&
+      sf.inputAt(1)->isSubquery();
+}
+
+ExprCP Translator::translateSpecialForm(
+    const lp::SpecialFormExpr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  if (expr.form() == lp::SpecialForm::kExists) {
+    return translateExists(expr, scope, applyTarget);
+  }
+
+  // IN (subquery): translate the lhs, then lift
+  // `Apply(kLeftSemiProject)` passing the lhs — `liftSubquery` records
+  // the lhs and the body's single output column as `Apply.inLhs` /
+  // `Apply.inBodyKey`. `Apply.nullAware()` returns true from
+  // their presence. Plain `IN (literals...)` flows through the
+  // generic path below.
+  if (isInSubqueryForm(expr)) {
+    ExprCP lhs = translateExpr(*expr.inputAt(0), scope, applyTarget);
+    const auto& subquery = *expr.inputAt(1)->as<lp::SubqueryExpr>();
+    return liftSubquery(
+        subquery,
+        velox::core::JoinType::kLeftSemiProject,
+        /*inLhs=*/lhs,
+        scope,
+        applyTarget);
+  }
+
+  // NOT EXISTS / NOT IN come through as `lp::Call("not", [kExists|kIn])`,
+  // not as a `SpecialForm::kNot`. The Call recursion handles the wrap:
+  // translateCall translates the EXISTS/IN arg (which lifts Apply and
+  // returns its mark), then builds `Call("not", [mark])`. The Apply
+  // shape is identical for IN vs NOT IN — null-aware semi-project both
+  // ways; the surrounding NOT inverts the mark.
+
+  ExprVector args = translateAll(expr.inputs(), scope, applyTarget);
+  Value value =
+      clampCardinality(Value{toType(expr.type()), maxCardinality(args)});
+
+  // Drop a redundant cast: CAST(x AS t) => x when typeof(x) == t. TRY_CAST too,
+  // since a same-type cast never errors. Pointer equality on interned types is
+  // exact, so a row-renaming cast (distinct interned type) is kept.
+  if (expr.form() == lp::SpecialForm::kCast ||
+      expr.form() == lp::SpecialForm::kTryCast) {
+    VELOX_CHECK_EQ(args.size(), 1);
+    if (args[0]->value().type == value.type) {
+      return args[0];
+    }
+  }
+
+  // Normalize an IN list: a single element folds to equality (`x IN (a)` is
+  // `x = a`) and a constant list drops duplicates (`x IN (a, a)` is `x IN
+  // (a)`).
+  if (expr.form() == lp::SpecialForm::kIn) {
+    if (ExprCP folded = normalizeInList(args)) {
+      return folded;
+    }
+  }
+
+  // `SpecialFormCallNames::toCallName` returns a static literal that is
+  // pointer-compared in `tryFromCallName`. Do not re-intern via `toName`,
+  // which would allocate a fresh arena copy and break the comparison.
+  Name callName = SpecialFormCallNames::toCallName(expr.form());
+
+  if (expr.form() == lp::SpecialForm::kDereference) {
+    return translateDereference(std::move(args), callName, value);
+  }
+
+  FunctionSet funcs = Call::unionArgFunctions(
+      functionBits(callName, /*specialForm=*/true), args);
+  auto* call = builder_.makeCall(callName, value, std::move(args), funcs);
+  return simplifier_.simplify(call);
+}
+
+ExprCP Translator::translateExists(
+    const lp::SpecialFormExpr& expr,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  VELOX_CHECK_EQ(expr.inputs().size(), 1);
+  const auto& subquery = *expr.inputs()[0]->as<lp::SubqueryExpr>();
+
+  // Fast path — EXISTS over a scalar (non-grouping) Aggregate with no
+  // HAVING above it is provably TRUE per SQL: scalar aggregates always
+  // emit exactly one row, so EXISTS sees that one row regardless of
+  // input cardinality. Fold to a constant before constructing Apply,
+  // matching Presto / modern DuckDB on shapes like
+  // `EXISTS (SELECT count(*) FROM t WHERE p)`. HAVING is the only
+  // operator that can make EXISTS-over-scalar-Agg evaluate to FALSE;
+  // when present (Filter above Aggregate), the root is a FilterNode
+  // and this fast path doesn't fire — Decorrelate's Rule B-EXISTS
+  // Path 1 handles it correctly.
+  //
+  // Walk past output-shaping Project chains (parser typically wraps
+  // `SELECT count(*) FROM ...` as `Project(Aggregate(...))`).
+  const lp::LogicalPlanNode* root = subquery.subquery().get();
+  while (root != nullptr && root->kind() == lp::NodeKind::kProject) {
+    root = root->onlyInput().get();
+  }
+  if (root != nullptr && root->kind() == lp::NodeKind::kAggregate) {
+    const auto* aggNode = root->as<lp::AggregateNode>();
+    if (aggNode->groupingKeys().empty() && aggNode->groupingSets().empty()) {
+      return builder_.makeLiteral(
+          velox::Variant(true), toType(velox::BOOLEAN()));
+    }
+  }
+  return liftSubquery(
+      subquery,
+      velox::core::JoinType::kLeftSemiProject,
+      /*inLhs=*/nullptr,
+      scope,
+      applyTarget);
+}
+
+ExprCP Translator::normalizeInList(ExprVector& args) {
+  VELOX_CHECK_GE(args.size(), 2);
+
+  // Single-element folding is sound in three-valued logic: `a IN (b)` and
+  // `a = b` agree on true, false, and null. The null-literal case folds to a
+  // constant (rather than `eq(a, null)`) so the surrounding expression can fold
+  // further without materializing the column.
+  auto foldSingleElement = [&](ExprCP element) -> ExprCP {
+    if (element->is(PlanType::kLiteralExpr) &&
+        element->as<Literal>()->literal().isNull()) {
+      return builder_.makeLiteral(
+          velox::Variant::null(velox::TypeKind::BOOLEAN),
+          toType(velox::BOOLEAN()));
+    }
+    return simplifier_.simplify(exprFactory_.makeEq(args[0], element));
+  };
+
+  if (args.size() == 2) {
+    return foldSingleElement(args[1]);
+  }
+
+  // A multi-element list can be deduped and lowered to an array constant only
+  // when every element is a literal.
+  if (!std::all_of(args.begin() + 1, args.end(), [](ExprCP arg) {
+        return arg->is(PlanType::kLiteralExpr);
+      })) {
+    return nullptr;
+  }
+
+  // Equal Literals hash-cons to the same Expr, so dedup by identity.
+  ExprVector deduped;
+  deduped.reserve(args.size());
+  deduped.push_back(args[0]);
+  folly::F14FastSet<ExprCP> seen;
+  seen.reserve(args.size() - 1);
+  for (size_t i = 1; i < args.size(); ++i) {
+    if (seen.insert(args[i]).second) {
+      deduped.push_back(args[i]);
+    }
+  }
+
+  // A list of equal literals (`a IN (5, 5)`) collapses to a single value.
+  if (deduped.size() == 2) {
+    return foldSingleElement(deduped[1]);
+  }
+  args = std::move(deduped);
+  return nullptr;
+}
+
+ExprCP Translator::translateDereference(
+    ExprVector args,
+    Name callName,
+    const Value& value) {
+  // Resolve a varchar field name to a numeric field index against the input row
+  // type, so emit only ever sees an integer selector.
+  VELOX_CHECK_EQ(args.size(), 2);
+  VELOX_CHECK(args[1]->is(PlanType::kLiteralExpr));
+  const auto* selector = args[1]->as<Literal>();
+  const auto* baseType = args[0]->value().type;
+  VELOX_CHECK(baseType->isRow());
+  int32_t index;
+  if (selector->literal().kind() == velox::TypeKind::VARCHAR) {
+    const auto& name = selector->literal().value<velox::TypeKind::VARCHAR>();
+    index = baseType->asRow().getChildIdx(name);
+  } else {
+    const int64_t raw = integerValue(&selector->literal());
+    VELOX_CHECK_GE(raw, 0);
+    VELOX_CHECK_LT(raw, baseType->size());
+    index = static_cast<int32_t>(raw);
+  }
+  auto* indexLiteral =
+      builder_.makeLiteral(velox::Variant(index), toType(velox::INTEGER()));
+  ExprVector resolved{args[0], indexLiteral};
+  FunctionSet funcs = Call::unionArgFunctions(
+      functionBits(callName, /*specialForm=*/true), resolved);
+  auto* call = builder_.makeCall(callName, value, std::move(resolved), funcs);
+  return simplifier_.simplify(call);
+}
+
+ExprCP Translator::translateLambda(
+    const lp::LambdaExpr& expr,
+    const Scope& scope) {
+  const auto& signature = expr.signature();
+
+  // TODO: mint canonical `Column*` per `(arg position, arg type)` so
+  // structurally-equal lambdas share one `Lambda*` (and their bodies share
+  // one `Call*` via Call hash-cons). Today each occurrence mints fresh arg
+  // Columns, defeating pointer-keyed dedup.
+  Scope bodyScope = scope;
+  ColumnVector args;
+  args.reserve(signature->size());
+  for (size_t i = 0; i < signature->size(); ++i) {
+    Name argName = toName(signature->nameOf(i));
+    Value argValue(toType(signature->childAt(i)), 1);
+    auto* column = Column::create(argName, argValue);
+    args.push_back(column);
+    bodyScope[signature->nameOf(i)] = column;
+  }
+
+  // Lambdas appear inside higher-order functions; subqueries inside a
+  // lambda body would need lifting above the surrounding higher-order
+  // call's relational input — uncommon and not threaded today.
+  ExprCP body = translateExpr(*expr.body(), bodyScope, /*applyTarget=*/nullptr);
+  return make<Lambda>(std::move(args), toType(expr.type()), body);
+}
+
+// Returns true if 'node' provably produces exactly one row. An EnforceSingleRow
+// over such a node is a no-op: the >1-row assertion can never fire, and the
+// empty-input null row it would synthesize can never be produced. Conservative
+// — returns false when it cannot prove exactly one row.
+bool producesExactlyOneRow(NodeCP node) {
+  switch (node->nodeType()) {
+    case NodeType::kAggregate: {
+      // A global (ungrouped) aggregate emits exactly one row, even over empty
+      // input. A grouping-set aggregate keys on the group-id column, so its
+      // grouping keys are non-empty and it is excluded here.
+      const auto* aggregate = node->as<Aggregate>();
+      return aggregate->groupingKeys().empty();
+    }
+    case NodeType::kEnforceSingleRow:
+      return true;
+    case NodeType::kProject:
+      return producesExactlyOneRow(node->as<Project>()->input());
+    default:
+      return false;
+  }
+}
+
+ColumnCP Translator::liftSubquery(
+    const lp::SubqueryExpr& subqueryExpr,
+    velox::core::JoinType kind,
+    ExprCP inLhs,
+    const Scope& outerScope,
+    NodeCP* applyTarget) {
+  VELOX_USER_CHECK_NOT_NULL(
+      applyTarget,
+      "Subquery encountered in an expression position with no relational "
+      "input above which to lift Apply");
+
+  const bool isSemi = kind == velox::core::JoinType::kLeftSemiProject;
+  // IN is the semi shape that has a non-null `inLhs`. EXISTS is semi
+  // without one. Scalar is non-semi (kInner or kLeft).
+  const bool isIn = isSemi && inLhs != nullptr;
+  const bool isExists = isSemi && !isIn;
+  // EXISTS reads only row presence — empty required-set lets the body
+  // prune all output columns. IN and scalar both need every body
+  // output column kept (IN reads it for the equi predicate; scalar
+  // reads it as the value).
+  const LpNameSet required =
+      isExists ? LpNameSet{} : allNames(*subqueryExpr.subquery()->outputType());
+
+  subqueries_.push(outerScope);
+  Translated inner = translateNode(*subqueryExpr.subquery(), required);
+  ColumnVector correlationColumns = subqueries_.pop();
+
+  NodeCP body = inner.node;
+  ColumnCP markColumn = nullptr;
+  ColumnCP returnedColumn = nullptr;
+  bool enforceSingleRow = false;
+
+  if (isSemi) {
+    // EXISTS / IN: synthesize a fresh BOOLEAN mark. Apply emits it via
+    // `markColumn`; the parent expression site references it.
+    // `enforceSingleRow` is meaningless for semi (cardinality assertion
+    // doesn't apply); kept false.
+    markColumn = Column::createBoolean("mark");
+    returnedColumn = markColumn;
+  } else {
+    // Scalar: body must produce exactly one column. The single body
+    // output col IS the value the parent expression references.
+    const auto& bodyOut = body->outputColumns();
+    VELOX_USER_CHECK_EQ(
+        bodyOut.size(), 1, "Scalar subquery must produce exactly one column");
+    returnedColumn = bodyOut[0];
+    // Shape C fix: if body's
+    // single output column collides by name with any column in
+    // applyTarget's outputColumns (e.g., `SELECT (SELECT a) FROM t`
+    // where body's output and outer t.a are both named "a"), wrap
+    // body in an aliasing Project with a fresh name. The alias becomes
+    // returnedColumn.
+    //
+    // KNOWN LIMITATION: this fix is design-correct at Translate level,
+    // but Decorrelate's Project peel currently exposes the original
+    // body (under the alias wrap) when peeling, and the resulting
+    // inner Apply's outputColumns = input.cols ++ originalBody.cols
+    // brings the duplicate back. Full Shape C handling requires
+    // Decorrelate's Project peel to apply the same aliasing trick to
+    // body cols that collide with input cols. Currently NYI in
+    // Decorrelate; tests like `SELECT (SELECT a) FROM t` still fail
+    // with "Duplicate output column" at PlanConsistencyChecker.
+    {
+      const auto& targetCols = (*applyTarget)->outputColumns();
+      auto hasNameCollision = [&](std::string_view name) {
+        for (ColumnCP c : targetCols) {
+          if (c->name() == name) {
+            return true;
+          }
+        }
+        return false;
+      };
+      if (hasNameCollision(returnedColumn->name())) {
+        ColumnCP alias = Column::create(
+            std::string(returnedColumn->name()) + "__lift",
+            returnedColumn->value());
+        body = builder_.make<Project>(Project::Key{
+            body,
+            ExprVector{returnedColumn},
+            ColumnVector{alias},
+        });
+        returnedColumn = alias;
+      }
+    }
+
+    if (correlationColumns.empty()) {
+      // Uncorrelated scalar: cross-join with the body, which must yield a
+      // single row. Wrap it in EnforceSingleRow unless it already provably
+      // produces exactly one row, in which case the guard is a no-op.
+      NodeCP wrapped = producesExactlyOneRow(body)
+          ? body
+          : builder_.make<EnforceSingleRow>(EnforceSingleRow::Key{body});
+
+      ColumnVector joinOutput = (*applyTarget)->outputColumns();
+      appendUnique(joinOutput, wrapped->outputColumns());
+
+      *applyTarget = builder_.make<Join>(Join::Key{
+          *applyTarget,
+          wrapped,
+          velox::core::JoinType::kInner,
+          /*leftKeys=*/{},
+          /*rightKeys=*/{},
+          /*filter=*/ExprVector{},
+          /*nullAware=*/false,
+          /*nullAsValue=*/false,
+          std::move(joinOutput),
+      });
+      return returnedColumn;
+    }
+
+    // Correlated scalar: kLeft Apply with enforceSingleRow=true.
+    enforceSingleRow = true;
+  }
+
+  // For IN: capture the equi pair `(lhs, body.col)` directly. Apply
+  // stores it as `inLhs` / `inBodyKey`; downstream consumers either
+  // read the pair (decorrelate's semi-recovery extracts the equi-key
+  // pair directly) or reconstruct an `eq` Call (uncorrelated IN
+  // collapse uses it as the resulting Join's filter).
+  ExprCP inBodyKey = nullptr;
+  if (isIn) {
+    const auto& bodyOut = body->outputColumns();
+    VELOX_USER_CHECK_EQ(
+        bodyOut.size(), 1, "IN subquery body must produce exactly one column");
+    inBodyKey = bodyOut[0];
+  }
+
+  // Apply.outputColumns per kind:
+  //   kLeft            : input.outputColumns
+  //                      ++ unique(body.outputColumns) ++ includeMarker
+  //   kLeftSemiProject : input.outputColumns ++ markColumn
+  ColumnVector outputColumns = (*applyTarget)->outputColumns();
+  if (isSemi) {
+    outputColumns.push_back(markColumn);
+  } else {
+    appendUnique(outputColumns, body->outputColumns());
+  }
+  ColumnCP includeMarker = nullptr;
+  if (kind == velox::core::JoinType::kLeft) {
+    includeMarker = Column::createBoolean("_include");
+    outputColumns.push_back(includeMarker);
+  }
+
+  auto* apply = builder_.make<Apply>(
+      {*applyTarget,
+       body,
+       std::move(correlationColumns),
+       kind,
+       /*filter=*/ExprVector{},
+       enforceSingleRow,
+       markColumn,
+       inLhs,
+       inBodyKey,
+       includeMarker,
+       std::move(outputColumns)});
+  *applyTarget = apply;
+  return returnedColumn;
+}
+
+} // namespace
+
+TranslatePass::Result TranslatePass::run(
+    const lp::LogicalPlanNode& plan,
+    optimizer::Schema& schema,
+    velox::core::ExpressionEvaluator& evaluator,
+    Builder& builder) {
+  Translator translator(schema, evaluator, builder);
+  return translator.run(plan);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/TranslatePass.h
+++ b/axiom/optimizer/v2/TranslatePass.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/logical_plan/LogicalPlanNode.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "velox/core/Expressions.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Translates a logical plan into the tree-IR.
+class TranslatePass {
+ public:
+  /// Output of `run`. `outputColumns` and `outputNames` describe the
+  /// user-visible output layout, aligned 1:1 with each other. `outputColumns`
+  /// may contain duplicate `Column*` entries (e.g., `SELECT v, v`).
+  struct Result {
+    NodeCP root;
+    ColumnVector outputColumns;
+    std::vector<std::string> outputNames;
+  };
+
+  /// Translates 'plan' into a tree-IR plus its user-visible output layout.
+  /// Looks up base tables via 'schema' for Scan nodes. Uses 'evaluator' to
+  /// constant-fold call expressions whose arguments are all literals. Uses
+  /// 'builder' to hash-cons tree-IR nodes; share a single Builder across
+  /// translate and downstream rewrites so identical sub-trees dedup across
+  /// passes. Throws VELOX_NYI for logical_plan node or expression types not
+  /// yet supported.
+  ///
+  /// 'schema' must outlive the returned IR (and any Velox plan emitted from
+  /// it). The IR's `BaseTable` nodes hold raw pointers to `TableLayout`s
+  /// owned by `schema`'s connector::Table entries; dropping `schema` before
+  /// emit leaves those pointers dangling.
+  ///
+  /// 'evaluator' and the memory pool it owns must outlive the returned IR
+  /// and any Velox plan derived from it. Compilation of foldable expressions
+  /// can allocate vectors on the evaluator's pool that are then referenced
+  /// from downstream `emit` outputs.
+  static Result run(
+      const logical_plan::LogicalPlanNode& plan,
+      optimizer::Schema& schema,
+      velox::core::ExpressionEvaluator& evaluator,
+      Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/docs/Decorrelate-agg-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-agg-rules.md
@@ -1,0 +1,705 @@
+# Apply-over-Aggregate Pushdown Rules
+
+*Companion to `Decorrelate-outer-refs-design.md` (resolves outer
+references) and `Decorrelate-design-rationale.md` (alternatives
+considered and rejected).*
+
+Iterative decorrelation peels one body operator per step. This doc
+covers the case where that operator is an `Aggregate`. It defines
+the lift shape for two Apply kinds:
+
+- `kLeft` — correlated scalar / value subqueries
+- `kLeftSemiProject` — correlated semi/anti-join projections
+
+Each kind has four sub-cases along two axes — `Apply.filter` null vs
+non-null, and `Agg.gby` empty vs non-empty — but the sub-cases share
+a single shape per kind, parameterized by those axes.
+
+## Relation to the literature — read before designing rules
+
+The general framing here (Apply as a dependent join, iterative
+pushdown, lifting Aggregate via per-`rn` grouping) follows
+Neumann & Kemper's unnesting work (HyPer, Umbra, Neumann 2024). But
+the **specific lifted shapes in those papers cannot be used here as
+written**, because they assume an execution model we don't have.
+
+Standard unnesting rewrites produce plans where L (the outer side)
+appears on multiple paths — typically as input to the inner Apply
+AND as the outer side of a LEFT JOIN that re-pads outers whose
+groups all got filtered out. In HyPer/Umbra, this is safe because:
+
+- The execution engine supports **DAG plans** (a single evaluated
+  subtree can have multiple consumers), or
+- There is a **materialization primitive** ("evaluate once, read N
+  times") that the optimizer inserts.
+
+Either way, L is evaluated once, and downstream operators read the
+same rows.
+
+**We have neither.** Plans are strict trees; there is no
+materialization operator. Evaluating L twice would be unsafe for
+two independent reasons:
+
+- **`rn` mismatch.** `AssignUniqueId` is order-dependent — a second
+  scan assigns different `rn` values, so the rejoin matches nothing.
+- **Non-determinism.** L can contain `random()`, `now()`, `uuid()`,
+  multi-source reads in unspecified order — two evaluations need not
+  return identical rows.
+
+So we can't borrow the paper's rewrites for any case that requires
+re-referencing L (the multi-row-per-outer + F_post case being the
+sharpest example). For those cases, we have to design rewrites that
+keep L on a single path through the plan — even when the equivalent
+academic shape is simpler.
+
+This constraint shapes most of what follows. When a sub-case looks
+unnaturally restricted or uses an in-place trick instead of the
+"obvious" rejoin, that's why.
+
+**Forward-looking note.** Even if execution later gains diamond
+support — almost certainly via an explicit materialization operator
+(the only viable mechanism in distributed execution) — the
+tree-shape rewrites in this doc remain the preferred path.
+Materialization is not free: memory pressure, pipeline break, extra
+shuffle in distributed plans. The mature optimizer pattern (same as
+CTE handling) is: use the tree-shape rewrite when it exists;
+materialize only when the reuse savings exceed materialization cost.
+So a future "rejoin with L via materialization" rule would be added
+as a CBO option, not a replacement for the rules below.
+
+### Aside — "why not just follow the paper?"
+
+A common reaction reading the paper is: "the rewrites are clean,
+just implement them." That works in HyPer/Umbra because those
+systems are engineered around the assumption that **a DAG of
+operators with a shared subtree is a small, absorbable cost**:
+
+- Single-node main-memory execution.
+- Compressed in-memory temp storage with vectorized re-reads.
+- Intermediates in OLAP are often small post-filter / post-agg.
+
+Outside that regime, the assumption breaks down quickly:
+
+- **Pipelining.** A shared subtree forces materialization, which
+  blocks downstream operators until the subtree completes. The
+  "free" DAG costs latency and breaks streaming execution.
+- **Memory pressure.** Materialized intermediates compete with
+  hash tables, sorts, and other operators for memory.
+- **Distributed execution.** DAGs become either broadcast
+  (replicate to all consumers — only cheap for small data) or
+  shuffle (network-heavy, often dominates query cost). What was a
+  "small constant" in single-node becomes a first-class cost
+  driver.
+
+In Axiom's setting (distributed Velox execution, potentially large
+intermediates), naively applying paper-style rewrites would produce
+plans whose physical realization includes shuffles or broadcasts
+that the original SQL didn't need. The paper isn't wrong — it
+optimizes for a different execution regime. Following it without
+adapting would trade correctness for plans that are slower than the
+correlated original.
+
+This is the subtle point: the paper's rewrites are **complete and
+efficient for their target system class, but not portable as-is**.
+A meaningful chunk of decorrelation engineering in any non-HyPer
+system is the work of producing tree-friendly variants that don't
+need DAG support, or producing DAG-aware variants that cost the
+materialization correctly so the CBO can choose intelligently.
+
+## Assumed model
+
+- Apply is a "true" dependent Join. Body may reference L's columns
+  and may produce N rows / N cols per outer; Apply's output is a
+  Velox-Join-shaped result.
+- Apply has two kinds: `kLeft` and `kLeftSemiProject`.
+- Apply carries a `filter` field (the eventual Join's residual
+  filter). During iteration, `Apply.filter` accumulates predicates as
+  earlier Filter operators are peeled from body.
+- Iteration peels one body operator per step. It terminates when
+  body has no outer refs left. At terminus, Apply renames to Join.
+
+## How to think about lifting Aggregate above Apply
+
+### The mental model
+
+Conceptually, `Apply over Agg(child, gby, aggs)` runs the Aggregate
+**per outer row** — for each L row, evaluate `Agg` over the child rows
+in scope for that outer.
+
+The equivalent single-pass shape: **tag each L row with a unique id
+`rn`, join L with child once, then aggregate grouped by `rn` (and any
+original `gby`)**. Each `rn` group corresponds to one L row's worth
+of child rows; aggregating within the group reproduces per-outer
+execution.
+
+**Picture 1 — `Apply.filter` is null (the plain case):**
+
+```
+- Agg                                   ← lifted from body
+    groupingKeys = [rn, gby]            ← rn isolates each L row's data
+    aggregates   = aggs
+  - Apply (kLeft)
+    - body  = child                     ← may still depend on L
+    - input = AssignUniqueId(L) → tagged_L
+```
+
+One row per outer. Empty-input outers (no child rows) get padded by
+`kLeft` → the lifted Agg's aggregates return NULL → need to be
+restored to their empty-input value (count → 0). That happens in a
+result Project (omitted here; see "the three primitives").
+
+**Picture 2 — `Apply.filter` is non-null:**
+
+`Apply.filter` predicates split into two classes:
+- **F_pre** — references only pre-aggregation cols (L.cols, gby
+  cols). Stays as `Apply.filter` below the lifted Agg — applied
+  before aggregation, becomes the eventual Join.filter at terminus.
+- **F_post** — references the aggregate result (or both pre- and
+  post-aggregation cols). Can't apply as a Filter above the lifted
+  Agg without losing outers (see "Why F_post folds into the
+  Project's IF" below). Folds into the result Project as an `IF`
+  wrap that nulls the aggregate values when the predicate fails.
+
+```
+- Project                               ← single Project; per agg col c:
+    result_c = IF(F_post_subst, c_coal, NULL)
+                                        ← c_coal := COALESCE(c, empty(c))
+                                          (or just c when empty(c) is NULL)
+                                          F_post_subst := F_post[c → c_coal]
+  - Agg                                 ← lifted from body
+      groupingKeys = [rn, gby]
+      aggregates   = aggs FILTER (WHERE _include)   ← excludes kLeft pads
+    - Apply (kLeft, filter = F_pre)     ← F_pre stays here
+      - body  = Project(child, [..., _include := true])
+                                        ← marks real rows; NULL on pad
+      - input = AssignUniqueId(L) → tagged_L
+```
+
+Notation: `c_coal` is shorthand for the `COALESCE(c, empty(c))`
+subexpression — used in prose and substitution rules below but not
+materialized as a separate column. `F_post_subst` is `F_post` with
+every reference to an aggregate column `c` rewritten to `c_coal`, so
+`c_coal` appears in both the IF condition and the IF's THEN branch.
+
+The rest of the doc fills in the details: the next subsection
+shows WHY the COALESCE wrap is needed (without it, F_post on
+NULL-sensitive predicates breaks); "the three primitives" defines
+the COALESCE / `_include` / L.cols-carry-through mechanisms; Rule A
+spells out the full schema with all axes.
+
+### Examples (for the non-obvious cases)
+
+Picture 1 covers the plain case (e.g.,
+`SELECT (SELECT count(*) FROM u WHERE u.a = t.a) FROM t`): no
+`Apply.filter`, one row per outer, done. The examples below are
+specific SQL queries that hit Picture 2 — `Apply.filter` non-null —
+useful to anchor the F_pre / F_post mechanics.
+
+**Example 1 — HAVING plus correlated WHERE:**
+
+```sql
+SELECT (SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 5) FROM t
+```
+
+`Apply.filter = (count_result > 5)` — F_post (references the agg
+result).
+
+For each `t` row: count `u` rows where `u.a = t.a`; if count > 5,
+return count, else NULL.
+
+Two valid decorrelated shapes:
+
+- **(a) Aggregate-below-join:** group `u` by `u.a` once, then LEFT
+  JOIN with `t` on the key. Efficient when `u` has duplicates per
+  `u.a` or many `t` rows share `t.a`.
+- **(b) Aggregate-above-join:** tag `t` with `rn`, join `t × u`
+  filtered by the correlation, aggregate per `rn`. Efficient when
+  the join is selective or the aggregate doesn't reduce cardinality.
+
+Both produce the same answer; choice between them is a cost
+decision.
+
+**Example 2 — HAVING-only correlation (motivates the F_post tweak):**
+
+```sql
+SELECT (SELECT count(*) FROM u HAVING count(*) > t.a) FROM t
+```
+
+`Apply.filter = (count_result > t.a)` — F_post (references both the
+agg result and an outer column).
+
+The aggregate is independent of `t`; the correlation lives entirely
+in HAVING. This is the case the next subsection picks apart.
+
+### Why F_post evaluates on `c_coal`, not raw `c`
+
+One concrete failure case shows why F_post in Picture 2 references
+`c_coal` (the `COALESCE(c, empty(c))` subexpression) and not the
+raw aggregate column `c`.
+
+Take this query:
+
+```sql
+SELECT (SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) = 0) FROM t
+```
+
+For a `t` row with no matching `u` rows (`u.a = t.a` returns 0
+rows), the original semantics:
+- Per-outer Agg over 0 rows: `count(*) = 0` (count's empty-input value).
+- HAVING: `0 = 0` → true → return 0.
+
+Now lift the Agg above Apply. The 0-match outer hits a `kLeft` pad
+→ `_include = NULL` → `FILTER (WHERE _include)` excludes the row
+→ `count(*)` over an empty group returns NULL (not 0).
+
+So the lifted Agg's raw `c = NULL` for this outer. If F_post used
+`c` directly, the HAVING would be `NULL = 0` → NULL → false → the
+result would be NULL. Wrong: original was 0.
+
+The COALESCE wrap restores the empty-input value before F_post
+sees it: `c_coal = COALESCE(c, 0) = 0` for the 0-match outer. The
+Project's IF then evaluates `IF(c_coal = 0, c_coal, NULL) =
+IF(0 = 0, 0, NULL) = 0`. ✓
+
+The general rule: any aggregate with a non-NULL empty-input value
+(count, count_if, …) needs F_post to see `c_coal` so NULL-sensitive
+predicates (`= 0`, `IS NULL`, `COALESCE(c, -1) < 0`, …) match the
+original semantics.
+
+### Shape (a) for equi correlation; shape (b) otherwise
+
+`kLeft` Aggregate peel emits **shape (a)** — aggregate the body once
+grouped by the correlation key, then LEFT-join the result back to the
+outer (no `AssignUniqueId`) — when the correlation lifts cleanly to
+equi keys and the aggregates don't reference the outer (`aggregatePeel`
+→ `aggregatePeelEqui` in `DecorrelatePass.cpp`). Otherwise it falls back to
+**shape (b)**, the AssignUniqueId per-outer-`rn` form the rest of this
+doc describes.
+
+No cardinality estimate is needed for the rewrite itself. Whether the
+body *scan* is restricted depends on the join-back's build/probe
+orientation, because a dynamic filter only reaches the **probe** side:
+
+- When the cost model builds the **outer** (the smaller side) and probes
+  the body aggregate, the DF on the correlation key (the aggregate's
+  grouping key) propagates through the `HashAggregation` to the body's
+  `TableScan`, restricting it to the outer's keys — q2/q17, whose outers
+  are selective (see the dynamic-filter note in
+  `TpchV1V2PlanComparison.md`).
+- When the **outer** is the larger side, the cost model builds the body
+  aggregate, which must scan and aggregate the whole body first; the DF
+  then restricts the outer, not the body. To restrict the body here —
+  especially when the outer has many rows but few distinct correlation
+  keys — an explicit reducing semijoin (push the outer's distinct keys
+  into the body before aggregating) is still needed. That reducer is
+  deferred; today shape (a) relies on DF, which covers the selective-outer
+  case.
+
+Shape (b) remains for non-equi correlation (`u.a > t.a`) and bodies where
+the correlation can't be lifted to equi keys above a correlation-free
+subtree.
+
+## The three primitives
+
+Every per-case rule below composes these three mechanisms. Defined
+once here; the rules reference them.
+
+**1. L.cols carry-through.** The lifted Aggregate's output naturally
+contains `rn`, `gby`, and aggregate result columns — but not L's
+other columns. For each `L.col`, add an `arbitrary(L.col)` aggregate
+whose output column REUSES the original L.col's `Column*`. Since
+L.col is constant within each `rn` group, `arbitrary` returns that
+value; downstream refs to L.col resolve unchanged.
+
+**2. `_include` marker for outer preservation.** With `kLeft` Apply,
+outers whose child produces 0 rows are padded with NULL — those
+padded rows would otherwise contribute to the aggregate (e.g.,
+`count(*) = 1` instead of `0`). Project `_include := true` on real
+body rows; LEFT JOIN padding turns it to NULL. Apply
+`FILTER (WHERE _include)` to every aggregate so padded rows are
+excluded.
+
+**3. Empty-input value reconstruction.** Per-outer execution of
+`count(*)` over 0 rows produces `0`, not NULL. After `_include`
+filtering, the aggregate returns NULL for padded outers. The result
+Project wraps in `COALESCE(agg, empty(agg))` for aggregates whose
+empty-input value is non-NULL (count, count_if, etc., per
+`FunctionRegistry::aggregateEmptyResultResolver`). Other aggregates
+(sum, max, etc.) leave NULL alone — that's their correct empty-input
+value.
+
+## Apply.filter classification: F_pre vs F_post
+
+When `Apply.filter` is non-null, each predicate falls into one of two
+classes:
+
+| Class | References | Placement |
+|-------|-----------|-----------|
+| **F_pre** | L.cols, gby cols (Aggregate's grouping-key outputs), `_include` | Stays on inner Apply's filter (becomes Join.filter at terminus) — applied before aggregation |
+| **F_post** | Post-aggregation cols (`gby`, agg results), OR mixed | Folded into the result Project as `IF(F_post_subst, c_coal, NULL)` — applied after aggregation |
+
+Above the lifted `Agg` sits a single Project that both restores
+empty-input values and applies the F_post IF wrap:
+
+```
+- Project           ← per agg col c:
+                       IF(F_post_subst, COALESCE(c, empty(c)), NULL)
+                       (the COALESCE is omitted when empty(c) is NULL)
+  - Agg (lifted, grouped by rn[, gby])
+    - Apply (kLeft, filter = F_pre)
+      ...
+```
+
+**Why F_post folds into the Project's IF instead of becoming a
+Filter node.** In the original tree, F_post was `Apply (kLeft).filter`
+sitting above a per-outer Aggregate that produces exactly one row
+per outer. If F_post failed, `kLeft` would pad the dropped row back
+as NULL — so the outer is always preserved, just with NULL values.
+
+After lifting Aggregate above Apply, the lifted Aggregate produces
+one row per outer (via `rn` grouping). There is no `kLeft` above it
+to pad. Putting F_post as a Filter node here would drop the row
+outright, losing the outer. The IF-in-Project shape reproduces the
+original behavior exactly: the row stays in place, and when F_post
+fails the per-aggregate values become NULL.
+
+Mixed predicates (e.g., `agg_result > L.col + 5`) count as F_post.
+L.cols remain accessible in the result Project via the carry-through
+primitive.
+
+## Cases covered
+
+Three axes pick the rule:
+- **Apply.kind** — `kLeft` (scalar correlated) or `kLeftSemiProject`
+  (EXISTS / IN).
+- **`Agg.gby`** — empty (global aggregate) or non-empty.
+- **IN-pair** (`Apply.inLhs` / `Apply.inBodyKey`) — only meaningful
+  for `kLeftSemiProject`; null means EXISTS-shape, non-null means
+  IN-shape with the equi pair `eq(inLhs, inBodyKey)` and `nullAware`
+  semantics applied at terminus.
+
+`Apply.filter` (null or non-null; F_pre / F_post split when non-null)
+parameterizes within each rule's body, not across rules.
+
+| # | Apply.kind | `Agg.gby` | IN-pair | Rule |
+|---|------------|-----------|---------|------|
+| 1 | `kLeft` | empty | n/a | A |
+| 2 | `kLeft` | non-empty | n/a | A ¹ |
+| 3 | `kLeftSemiProject` | empty | null (EXISTS) | **B-EXISTS Path 1** |
+| 4 | `kLeftSemiProject` | empty | non-null (IN) | **B-IN Path 1** |
+| 5 | `kLeftSemiProject` | non-empty | null (EXISTS) | **B-EXISTS Path 2** |
+| 6 | `kLeftSemiProject` | non-empty | non-null (IN) | **B-IN Path 2** |
+
+¹ NYI when `Apply.filter` is non-null (correlated post-aggregate
+predicate over a multi-row gby). Design open between window-based
+per-rn collapse vs translate-side restriction; see
+`Decorrelate-design-rationale.md`.
+
+NYI cases throw at planning time; they don't silently produce wrong
+results.
+
+Rule body discussions below refer to the original sub-case
+enumeration that splits each row above by `Apply.filter` and (for
+Rule B) by EXISTS / IN. The mapping:
+
+- Rule A → sub-cases 1 (filter null, empty gby), 2 (null, non-empty),
+  3 (non-null, empty), 4 (non-null, non-empty — NYI).
+- Rule B-EXISTS Path 1 → 5a (filter null), 7a (non-null).
+- Rule B-EXISTS Path 2 → 6a (null), 8a (non-null).
+- Rule B-IN Path 1 → 5b (null), 7b (non-null).
+- Rule B-IN Path 2 → 6b (null), 8b (non-null).
+
+**NYI error message format** (deferred cases):
+
+```
+VELOX_NYI("Decorrelate Case <N> (<kind>, Apply.filter <null|non-null>, "
+          "Agg.gby <empty|non-empty>, IN-pair <null|non-null>) is not "
+          "yet implemented");
+```
+
+The check fires inside the Aggregate peel before any IR is constructed.
+
+## Rule A — `kLeft`
+
+**Before:**
+
+```
+- Apply (kLeft, filter = F)              // F may be null
+  - body = Agg(child, gby, aggs)          // gby may be empty
+  - input = L
+```
+
+**After:**
+
+```
+- Project:                              // single Project; per output col:
+    for each agg output c:
+      c_coal       = COALESCE(c, empty(c))   if empty(c) is non-NULL
+                     = c                     otherwise
+      F_post_subst = F_post[c → c_coal]
+      result_c     = IF(F_post_subst, c_coal, NULL)   if F_post applicable
+                     = c_coal                         otherwise
+    other cols: pass-through
+  - Agg
+      groupingKeys = [rn] ++ gby
+      aggregates   = aggs with FILTER (WHERE _include)
+                  ++ arbitrary(L.col) for each L.col
+    - Apply (kLeft, filter = F_pre)          // F_pre may be empty
+      - body  = Project(child, [..., _include := true])
+      - input = AssignUniqueId(L) → tagged_L
+```
+
+Where:
+
+- `F_pre`, `F_post` come from splitting `F` per the classification
+  above. When `F` is null, both are empty (the IF wrap drops out;
+  the COALESCE wrap still applies).
+- `F_post_subst` is `F_post` with each aggregate column ref `c`
+  rewritten to `c_coal`. See "Why F_post must evaluate on the
+  COALESCE'd value" for why.
+- `gby` adds zero or more grouping keys; an outer with 0 child rows
+  produces a `(rn, NULL_gby)` pad-row → `_include` filter excludes
+  → aggregates NULL → COALESCE restores empty-input values → exactly
+  one output row per outer.
+- Result Project's IF wrap applies per-aggregate; gby columns pass
+  through unchanged (NULL on padded outers, per original `kLeft`
+  semantics).
+
+## Rule B — `kLeftSemiProject`
+
+Direction: **`bool_or` recovery** (lifted Aggregate emits
+`bool_or(_include)` or `bool_or(combined) FILTER(_include)`; mark IS
+the aggregate output, wrapped in `COALESCE(..., false)` for
+non-null-aware shapes). Rejected alternatives: a new counting join
+kind, and the v1-style `NOT(count == 0)` pattern — both add substrate
+or wrappers for no semantic gain.
+
+Recovery only fires when the body Aggregate's user aggregates are
+genuinely referenced past the kSemi mark. The aggregate-elision
+early-out below catches the more common DISTINCT-shaped bodies
+before they reach the per-IN/EXISTS rules.
+
+### Aggregate-elision early-out
+
+Fires at the entry of `aggregatePeelSemi`, before the IN/EXISTS
+dispatch. Preconditions:
+
+- `aggregate->groupingKeys()` non-empty (scalar Aggregate is
+  Case 5a's fast-path, handled separately — `Aggregate` over an
+  empty input emits one row, so dropping it would change EXISTS
+  semantics)
+- `accumulatedFilter` does not reference any of
+  `aggregate->aggregates()` outputs
+- `inBodyKey` (for IN) does not reference any of
+  `aggregate->aggregates()` outputs
+
+When these hold, the body Aggregate is a pure DISTINCT — kSemi
+already dedupes its body, so drop the Aggregate and rewrite a new
+`Apply(kLeftSemiProject, body=aggregate->input(), ...)` with
+`accumulatedFilter` and `inBodyKey` substituted through the
+grouping-key output → grouping-key expression map. The outer driver
+then takes the simpler kSemi join-peel path, which the executor
+runs natively as `LEFT SEMI (PROJECT)` — no AssignUniqueId, no
+two-stage Aggregate, no `bool_or` recovery.
+
+This subsumes Cases 6a (EXISTS, no HAVING) and the IN analogue
+where `inBodyKey` is a grouping-key expression with no HAVING, and
+also handles HAVING-over-grouping-keys (the HAVING substitutes
+through unchanged and rides along as the new Apply's filter, to
+be pushed down on the next iteration). The recovery paths below
+remain in play for the genuinely-need-the-aggregate cases (Cases
+7a/8a with HAVING referencing a user agg, IN where `inBodyKey`
+references a user agg, null-aware IN with the equi-pair on an
+aggregate output).
+
+## Rule B-EXISTS — `kLeftSemiProject` without IN equi-pair (`Apply.inLhs == nullptr`)
+
+Covers Cases 5a/6a/7a/8a. Mirrors Rule B-IN's structure with the
+equi-pair half of `combined` removed and the mark CASE reduced to a
+two-state form (no null-aware tri-state — EXISTS has no NULL source).
+
+  combined := COALESCE(F_post_subst, false)   if F_post present
+              TRUE                              otherwise
+
+### Path 1 — empty gby (cases 5a, 7a): single aggregate + inline mark
+
+Stage-1 Aggregate per `[rn]` produces one row per outer. Mark =
+`combined` directly.
+
+```
+Aggregate:
+  gby  = [rn]
+  aggs = body's user aggs FILTER(_include)
+       ++ arbitrary(L.col) for each outer col
+
+Final Project:
+  mark := combined
+       (= TRUE for 5a; = COALESCE(F_post_subst, false) for 7a)
+```
+
+For 5a: mark = TRUE for every outer (matches strict SQL — scalar agg
+always emits one row → EXISTS sees one row → TRUE).
+For 7a (pad-only outer): user aggs FILTER(_include) evaluate over the
+empty set, so `F_post_subst` runs against the SQL "agg over empty"
+values (NULL for max, 0 for count) and mark reflects that.
+
+### Path 2 — non-empty gby (case 8a): two aggregates
+
+Case 6a (no F_post, non-empty gby) is caught by the aggregate-elision
+early-out above; this path serves the F_post-present case only.
+
+Stage 1 per `[rn, gby...]`; Stage 1.5 Project computes `combined`
+per group; Stage 2 per `[rn]` collapses across groups.
+
+```
+Stage 1 Aggregate (lifted body):
+  gby  = [rn, gby...]
+  aggs = body's user aggs FILTER(_include)
+       ++ arbitrary(_include)        -- pad marker for Stage 2 FILTER
+       ++ arbitrary(L.col)
+
+Stage 1.5 Project (per-group combined bit):
+  combined := TRUE | COALESCE(F_post_subst, false)
+
+Stage 2 Aggregate (mark recovery):
+  gby  = [rn]
+  aggs:
+    bool_or(combined) FILTER(_include) AS has_true
+    arbitrary(L.col)
+
+Final Project:
+  mark := COALESCE(has_true, false)
+```
+
+For 6a (no F_post): `combined = TRUE`. `bool_or(TRUE) FILTER(_include)`
+returns TRUE if any real group exists, NULL if pad-only outer.
+COALESCE → FALSE for pad-only — matches strict SQL "gby on empty
+input → 0 groups → FALSE".
+For 8a (with F_post): mark = TRUE iff any real group passes HAVING.
+
+### Invariants (both paths)
+
+- Same `_include`-discrimination invariant as B-IN: the FILTER on
+  Stage 2's bool_or discards the synthetic pad-only group.
+- F_post coalesces to **false** — a HAVING that fails or returns NULL
+  on a real row drops that row's contribution to existence.
+- No `nullAware` consideration — EXISTS has no equi-pair to source
+  NULL from. Mark is unconditionally two-state.
+
+## Rule B-IN — `kLeftSemiProject` with IN equi-pair (`Apply.inLhs` / `Apply.inBodyKey` non-null)
+
+Covers cases 5b/6b/7b/8b uniformly. Two paths, branched on
+`aggregate->groupingKeys().empty()`. Both build
+the same `combined` per body row:
+
+  combined := [if F_post present: COALESCE(F_post_subst, false) AND]
+              eq(inLhs, inBodyKey_subst)
+
+F_post coalesces to **false**: a HAVING that fails or returns NULL on
+a body row means the row does not contribute to the IN match.
+
+### Path 1 — empty gby (cases 5b, 7b): single aggregate + inline mark
+
+Stage-1 Aggregate per `[rn]` produces exactly one row per outer.
+Mark derived in the final Project via a NULL-aware CASE — no Stage 2.
+
+```
+Aggregate:
+  gby  = [rn]
+  aggs = body's user aggs FILTER(_include)
+       ++ arbitrary(_include)        -- pad marker
+       ++ arbitrary(L.col)
+       ++ arbitrary(inLhs)           [if outer]
+
+Final Project:
+  mark := CASE
+    WHEN _include IS NULL THEN false   -- empty body → IN = false
+    WHEN combined         THEN true
+    WHEN combined IS NULL THEN NULL    -- null-aware NULL state
+    ELSE                       false
+  END
+```
+
+### Path 2 — non-empty gby (case 8b, and 6b when `inBodyKey` references a user aggregate): two aggregates
+
+When `inBodyKey` is purely a grouping-key expression and no HAVING is
+present, Case 6b is caught by the aggregate-elision early-out above
+(IN naturally dedupes its right-hand side). This path serves the
+cases where the user aggregates are genuinely referenced —
+typically `inBodyKey = max(...)` / `min(...)` / etc., or any
+HAVING that references aggregate outputs.
+
+Stage 1 per `[rn, gby...]`; Stage 2 per `[rn]` collapses across gby
+groups using two `bool_or`s to preserve null-awareness.
+
+```
+Stage 1 Aggregate (lifted body):
+  gby  = [rn, gby...]
+  aggs = body's user aggs FILTER(_include)
+       ++ arbitrary(_include)
+       ++ arbitrary(L.col)
+       ++ arbitrary(inLhs)
+
+Stage 1.5 Project (per-group combined bit):
+  combined := COALESCE(F_post_subst, false) AND eq(inLhs, inBodyKey_subst)
+
+Stage 2 Aggregate (mark recovery):
+  gby  = [rn]
+  aggs:
+    bool_or(combined)          FILTER(_include) AS has_true
+    bool_or(combined IS NULL)  FILTER(_include) AS has_null
+    arbitrary(L.col), arbitrary(inLhs)
+
+Final Project:
+  mark := CASE
+    WHEN COALESCE(has_true, false) THEN true
+    WHEN has_null                  THEN NULL
+    ELSE                                false
+  END
+```
+
+### Invariants (both paths)
+
+- **`inBodyKey_subst`** uses Case 3's `c → c_coal` substitution when
+  `inBodyKey` references a COALESCE-needing aggregate. Same mechanism
+  as F_post; not a special case.
+- **`FILTER(_include)` on Stage 2 `bool_or`s is load-bearing.** Without
+  it, an unmatched outer's pad-row group can synthesize
+  `combined = NULL` and emit a spurious `mark = NULL` instead of `false`.
+- **Pad-marker carry** (`arbitrary(_include)` in Stage 1): for a real
+  `(rn, gby)` group it yields `true`; for a pad-only group it yields
+  `NULL`. Stage 2's FILTER consumes this signal.
+- **`nullAware = false`** (non-null-aware IN): wrap final mark with
+  `COALESCE(mark, false)`. With `nullAware = true`, emit the tri-state
+  mark as-is.
+- **Case 4-equivalent restriction does NOT apply here.** F_post does
+  not need IF-in-Project form because the mark CASE consumes F_post
+  directly. F_post + non-empty gby is fine on Path 2.
+
+### Why `inLhs` / `inBodyKey` stay distinct from `Apply.filter`
+
+An earlier framing considered folding the IN equi `eq(inLhs,
+inBodyKey)` into `Apply.filter` so the F_pre / F_post split would
+handle it uniformly. That doesn't work because **`nullAware` applies
+only to the IN equi pair**, not to other filter conjuncts:
+
+- `eq(inLhs, inBodyKey)` → NULL contributes to `mark = NULL` (SQL
+  three-valued IN logic).
+- Other filter conjuncts → NULL filters the row out (`mark`
+  contribution = false), not NULL.
+
+If both lived in `filter`, terminus would need to distinguish "the IN
+equi conjunct" from "other conjuncts" — pattern-matching on
+`eq(outer_col, body_col)` shape doesn't work because correlated WHERE
+predicates have the same shape. The pair MUST stay a distinct field on
+Apply to preserve nullAware semantics down to terminus (where it
+lowers to `Join.leftKeys` / `Join.rightKeys` + `Join.nullAware`).
+
+## Known design gaps
+
+### Other body operators
+
+The agg rules doc only addresses `Aggregate` in body. Body operators
+**Window, Limit, Sort, Join (inside body), UnionAll, Unnest, nested
+Apply** are not designed here. Each would need its own peel rule.
+Currently NYI'd loudly at the driver.

--- a/axiom/optimizer/v2/docs/Decorrelate-design-rationale.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-design-rationale.md
@@ -1,0 +1,435 @@
+# Decorrelate Design Rationale
+
+*Companion to `Decorrelate-agg-rules.md` and
+`Decorrelate-outer-refs-design.md`. Captures alternatives we
+considered, paths we rejected, and why. Half the value of this doc
+is preserving dead-ends so future readers don't re-walk them.*
+
+The rules docs say WHAT the decorrelate pass does. This doc says
+WHY each choice was made — including the rejected alternatives that
+look attractive on first read.
+
+## Why we can't just follow the paper
+
+Standard reference: Neumann & Kemper "Unnesting Arbitrary Queries"
+(2015) and HyPer / Umbra follow-ups, including Neumann 2024.
+
+The paper's framework (Apply as dependent join, iterative pushdown,
+lifting Aggregate via per-`rn` grouping) is sound and we use it. But
+the **specific lifted shapes** in the paper aren't usable as written
+in our setting. Three independent reasons, in order of severity:
+
+**1. Correctness.** The standard shapes (e.g., LEFT-JOIN-back to L
+to re-pad outers whose groups all got filtered) require L to appear
+on multiple paths in the plan. We don't have shared scans or a
+materialization operator. Re-evaluating L is unsafe:
+
+- **`rn` mismatch.** `AssignUniqueId` is order-dependent; a second
+  scan produces different `rn` values; the LEFT JOIN on `rn` would
+  match nothing. Every outer would get padded → wrong results.
+- **Non-determinism.** L can contain `random()`, `now()`, `uuid()`,
+  multi-source reads in unspecified order. Two evaluations need not
+  return identical rows.
+
+This is a correctness blocker, not a performance concern.
+
+**2. Distributed-execution cost.** Even with future DAG / materialization
+support, the paper's shapes assume shared subtrees are nearly free
+— true in HyPer/Umbra (single-node main-memory, compressed in-memory
+temp storage), false in distributed execution where DAGs become
+broadcast (only cheap for small data) or shuffle (often dominates
+query cost).
+
+**3. Per-shape inefficiency.** Even within the paper's target system
+class, the canonical rewrites are a baseline. Per-shape shortcuts
+(e.g., our IF-in-outer-Project for empty `gby`) can avoid the
+materialization entirely. The paper doesn't enumerate these.
+
+So: the framework is portable, the shapes are not. Most of the rules
+in `Decorrelate-agg-rules.md` are tree-friendly variants invented to
+satisfy reason (1), with awareness of (2) and (3).
+
+## Shapes considered for Apply over Aggregate
+
+### LEFT-JOIN-back to L — rejected (correctness)
+
+The textbook shape: filter the lifted Agg's output with F_post,
+then LEFT JOIN to L on `rn` to re-pad outers whose groups all got
+dropped. Rejected because it requires re-evaluating L (see
+correctness reason above).
+
+Would become viable if/when we add a materialization operator. Even
+then, it would be a CBO option, not a default — see "Forward-looking
+note" in the rules doc.
+
+### IF-in-outer-Project — kept, scope-limited to empty `gby`
+
+For empty `gby` (global Agg, exactly one row per outer), the
+LEFT-JOIN-back rejoin isn't needed: the outer Project wraps each
+aggregate column as `IF(F_post_subst, c_coal, NULL)`, which keeps
+the row in place and nulls the values when F_post fails. This
+matches the original `kLeft` semantics (row preserved, body cols
+NULL) exactly because there's always exactly one row per outer to
+operate on.
+
+**Breaks for non-empty `gby`.** The lifted Agg now produces N rows
+per outer (one per gby group). IF-in-Project would emit all N rows
+with selective NULLs — but the original semantics drops failing
+rows and pads ONCE if all fail. Wrong row counts.
+
+So this shape stays, but Rule A applies it only to sub-cases 1 and
+3 (empty `gby`).
+
+### Window-based per-rn collapse — open candidate for non-empty `gby`
+
+Sketch: tag each row from the lifted Agg with
+`survives = F_post AND _include`. Compute
+`any_survives = MAX(survives) OVER (PARTITION BY rn)`. Then in the
+outer Project:
+
+- Rows with `survives = true` → emit aggregate values.
+- For outers with `any_survives = false` → emit one NULL-padded
+  row per `rn` (need a tiebreaker to pick exactly one row from each
+  failing rn group).
+
+No L re-scan. Costs: a window pass over the lifted Agg output, plus
+the tiebreaker logic.
+
+Open issues:
+
+- Exact tiebreaker. Simplest: `ROW_NUMBER() OVER (PARTITION BY rn
+  ORDER BY (anything stable))` and keep rn=1. Needs verification
+  that this composes cleanly with the outer Project.
+- Whether to fold this into Rule A as the canonical non-empty-gby
+  variant, or split into a separate rule. Probably separate — the
+  shape diverges enough that conflating reads poorly.
+
+### Translate-side restriction — open alternative for non-empty `gby`
+
+Sketch: never let F_post on multi-row gby reach `Apply.filter`.
+Translate handles HAVING-with-gby specially: instead of lifting it
+as a Filter that the Filter-peel rule will absorb into
+`Apply.filter`, keep it as a Filter **under** the Apply (above the
+Aggregate but inside body). The Filter-peel rule's preconditions
+prevent it from lifting this Filter when gby is non-empty.
+
+Pros: keeps Rule A simple — only the empty-gby case needs IF-in-Project.
+
+Cons: more bookkeeping at translate; the Filter-peel rule needs a
+case split; coupling between SQL translation and rule preconditions
+that has to be maintained.
+
+Decision: deferred until we have the window-based variant sketched
+end-to-end and can compare.
+
+### Per-rn re-aggregate — rejected
+
+After F_post Filter drops failing rows, run another Agg grouped by
+`rn` to detect outers with zero survivors. Problem: this collapses
+N rows per outer into 1, losing gby differentiation. Only correct
+for empty gby — in which case we already have IF-in-Project, which
+is cheaper.
+
+## kLeftSemiProject mark derivation — three candidate directions
+
+(Detailed alternatives behind Rule B's placeholder status in the
+rules doc.)
+
+### Direction 1 — New `kCountingLeftSemiProject` Apply/Join kind
+
+Add a new Apply kind that emits each L row with a count of matching
+body rows. The outer Project computes `mark = (count > 0)`.
+
+Pros: clean separation between substrate and rule; mark derivation
+becomes trivial; reusable for COUNT-style anti-join patterns too.
+
+Cons: substrate addition — new Apply kind, new corresponding Join
+kind, execution support, costing. Non-trivial.
+
+### Direction 2 — `count` + `NOT(count == 0)` pattern
+
+Lifted Aggregate emits per-outer `count(_include)`. Outer Project
+derives `mark = NOT(count == 0)`. No new substrate.
+
+Pros: works with existing kinds; minimal change.
+
+Cons: introduces a count where a boolean would suffice — slightly
+wasteful; doesn't generalize as cleanly to mixed semi/anti shapes.
+
+### Direction 3 — `bool_or` pattern (matches current v2 substrate)
+
+Lifted Aggregate emits per-outer `bool_or(_include)`. The aggregate
+output IS the mark — no separate derivation. Uses
+`AggregateRecovery::makeBoolOr` already present in v2.
+
+Pros: matches existing v2 substrate exactly; no new aggregate
+needed; mark is the aggregate's natural output.
+
+Cons: `bool_or` semantics with `_include` (where NULL means "kLeft
+pad, not a real match") needs care — `bool_or(NULL, NULL) = NULL`,
+which must be coerced to `false` in the outer Project.
+
+### Worked-out shapes for Cases 5 / 6 (filter null), assuming Direction 3
+
+The lifted shape splits along the gby axis. v1 raises `NYI` on this
+entire pattern ("Outer-column reference in the aggregate body of an IN
+subquery is not supported yet"), so v2 is genuinely new territory
+here — no v1 baseline to
+match, just SQL correctness.
+
+**Case 5 — gby empty.** Lifted Agg always produces exactly one row
+per outer; predicate runs once per outer; mark is the predicate
+result directly. One Agg over Apply.
+
+```
+- Project: mark = predicate(L.cols, agg_output)
+  - Agg
+      groupingKeys = [rn]
+      aggregates   = aggs FILTER (WHERE _include)
+                  ++ arbitrary(L.col) for each L.col
+    - Apply (kLeft)
+      - body  = Project(child, [..., _include := true])
+      - input = AssignUniqueId(L) → tagged_L
+```
+
+**Case 6 — gby non-empty.** Lifted Agg produces N rows per outer
+(one per gby group). Predicate runs per row giving N booleans per
+outer; need to OR them into one mark per outer → extra reduction.
+Two Aggs over Apply.
+
+```
+- Project: mark = collapsed_mark
+  - Agg                                   ← per-outer reduction
+      groupingKeys = [rn]
+      aggregates   = bool_or(per_group_mark) AS collapsed_mark
+                  ++ arbitrary(L.col) for each L.col
+    - Project: per_group_mark = predicate(L.cols, agg_output)
+      - Agg                               ← per-(rn, gby), like Rule A
+          groupingKeys = [rn, gby]
+          aggregates   = aggs FILTER (WHERE _include)
+                      ++ arbitrary(L.col)
+        - Apply (kLeft)
+          - body  = Project(child, [..., _include := true])
+          - input = tagged_L
+```
+
+(Case 5 = Case 6 with the outer Agg collapsed to identity — could
+be a single rule that the optimizer simplifies when gby is empty.)
+
+### Streaming / shuffle properties of Case 6's two-Agg shape
+
+The Agg-over-Agg-over-Apply shape streams cleanly under common
+physical plans:
+
+- **Inner Agg (`[rn, gby]`).** `AssignUniqueId(L)` assigns rn
+  monotonically as L is scanned, so rows arrive in rn order. Within
+  each rn, gby values are unordered, but the aggregate only needs
+  state for the *current* rn — flush when rn changes. State size =
+  max distinct gby values per outer (typically small), not total
+  cardinality.
+- **Outer Agg (`[rn]`).** Inner Agg emits in rn order, so outer Agg
+  holds one `bool_or` accumulator per current rn and flushes at the
+  rn boundary. Fully streaming, constant state per outer.
+
+**No shuffle in the common case.** Both Aggs stream as long as L
+stays partitioned the way `AssignUniqueId` produced it (rn
+contiguous within each partition). The Apply itself doesn't break
+rn locality if body's child is broadcast or partition-local.
+
+**Shuffle risk.** If body's child must be shuffled by some key (e.g.,
+equi-correlation optimization promoting body to a partitioned
+side), rn locality breaks and the inner Agg needs a re-sort or
+hash-agg on rn first — costing a shuffle. The shape itself doesn't
+force this; physical join planning does.
+
+For the canonical SQL example
+(`SELECT t.id FROM t WHERE t.x IN (SELECT max(u.b + t.a) FROM u)`),
+the body is a full scan of `u` with no equi-correlation, so the
+natural physical plan is `u` broadcast (or replicated) per L
+partition → no shuffle, both Aggs stream.
+
+### Cases 7 / 8 (filter non-null) — extension sketch
+
+Fold F_post into the per-(rn, gby) mark predicate: replace
+`per_group_mark = predicate(...)` with
+`per_group_mark = predicate(...) AND F_post_subst`. The outer
+`bool_or` reduction is unchanged. Same streaming properties as
+Cases 5/6.
+
+(F_post here references the lifted Agg's outputs, so the same
+`c_coal` substitution Rule A uses applies — needs an additional
+inner-Project of COALESCE before the per-group mark Project. Not
+yet fully sketched.)
+
+### Aggregate-elision early-out (subsumes Cases 5a/6a and the
+DISTINCT-shaped IN analogue)
+
+Layered on top of Direction 3. When the body Aggregate's user
+aggregates are not referenced by anything that survives the kSemi
+mark — i.e. neither the accumulated filter nor `inBodyKey` touches
+an aggregate-result column — the Aggregate is a pure DISTINCT and
+the kSemi mark already gives one bit per outer regardless. Dropping
+the Aggregate and recursing on its input lets the simpler kSemi
+join-peel path produce a native `LEFT SEMI (PROJECT)`, with no
+AssignUniqueId / two-stage Aggregate / `bool_or` recovery.
+
+This isn't a new direction — it's a precondition check that picks
+between "no recovery needed" and "Direction 3 recovery". The
+recovery shapes stay valid for the cases that genuinely need the
+user aggregates; the early-out just keeps them off the common path.
+
+Worked-out example. Before: `EXISTS (SELECT 1 FROM u WHERE u.a > t.b
+GROUP BY u.x)` lifted as AssignUniqueId → NLJ(kLeft) → Aggregate per
+[rn] with `bool_or(_include)`. After: NLJ(kLeftSemiProject) directly
+over `TableScan(u)` with the gt as join condition. Identical results,
+simpler plan, native executor support.
+
+## Decisions made
+
+- **Decorrelate emits Shape (b) only** (aggregate-above-join with
+  `rn` grouping). Shape (a) (aggregate-below-join) is a downstream
+  rewrite the join-order pass applies when cost-justified. Three
+  reasons: (1) shape (b) works for both equi and non-equi
+  correlation; (2) choosing between (a) and (b) needs cardinality
+  estimates decorrelation doesn't have; (3) one canonical shape
+  keeps per-case rules simple. Detail in
+  `Decorrelate-agg-rules.md` §"Shape (a) for equi correlation; shape
+  (b) otherwise".
+- **F_pre vs F_post classification happens at rule application,
+  not at translate.** Translate doesn't know which axes the
+  surrounding Apply will hit; classification is local to the rule.
+- **No `Apply (kInner)` at all.** Translate lowers uncorrelated
+  scalar subqueries directly to `Join(kInner, input, EnforceSingleRow(body))`
+  — Apply only carries correlated scalar (kLeft) and EXISTS / IN
+  (kLeftSemiProject). No iteration step changes kind.
+- **L.cols carry-through via `arbitrary(L.col)` with `Column*`
+  reuse.** Alternatives considered: (a) add L.cols to
+  `groupingKeys` — works but inflates the grouping cardinality
+  for no semantic benefit (each rn group already has one L value);
+  (b) carry via a side-channel — breaks the principle that
+  downstream refs resolve by `Column*`. The `arbitrary` aggregate
+  is the cleanest option and is constant-folded inside each `rn`
+  group anyway.
+
+## Known design gaps (consolidated)
+
+Two genuine gaps, tracked in the per-rule docs and consolidated here.
+
+### Gap 1 — Cases 5/6 IN-shape (`Apply.inLhs` set, body = Aggregate)
+
+**Where**: `Decorrelate-agg-rules.md` §"Known design gaps".
+
+**What's missing**: Cases 5/6 specify mark derivation via
+`bool_or(_include)` for **EXISTS-shape**. For **IN-shape** (where
+the Apply carries `inLhs` / `inBodyKey`), the equi predicate
+`eq(inLhs, inBodyKey)` needs to be folded into the per-row mark
+derivation before `bool_or` collapses. This wasn't worked out in
+the rules docs.
+
+**Why `inLhs` / `inBodyKey` stay distinct from `Apply.filter`.** An
+attractive simplification considered: fold the IN equi into `filter`
+and rely on the existing F_pre / F_post split. It doesn't work
+because **`nullAware` applies only to the IN equi pair**, not to
+other filter conjuncts:
+- `eq(inLhs, inBodyKey)` evaluating NULL → mark NULL (three-valued
+  IN logic).
+- Other filter conjuncts evaluating NULL → row filtered out (mark
+  contribution = false).
+
+If both lived in `filter`, terminus couldn't reliably tell which
+conjunct came from IN (pattern-matching `eq(outer_col, body_col)`
+collides with correlated WHERE predicates of the same shape). The
+pair MUST stay distinct on Apply to preserve nullAware semantics
+through to terminus (where they lower to `Join.leftKeys` /
+`Join.rightKeys` + `Join.nullAware`).
+
+**Implementation framing.** IN-with-Agg-body is a separate mechanism
+parallel to F_post, not a special case of it:
+- F_post: substitute accFilter conjuncts referencing agg-result cols
+  via `c → c_coal`; fold into the IF-in-outer-Project wrap.
+- IN-shape: substitute `inBodyKey` via the same `c → c_coal` rules
+  when it references an agg-result col; fold into the per-row mark
+  predicate as `_include AND eq(inLhs, inBodyKey_subst)`, then
+  `bool_or` per outer.
+
+Both mechanisms share the substitution helper but have different
+result-shape concerns (IF-wrap vs bool_or mark derivation).
+
+**Required changes to `aggregatePeelSemi`**:
+- Currently drops user aggregates entirely (EXISTS doesn't need
+  them). For IN, must keep the aggregates whose results `inBodyKey`
+  may reference, so the substitution has targets.
+- Add `inBodyKey` resolution against lifted Agg outputs, including
+  `c → c_coal` for COALESCE-needing aggregates.
+- Build per-row predicate as `_include AND eq(inLhs, inBodyKey_subst)`
+  feeding into `bool_or`.
+- Preserve nullAware semantics: `bool_or` returns NULL when all
+  inputs are NULL on the equi side; the final COALESCE remaps NULL →
+  false ONLY when `nullAware == false`. For `nullAware == true`,
+  the mark stays NULL for outers with all-NULL equi evaluations.
+
+**Open subtleties**:
+- Case 6 IN-shape (gby non-empty): same per-(rn, gby) eval into the
+  per-row predicate, then `bool_or` per `rn`.
+- Interaction with concurrent F_post conjuncts on accFilter: both
+  fold into the per-row predicate via AND; both contribute to the
+  set of agg-result substitutions.
+
+**Implementation status**: NYI loud (`VELOX_NYI` at Aggregate peel
+when `kSemi + inLhs != nullptr`).
+
+### Gap 2 — Shape C composition with Decorrelate Project peel
+
+**Where**: `Decorrelate-outer-refs-design.md` and
+`Decorrelate-project-rules.md` §"Known design gap — Shape C
+composition".
+
+**What's missing**: The outer-refs design specifies a Translate-side
+fix (alias body when output collides with applyTarget's outputs).
+This is design-correct in isolation but **insufficient** in the
+presence of Decorrelate's Project peel. Project peel peels the
+alias wrap, exposes the un-aliased body, and the inner Apply's
+`outputColumns = input.cols ++ originalBody.cols` brings the
+duplicate back.
+
+**Required completion**: Project peel's `projectPeelLeft`
+must detect collisions in the inner Apply's outputColumns (by
+Column* identity OR by name) and apply the same aliasing trick
+recursively — wrapping body cols that collide and propagating the
+alias through the lifted Project's expression rewrite.
+
+**Open subtleties**:
+- Per-col aliasing for multi-col bodies.
+- Lifted Project's expr rewrite to honor aliases (via
+  `ExprFactory::substitute`).
+- Interaction with COALESCE wraps in Aggregate peel (cols may
+  already be fresh; don't double-alias).
+
+**Implementation status**: Translate-side fix landed; Decorrelate
+completion NYI. Tests like `SELECT (SELECT a) FROM t` still fail
+with "Duplicate output column" at PlanConsistencyChecker.
+
+### Out-of-scope absences (not gaps per se — items the design didn't aim to cover)
+
+- **Body operators**: Window, Limit, Sort, Join (in body), UnionAll,
+  Unnest, nested Apply — no peel rules designed. Each would need
+  its own per-operator design + impl.
+- **Aggregate Cases 4, 7, 8** — explicitly deferred in
+  `Decorrelate-agg-rules.md`. Design has notes on the approach
+  (window-based vs translate-side restriction for Case 4;
+  per-(rn, gby) F_post + outer bool_or for 7/8) but specific
+  shapes not worked out.
+
+## Sources cited
+
+- Neumann, T., & Kemper, A. (2015). "Unnesting Arbitrary Queries."
+  BTW 2015. The canonical reference for the iterative pushdown
+  framework we follow.
+- Neumann, T. (2024). Follow-up work in the same line (Umbra
+  context). To be cited precisely once we locate the exact paper.
+- Galindo-Legaria, C., & Joshi, M. (2001). "Orthogonal Optimization
+  of Subqueries and Aggregation." SIGMOD 2001. The Apply-operator
+  framing from SQL Server's optimizer.
+- Elhemali, M., Galindo-Legaria, C., Grabs, T., & Joshi, M. (2007).
+  "Execution Strategies for SQL Subqueries." SIGMOD 2007. Cost-based
+  subquery execution in SQL Server.

--- a/axiom/optimizer/v2/docs/Decorrelate-driver.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-driver.md
@@ -1,0 +1,184 @@
+# Decorrelate Driver
+
+*Companion to:*
+- *`Decorrelate-filter-rules.md` — Filter peel.*
+- *`Decorrelate-project-rules.md` — Project peel.*
+- *`Decorrelate-agg-rules.md` — Aggregate peel.*
+- *`Decorrelate-limit-rules.md` — Limit peel.*
+- *`Decorrelate-join-rules.md` — Join peel.*
+- *`Decorrelate-enforce-single-row.md` — ESR handling at terminus.*
+- *`Decorrelate-design-rationale.md` — alternatives considered, rejected paths.*
+
+The driver is the loop that turns each `Apply` node into a `Join`. The
+per-op rules (Filter, Project, Aggregate, Limit, Join, AssignUniqueId)
+describe HOW to peel one body operator; the driver describes WHICH
+rule fires WHEN, how state is maintained between peels, and when
+iteration terminates.
+
+## Mental model
+
+```
+Apply (kLeft, body = some_subtree)
+  ↓ peel one body operator (Filter / Project / Aggregate)
+Apply (kLeft, body = smaller_subtree)
+  ↓ peel another
+...
+  ↓ terminus: body has no outer refs
+Join (kLeft, right = simplified_subtree)
+```
+
+Apply's state, as the driver sees it (see `Node.h` for full
+invariants):
+
+- `input` — the outer (correlated) side. Stable across iterations.
+- `body` — the (sub)query tree being decorrelated. Shrinks per peel.
+- `kind` — what the subquery context expects per outer row. Stable
+  across iterations.
+   - `kLeft` — correlated scalar / lateral subquery: emit one row per
+     `(outer, body-match)` and a NULL-padded row for outers with no
+     match.
+   - `kLeftSemiProject` — `EXISTS` / `IN`: emit one row per outer
+     with a fresh BOOLEAN `markColumn` (true iff any body row matches,
+     NULL-aware for IN).
+- `correlationColumns` — `input` columns still referenced inside
+  `body`. Recomputed from `body` each iteration; emptying it
+  triggers terminus.
+- `filter` — residual predicates that ride with Apply through
+  iteration and become `Join.filter` at terminus. May grow when a
+  Filter peel absorbs predicates from `body`.
+- `enforceSingleRow` — scalar-subquery cardinality flag. Stable;
+  honored at terminus per `Decorrelate-enforce-single-row.md`.
+- `markColumn` — `kLeftSemiProject` mark output. Stable.
+- `includeMarker` — `kLeft` pad-row marker. Stable.
+- `inLhs` / `inBodyKey` — IN equi-pair (kLeftSemiProject only).
+  Stable except under Project peel, which may substitute Project's
+  exprs into `inBodyKey` (Rule B).
+- `outputColumns` — Apply's external schema. Stable.
+
+Per peel, `body` shrinks and `filter` may grow; the surrounding tree
+may gain operators above Apply (the peeled operator lands there for
+some rules).
+
+## Driver loop
+
+```
+driver(apply):
+  loop:
+    recompute apply.correlationColumns from apply.body
+    if apply.correlationColumns is empty:
+      return terminus(apply)              // Apply → Join + optional ESR
+    rule = dispatchByBodyOperator(apply.body)
+    if rule is null:
+      VELOX_NYI("driver: no peel rule for body operator X")
+    apply = rule.apply(apply)             // peel, returning transformed tree
+                                          // (may contain new Apply nodes;
+                                          //  rule may itself throw NYI for
+                                          //  subcases it doesn't handle)
+```
+
+The driver is invoked once per `Apply` node in the plan. When a peel
+rule (notably Aggregate) produces a tree containing a NEW inner Apply,
+the driver is recursively invoked on that inner Apply.
+
+## Per-peel dispatch
+
+Dispatch by `body`'s outermost operator:
+
+| Body operator     | Rule                                              |
+|-------------------|---------------------------------------------------|
+| `Filter`          | `Decorrelate-filter-rules.md`                     |
+| `Project`         | `Decorrelate-project-rules.md`                    |
+| `Aggregate`       | `Decorrelate-agg-rules.md`                        |
+| `Limit`           | `Decorrelate-limit-rules.md`                      |
+| `Join`            | `Decorrelate-join-rules.md`                       |
+| `AssignUniqueId`  | lift above Apply; recurse on inner Apply over child |
+| anything else     | `VELOX_NYI` ("correlated reference inside …")     |
+
+There is no leaf fast-path: when body is `Scan` / `Values` (or any
+node that doesn't actually reference outer columns), the next
+`recompute` finds an empty correlation set and terminus fires before
+dispatch — no peel is consulted.
+
+`EnforceSingleRow` does not appear as a body operator — it's the
+`Apply.enforceSingleRow` flag, handled at terminus (see
+`Decorrelate-enforce-single-row.md`).
+
+## `correlationColumns` recomputation
+
+After each peel, recompute `apply.correlationColumns` by walking the
+new `body` and collecting references to `apply.input`'s columns.
+
+**Recompute, not incremental.** A peel may absorb body's only reference
+to an outer col (drop the ref) OR may peel one of several occurrences
+(ref still in body via the other occurrences). Subtracting a ref per
+peel would be wrong; the walk is the only correct mechanism.
+
+**Refs in `apply.filter` don't count.** Those are at the boundary —
+they become `Join.filter` at terminus and don't block iteration. Only
+refs INSIDE `body` block terminus.
+
+TODO: cache correlation refs per body node to avoid walking the full
+body on each peel. Optimization, not correctness — defer until profile
+shows it matters.
+
+## Terminus
+
+`correlationColumns` empty → terminus:
+
+Translate `Apply` → `Join`, dispatched on `apply.kind`:
+
+- **`kLeft`**: wrap body with an `_include := true` marker Project,
+  then LEFT JOIN with `Apply.filter` as `Join.filter`. If
+  `enforceSingleRow=true`, additionally tag input with
+  `AssignUniqueId` and wrap the LEFT JOIN in `EnforceDistinct` on
+  that id column; a final Project strips the id. See
+  `Decorrelate-enforce-single-row.md`.
+- **`kLeftSemiProject`**: LEFT SEMI PROJECT with `markColumn` as the
+  mark output. For IN, the `(inLhs, inBodyKey)` equi-pair becomes
+  Join equi-keys; `Apply.filter` becomes `Join.filter`.
+  `enforceSingleRow` is invariant false for this kind.
+
+**Non-correlated Apply hits this directly.** When translate emits an
+uncorrelated `kLeftSemiProject` Apply (uncorrelated `EXISTS` / `IN`),
+the first `recompute` finds an empty correlation set → straight to
+terminus without any peel rule firing.
+
+## NYI from rules
+
+Rules may throw `VELOX_NYI` for sub-cases they don't yet handle —
+those are rule-local limitations, not driver concerns. The driver
+just propagates the error. Examples: Aggregate Case 4 (kLeft +
+non-empty F_post + non-empty gby — see `Decorrelate-agg-rules.md`);
+Aggregate over `GROUPING SETS`; kSemi+IN over Limit with count ≥ 1;
+Join body of kind `kFull`, and
+various outer/body-kind combinations under `joinPeel`; pure-outer
+aggregates (args reference only outer columns) — declined loud
+pending the pure-outer-aggregate rewrite.
+
+## Order of operations subtleties
+
+- **Recompute BEFORE checking terminus.** A peel may have just dropped
+  the last outer ref; without recomputing first, the driver would
+  attempt another peel on a body that's now ready for terminus.
+- **Recursive Apply.** Project / Aggregate / Limit / Join /
+  AssignUniqueId peels each emit a tree containing a fresh inner
+  Apply whose body is the peeled operator's child (or, for Join,
+  a chained pair of Apply nodes over the two sides). The peel calls
+  `rewrite` on that inner Apply to re-enter the driver; each step
+  strictly shrinks body, so iteration converges. Filter peel is the
+  exception — it mutates `body` and `accumulatedFilter` in place
+  inside the driver loop and continues, with no inner Apply.
+- **Filter peel may trigger terminus.** If Filter was the last body
+  operator carrying an outer ref, peeling it empties
+  `correlationColumns` → terminus on the next iteration.
+
+## What the driver does NOT do
+
+- **Decide F_pre vs F_post.** That's the Aggregate rule's local concern
+  at lift time, not the driver's. The driver just hands the Filter rule
+  the Filter; it absorbs predicates uniformly into `Apply.filter`.
+- **Optimize peel order across multiple options.** Dispatch is purely
+  by body's outermost operator. No cost-based choice.
+- **Validate body shape post-rule.** Each rule is responsible for
+  producing a well-formed result; the driver re-enters the loop and
+  re-recomputes from there.

--- a/axiom/optimizer/v2/docs/Decorrelate-enforce-single-row.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-enforce-single-row.md
@@ -1,0 +1,117 @@
+# Decorrelate EnforceSingleRow Handling
+
+*Companion to:*
+- *`Decorrelate-driver.md` — driver loop, terminus.*
+- *`Decorrelate-agg-rules.md` — Aggregate peel (special case: ESR redundancy).*
+- *`Decorrelate-design-rationale.md` — why ESR is an Apply flag and not a body operator.*
+
+`Apply.enforceSingleRow` is a flag set by Translate for scalar
+subquery contexts where SQL requires the subquery to return 0 or 1
+row per outer (`> 1` errors at runtime). The flag rides with Apply
+through iteration; this doc covers how it lowers at terminus and
+where it interacts with peel rules.
+
+## Why a flag, not a body operator
+
+Earlier designs put `EnforceSingleRow` as a wrapper inside body. That
+breaks under iteration: when correlations peel out of body, the
+EnforceSingleRow's scope strips from "per outer" to "global" because
+body's per-outer evaluation is gone. The assertion then fires on the
+wrong cardinality (or doesn't fire at all).
+
+By making ESR an `Apply` flag, the per-outer scope is bound to Apply,
+not to body's internal shape. The flag travels through iteration
+unchanged; the assertion is enforced at terminus where the per-outer
+semantics are explicit.
+
+See `Decorrelate-design-rationale.md` §"Shapes considered for Apply
+over Aggregate" for the rejected body-operator alternatives.
+
+## Per-kind lowering at terminus
+
+| `kind`             | `enforceSingleRow` | Terminus shape                                            |
+|--------------------|--------------------|-----------------------------------------------------------|
+| `kLeft`            | false              | LEFT JOIN                                                 |
+| `kLeft`            | true               | LEFT JOIN + per-`rn` `EnforceDistinct` (see below)        |
+| `kLeftSemiProject` | (invariant: false) | LEFT SEMI PROJECT (no ESR)                                |
+
+## kLeft + ESR=true — per-`rn` `EnforceDistinct`
+
+Body is per-outer; the assertion needs per-outer scope. Velox's global
+`EnforceSingleRow` doesn't suffice — and there's no `single_value()`
+aggregate. The substrate already has the right primitive:
+`EnforceDistinct` (`v2/Node.h` / lowers to Velox
+`EnforceDistinctNode`) — asserts ≤1 row per distinct key.
+
+Lowering shape:
+
+```
+- EnforceDistinct (distinctKeys = [rn],
+                   errorMessage = "Scalar sub-query has returned multiple rows")
+  - LEFT JOIN
+      filter = Apply.filter
+    - input = AssignUniqueId(L) → tagged_L (adds `rn`)
+    - body (already simplified by iteration)
+```
+
+Per-outer cardinality at the LEFT JOIN's output:
+- N = 0 matching body rows → LEFT JOIN pads 1 row (body cols NULL) →
+  EnforceDistinct sees 1 row per `rn` → passes. ✓ SQL "scalar
+  subquery returns NULL when 0 rows".
+- N = 1 matching body row → 1 row per `rn` → passes. ✓
+- N > 1 matching body rows → > 1 row per `rn` → runtime error. ✓
+  SQL "scalar subquery errors when > 1 row".
+
+No per-rn aggregate synthesis needed. `EnforceDistinct` is a
+pass-through node (its output columns equal its input's pointer-for-
+pointer), so the parent expression that referenced the scalar
+subquery's value resolves directly to body's output column appearing
+in the LEFT JOIN's output.
+
+**Implementation note**: in practice a final `Project` above
+`EnforceDistinct` is needed to strip `rn` from the output schema —
+`EnforceDistinct` requires `rn` in its input (it's the distinct
+key), and pass-through preserves it, so the consumer sees `rn`
+unless we project it out. The Project is purely a column-prune; it
+adds no expressions. Output schema = `apply.outputColumns` =
+`input.cols ++ body.cols`.
+
+## Interaction with peel rules — redundancy detection
+
+When body contains an `Aggregate` with empty `gby`, the lifted Agg
+naturally produces exactly one row per outer (per-`rn` group). The
+ESR assertion is then *redundant* — Aggregate already enforces ≤1
+row per outer via grouping.
+
+**Translate should not set ESR=true when body has a global
+Aggregate.** Specifically, if the SQL is
+`SELECT (SELECT max(x) FROM ...) FROM t`, the inner `max(x)` is a
+global Agg → always 1 row per outer → ESR is unneeded. Translate
+emits `Apply.enforceSingleRow=false`.
+
+**Aggregate peel preserves ESR.** If translate set ESR=true (e.g.,
+because the SQL form looked scalar but body wasn't initially analyzed
+as having a global Agg), the Aggregate rule peels normally. At
+terminus, both the lifted Agg's per-`rn` grouping AND the
+`EnforceDistinct([rn])` wrap apply. EnforceDistinct becomes a no-op
+(each per-`rn` group already has 1 row from the lifted Agg). Correct
+but redundant; downstream optimization can elide.
+
+**Filter / Project peel don't interact with ESR.** Both preserve
+per-outer cardinality (Filter peel: predicates absorbed into
+Apply.filter, applied at the join boundary before ESR; Project peel:
+no cardinality change). ESR rides through unchanged.
+
+## What this rule does NOT do
+
+- **Detect mid-iteration redundancy.** If body becomes an Aggregate
+  during iteration (peel reveals it), we don't drop ESR=true at that
+  point. The redundant wrap is left for downstream optimization.
+- **Lower ESR before terminus.** The flag stays on Apply until
+  terminus; no per-iteration wrap.
+- **Handle EnforceSingleRow node inside body.** Under the relaxed
+  Apply contract, body doesn't contain EnforceSingleRow nodes —
+  translate uses the flag instead. If iteration somehow encounters an
+  EnforceSingleRow inside body (e.g., from a sub-Apply that hasn't
+  been driven yet), that's the inner Apply's concern, not this
+  doc's.

--- a/axiom/optimizer/v2/docs/Decorrelate-filter-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-filter-rules.md
@@ -1,0 +1,103 @@
+# Decorrelate Filter Rules
+
+*Companion to:*
+- *`Decorrelate-driver.md` — driver loop, terminus, NYI guards.*
+- *`Decorrelate-agg-rules.md` — F_pre / F_post classification at Aggregate lift.*
+
+Peels a `Filter` from `body` by absorbing its predicates into
+`Apply.filter`. Uniform across `Apply.kind` (kLeft / kLeftSemiProject).
+
+## Mental model
+
+```
+Apply (kind, filter = F_existing, body = Filter(child, P))
+  ↓
+Apply (kind, filter = F_existing AND P, body = child)
+```
+
+Filter disappears from body; its predicates land in `Apply.filter`.
+At terminus, `Apply.filter` becomes `Join.filter`.
+
+## Rule
+
+**Before:**
+
+```
+- Apply (kind, filter = F_existing, body = Filter(child, P))
+  - input = L
+```
+
+**After:**
+
+```
+- Apply (kind, filter = F_existing AND P, body = child)
+  - input = L
+```
+
+Where:
+- `F_existing AND P` is the conjunction of the pre-existing
+  `Apply.filter` (null treated as TRUE) with the Filter's predicate.
+  Implementation: use a helper that ANDs nullable filters and
+  collapses TRUE.
+- `kind` is preserved.
+- `Apply.input`, `Apply.enforceSingleRow`, `Apply.markColumn`,
+  `Apply.inLhs`, `Apply.inBodyKey` are all unchanged.
+- No new node is introduced above Apply. The Filter is gone.
+
+## Why uniform across kinds (and across F_pre / F_post)
+
+**No kind-based case analysis.** `kLeft` and `kLeftSemiProject` both
+treat `Apply.filter` the same way at terminus — it becomes
+`Join.filter`. So absorbing predicates uniformly is sound.
+
+**No correlated / non-correlated split.** Both correlated predicates
+(reference outer cols) and non-correlated predicates (reference only
+body cols) absorb into `Apply.filter`. At terminus, `Join.filter`
+applies them all — semantically identical to the original
+`Apply(body=Filter(...))`. The optimizer's later pushdown pass moves
+non-correlated predicates into the scan side; that's not
+decorrelate's concern.
+
+**No F_pre / F_post split at this rule.** The Aggregate peel rule
+splits `Apply.filter` into F_pre (applied below the lifted Agg) and
+F_post (folded into the result Project's IF wrap) at *lift time*. The
+Filter rule has no Aggregate in view yet — it just accumulates
+predicates and lets the eventual Aggregate rule classify them.
+
+## Soundness under `enforceSingleRow`
+
+`Apply.enforceSingleRow == true` (only meaningful for `kLeft`; the
+invariant forbids it for `kLeftSemiProject`): predicate absorption is
+sound because the per-`rn` single-row assertion at terminus operates
+on the post-filter rows:
+
+- Before: per L row, body produces filtered child rows; ESR asserts ≤1.
+- After: per L row, body produces all child rows; `Join.filter`
+  selects matching rows at the join boundary; per-`rn` aggregate
+  asserts ≤1 on the matching rows.
+
+Same cardinality per outer in both shapes.
+
+## Termination contribution
+
+If the Filter carried the only remaining outer reference in body
+(e.g., body was `Filter(Scan(u), u.a = t.a)`), absorbing it into
+`Apply.filter` empties `correlationColumns` on the next recompute →
+driver hits terminus. This is the common shape for simple correlated
+scalar subqueries.
+
+If body has more correlated operators below the Filter, the driver
+continues peeling them.
+
+## What this rule does NOT do
+
+- **Reorder predicates relative to Aggregate.** F_pre / F_post
+  classification happens later, at Aggregate lift.
+- **Detect cardinality-changing implications.** Predicates that would
+  cause `Apply.enforceSingleRow == true` to misfire are caught at
+  terminus, not here.
+- **Push predicates further down into body.** The Filter peel raises
+  predicates UP into `Apply.filter`. Predicates already inside body
+  (e.g., a `Filter(Scan, ...)` further down) get peeled in subsequent
+  driver iterations when the outer Filter is gone and the inner one
+  becomes the new outermost body operator.

--- a/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-join-rules.md
@@ -1,0 +1,273 @@
+# Decorrelate Join Rules
+
+*Companion to:*
+- *`Decorrelate-driver.md` — driver loop, terminus, NYI guards.*
+- *`Decorrelate-filter-rules.md` — Filter peel.*
+- *`Decorrelate-project-rules.md` — Project peel.*
+- *`Decorrelate-agg-rules.md` — Aggregate peel.*
+- *`Decorrelate-limit-rules.md` — Limit peel.*
+
+Peels a `Join` from `body`. Body's Join encodes a relational join
+between its two sides (`A` = left, `B` = right) under
+`(joinKind, leftKeys, rightKeys, filter)`.
+
+## Mental model
+
+`Apply(L, Join(A, B, joinKind, predicate))` evaluates the join per
+outer row of `L`. Tree-only execution forbids putting `L` on two
+sides of a downstream Join (no DAG support, no materialization
+operator — see `Decorrelate-design-rationale.md` §"Why we can't just
+follow the paper"), so the textbook "Apply distributes over Join"
+rewrite (which duplicates `L` to both sides) is out of bounds.
+
+Instead, **serialize**: compute `A` per outer first, then compute `B`
+per `(outer, A)` row. This places `L` only at the bottom of the chain
+and preserves tree shape.
+
+```
+Apply(L, Join(A, B, joinKind, predicate), outerKind, ...)
+↓ joinPeel
+[outer envelope: ESR / markColumn / NULL-collapse / IN equi]
+  applyB = Apply(applyA, B, kindForB, filter=predicate, keysForB=...)
+    applyA = Apply(L, A, kindForA, ...)
+```
+
+- `applyA` decorrelates the left side per outer L. Its `outputColumns`
+  are `L.cols ++ A.cols ++ [applyA.includeMarker]` (relaxed Apply
+  contract).
+- `applyB` decorrelates the right side per `(outer, A)` row. Its input
+  is `applyA`'s output, so it can resolve any predicate involving
+  `L`, `A`, or `B`. `applyB.filter` carries the Join's predicate.
+- The outer envelope handles `outerKind`-specific semantics:
+  ESR wrap (scalar context), markColumn synthesis (kSemi), post-Filter
+  for INNER semantics (drop pad rows), or IN equi check.
+
+Each chained `Apply` is independently decorrelatable by the driver —
+they recurse through the normal peel machinery.
+
+## Predicate normalization
+
+`Join.leftKeys[i] = Join.rightKeys[i]` conjuncts and `Join.filter` are
+together the body Join's "predicate." Before applying any per-kind
+rule, normalize to a single `predicate` expression:
+
+```
+predicate = AND(eq(leftKeys[i], rightKeys[i]) for i) AND filter
+```
+
+(Or `nullptr` if all components are empty / TRUE.) The normalized
+predicate becomes `applyB.filter`. Where the rule needs to split the
+predicate (e.g., equi-pair for IN), it re-extracts from the
+normalized form.
+
+## Body `joinKind` translation
+
+Each Join kind maps to a chain configuration. `kindForB` controls
+whether `applyB` pads on no-match (kLeft pad) or projects a mark
+(kLeftSemiProject).
+
+| `joinKind` | `kindForB` | Outer envelope addition |
+|---|---|---|
+| `kInner` | `kLeft` | per-rn pad-collapse: drop `applyB` pad rows, keeping exactly one pad per outer with no match — see §"INNER pad-row drop" |
+| `kLeft` | `kLeft` | none — `kLeft` pad maps to `A LEFT JOIN B`'s pad |
+| `kRight` | swap to `kLeft` with sides reversed (`applyA=B, applyB=A`) | none — symmetry |
+| `kFull` | NYI | needs both sides' unmatched rows; tree-only can't express without re-evaluating one side. Loud NYI. |
+| `kLeftSemiFilter` | `kLeftSemiProject` (apply emits per-A mark) | `Filter(mark)` then drop mark; equivalent to A-rows-with-any-matching-B |
+| `kLeftSemiProject` (in body) | `kLeftSemiProject` | mark propagates as a new column; outer's body-cols accordingly |
+| `kAnti` | `kLeftSemiProject` | `Filter(NOT mark OR mark IS NULL)` |
+
+(Filter expressions in the envelope use `Builder::makeBoolean` /
+`ExprFactory::makeIsNull` per the existing conventions.)
+
+## Correlation distribution
+
+Per outer `L`, A and B can each be correlated (reference `L` cols) or
+not. Combinations and chain effect:
+
+| (A corr?, B corr?) | Chain behavior |
+|---|---|
+| (T, T) | Both `Apply`s in chain stay correlated; driver decorrelates each via Filter / Project / Agg / Limit peels. |
+| (T, F) | `applyA` correlated (driver peels); `applyB` uncorrelated (terminus fast-path → cross-product Join). |
+| (F, T) | Rewrite to put correlated side outermost OR keep order with `applyA` uncorrelated (terminus fast-path) and `applyB` correlated. Prefer outermost-correlated for shallower chain; both shapes are semantically equivalent. |
+| (F, F) | Outer Apply itself is uncorrelated; driver's terminus fast-path fires before any peel. Join peel never sees this. |
+
+B may reference A cols via the Join's predicate even when B's
+relation isn't correlated to `L`; that's handled by `applyB.filter`
+referencing input cols.
+
+## Outer Apply kind
+
+The outer envelope above depends on the **outer** Apply's kind.
+
+### outerKind = `kLeft` (scalar context)
+
+The outer Apply emits one row per outer (per scalar-subquery
+semantics). Body's Join output becomes that row's value(s). Outer's
+`includeMarker` is `true` on real body rows, `NULL` on pad.
+
+- Outer's `includeMarker` resolves by body Join kind:
+  - Body kInner: `applyA.includeMarker AND applyB.includeMarker` —
+    a real body row requires both sides to match; applyB pads
+    (unmatched right) represent body rows that don't exist and must
+    be excluded.
+  - Body kLeft: `applyA.includeMarker` alone — the inner LEFT JOIN's
+    right-side pad rows ARE real body rows (left preserved with
+    NULL right cols), so applyB's marker must not gate inclusion.
+  - Body kSemi*: chain's `applyB.includeMarker` maps to outer's
+    `includeMarker` via the same aliasing the Limit peel uses (see
+    `Decorrelate-limit-rules.md` §"kLeft + count >= 1").
+- ESR=true (`enforceSingleRow`) handling depends on body Join kind:
+  - Body kLeft: leg-wise ESR on `applyA` (`|A| ≤ 1`) and `applyB`
+    (per-A `|B| ≤ 1`) enforces the scalar bound; their conjunction is
+    exactly "≤1 body row per outer," and the chain already emits one
+    row per outer.
+  - Body kInner: leg-wise ESR is wrong — an empty side makes the body
+    empty (a valid 0-row scalar → NULL), but a per-leg check fires on
+    the other side's rows. Run the per-rn pad-collapse first, then
+    `EnforceDistinct(rn)` over the collapsed stream; see §"INNER
+    pad-row drop."
+
+### outerKind = `kLeftSemiProject` EXISTS (inLhs == nullptr)
+
+Outer emits one row per outer with `markColumn = true` iff body's Join
+produces ≥1 row.
+
+- Mark composition: chain's `applyB` is kLeftSemiProject → emits its
+  own mark per outer. Outer `markColumn` then equals the chained mark
+  (possibly composed with applyA's mark if both contribute).
+- For body kInner+kSemi: mark = `applyA.mark AND applyB.mark`
+  (∃ a ∧ ∃ matching b).
+- For body kLeft: mark = `applyA.mark` (B doesn't gate existence —
+  unmatched B still emits via pad).
+- For body kSemi (in body) / kAnti: mark composes per kind.
+
+### outerKind = `kLeftSemiProject` IN (inLhs != nullptr, inBodyKey set)
+
+Outer emits `markColumn = (inLhs IN body's output column inBodyKey)`.
+`inBodyKey` references one of body's output columns; under chain
+rewrite, `inBodyKey` references A.cols or B.cols (or an expression
+over them).
+
+- If `inBodyKey` references only A cols: fold IN equi into `applyA`'s
+  semi shape directly; `applyB` becomes a filter on existence rather
+  than the mark source.
+- If `inBodyKey` references B cols: fold into `applyB`'s IN equi. The
+  IN check evaluates after the full (L,A,B) tuple is constructed.
+- If `inBodyKey` is a computed expression over both (rare):
+  intermediate Project after the chain computes it; then a follow-up
+  per-rn aggregate (`bool_or` over `eq(inLhs, inBodyKey)`) collapses
+  to the mark.
+
+The `nullAware` flag on outer Apply propagates to whichever Apply in
+the chain hosts the IN equi.
+
+## INNER pad-row drop with outer kLeft preservation
+
+`outerKind=kLeft` over `joinKind=kInner` needs `outer LEFT JOIN body`
+semantics per outer L:
+- body produces matching (a, b) rows.
+- ≥1 matches → emit those rows.
+- 0 matches → emit a single NULL-padded row (outer preserved).
+
+The chain's kLeft legs do NOT deliver this directly. Per outer they
+emit `Σ over A-rows of max(1, matching B)` rows, tagging each with
+`combinedMarker = applyA.includeMarker AND applyB.includeMarker`
+(true only on real (a, b) pairs). Two failure modes:
+
+- A real match and a pad both carry the outer, so INNER semantics
+  require dropping the pad rows (`combinedMarker` false).
+- Dropping *all* pad rows loses the outer entirely when there are 0
+  matches. And when one side is empty while the other has >1 rows, the
+  legs emit one pad row per surviving row — so a 0-match outer is
+  represented by *multiple* pad rows, not one. A bare `EnforceDistinct`
+  then raises on those duplicate pads, and a plain projection
+  duplicates the outer row. (This is the cross-join bug: `|A|>1,
+  |B|=0` yields `|A|` pad rows where semantics demand one.)
+
+**Resolution — per-rn pad-collapse.** Restore exactly one pad per
+match-less outer while keeping every real row:
+
+1. `rn = AssignUniqueId(L)` at chain bottom (the tagged_L pattern the
+   Limit peel uses).
+2. Chain produces `(L, rn, a, b, combinedMarker)`.
+3. Window over `PARTITION BY rn`: `anyMatch = bool_or(combinedMarker)`
+   and `padOrdinal = row_number()`.
+4. `Filter(combinedMarker OR (NOT anyMatch AND padOrdinal = 1))` —
+   real rows survive; a match-less outer keeps its first row (a pad)
+   and drops the rest.
+
+This covers the cross-join case (empty Join-node `predicate`): a side
+being empty is exactly the 0-match case, and the collapse reduces the
+duplicate pads to one. A cross-side predicate written as a WHERE above
+the cross join rides in `applyB.filter`, so `anyMatch` correctly
+handles the resulting mixed matches; only a predicate on the Join node
+itself (explicit `JOIN ... ON`) is currently NYI (see §"Cases
+covered").
+
+### ESR interaction
+
+- **ESR=false**: the Filter above is the whole envelope — real rows
+  (possibly many) plus one pad per match-less outer.
+- **ESR=true**: wrap the Filter output in `EnforceDistinct(rn)`. A
+  match-less outer contributes exactly one (pad) row and never trips
+  it; an outer with >1 real matches contributes >1 row and raises
+  SQL's "scalar subquery returned multiple rows" error.
+
+`joinKind=kLeft` does NOT use this pass: there `combinedMarker` is
+`applyA.includeMarker` alone (applyB pads are real LEFT JOIN output),
+so the chain already emits one row per A-row and leg-wise ESR on
+`applyA` / `applyB` enforces the scalar bound directly.
+
+## Cases covered
+
+Combinations across (outerKind, joinKind):
+
+| outerKind | joinKind | Status |
+|---|---|---|
+| kLeft (ESR=true) | kInner cross-join | **in scope** (per-rn pad-collapse + `EnforceDistinct(rn)`) |
+| kLeft (ESR=true) | kInner with predicate | designed (per-rn pad-collapse + `EnforceDistinct(rn)`); **NYI loud** in code |
+| kLeft (ESR=true) | kLeft | **in scope** |
+| kLeft (ESR=true) | kRight | **in scope** (via swap) |
+| kLeft (ESR=true) | kFull | NYI loud |
+| kLeft (ESR=true) | kLeftSemiFilter / kLeftSemiProject / kAnti | **in scope** |
+| kLeft (ESR=false) | kInner cross-join | **in scope** (per-rn pad-collapse; see §"INNER pad-row drop") |
+| kLeft (ESR=false) | kInner with predicate | designed (per-rn pad-collapse; see §"INNER pad-row drop"); **NYI loud** in code |
+| kLeft (ESR=false) | kLeft / kRight | **in scope** |
+| kLeft (ESR=false) | kFull | NYI loud |
+| kLeft (ESR=false) | kLeftSemi* / kAnti | **in scope** |
+| kLeftSemiProject EXISTS | any non-kFull | **in scope** (mark composes per §"outerKind = kLeftSemiProject EXISTS") |
+| kLeftSemiProject IN | any non-kFull | **in scope** (IN equi routed per `inBodyKey` reference site) |
+| any | kFull | NYI loud — needs DAG / re-evaluation of one side |
+
+NYI loud throws `VELOX_NYI` at the dispatch point with the specific
+shape in the error message; satisfies the correctness invariant from
+`Decorrelate-design-rationale.md`.
+
+## Termination contribution
+
+`joinPeel` is a full-replacement rule: it constructs the chain and
+returns the fully-decorrelated subtree, including the outer envelope.
+The outer Apply is gone after the rule. Driver does not re-iterate.
+
+Each chained `Apply` is dispatched through the normal driver loop and
+hits whatever per-op peels apply to its body (Filter / Project / Agg /
+Limit / nested Join).
+
+## What this rule does NOT do
+
+- **Handle `kFull`**: see NYI rationale. Future work; requires DAG
+  support or materialization.
+- **Reorder for performance**: chain order is `Apply(L, A)` then
+  `Apply(prev, B)` in body-Join's natural left-right order. Optimizer
+  later may swap if cost-justified; that's not decorrelate's concern.
+- **Optimize uncorrelated side**: if A is uncorrelated, `applyA` hits
+  terminus fast-path → cross-product Join. No special case in this
+  rule.
+- **Fuse with surrounding Project peel**: if outer body is
+  `Project(Join(...))`, Project peel runs first (driver dispatch by
+  body's outermost op) and lifts the Project; `joinPeel` sees the
+  cleaned-up Join body.
+- **Multi-leaf nested Joins**: a body `Join(Join(A1, A2), B)` decorrelates
+  as `joinPeel` over the outer Join; the inner `Join(A1, A2)` becomes
+  `applyA`'s body and the driver recurses into `joinPeel` on it. No
+  special depth limit; recursion terminates at leaf scans.

--- a/axiom/optimizer/v2/docs/Decorrelate-limit-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-limit-rules.md
@@ -1,0 +1,89 @@
+# Decorrelate Limit Rules
+
+*Companion to:*
+- *`Decorrelate-driver.md` — driver loop, terminus, NYI guards.*
+- *`Decorrelate-filter-rules.md` — Filter peel.*
+- *`Decorrelate-project-rules.md` — Project peel.*
+- *`Decorrelate-agg-rules.md` — Aggregate peel.*
+
+Peels a `Limit` from `body`. Behavior depends on `Apply.kind` and
+`Limit.count` (offset must be 0; non-zero is rejected with a
+`VELOX_USER_CHECK`).
+
+## Cases
+
+`count = 0` does not reach this rule: Translate rewrites `LIMIT 0` to
+`Values(empty)` upstream (`translateLimit`). The peel asserts `count
+>= 1`.
+
+| `Apply.kind` | Rewrite |
+|---|---|
+| `kLeftSemiProject` EXISTS (`inLhs == nullptr`) | Drop `Limit`. `∃ row in first N` ↔ `∃ row` for `N >= 1`. Recurse with body = `Limit.input`. |
+| `kLeft` | Per-outer LIMIT via window. See "kLeft + count >= 1" below. |
+| `kLeftSemiProject` IN | **NYI.** Per-outer LIMIT must precede the IN equi check at terminus; needs `terminusSemi` restructuring. |
+
+## kLeft + count >= 1
+
+Shape:
+
+```
+- Project (alias inner includeMarker → outer includeMarker, drop rn / row_number)
+  - Filter (row_number <= count)
+    - Window (partition by rn, row_number AS __limit_rn)
+      - decorrelate(
+          Apply (kLeft, fresh includeMarker, accumulatedFilter)
+            - body  = Limit.input
+            - input = AssignUniqueId(apply.input, rn)
+        )
+```
+
+Where:
+
+- `rn` is a fresh BIGINT column minted on `apply.input` via
+  `AssignUniqueId`. It serves as the window partition key, ensuring
+  `row_number()` resets per outer row.
+- The inner `Apply` is a normal correlated `kLeft` with a fresh
+  `includeMarker`. The driver recurses on it; at terminus it becomes a
+  LEFT JOIN with `_include` materialized on the right side as `true`.
+- `row_number() OVER (PARTITION BY rn)` numbers body rows per outer
+  starting at 1. With no `ORDER BY`, the row pick is non-deterministic —
+  matching SQL `LIMIT` semantics without explicit ordering.
+- `Filter (__limit_rn <= count)` keeps only the first `count` body rows
+  per outer.
+- The top `Project` reshapes to `apply.outputColumns`, sourcing the
+  outer `includeMarker` from the inner one (per-outer LIMIT keeps the
+  real-vs-pad signal: an outer with no body matches survives via the
+  inner `kLeft` pad with `includeMarker = NULL`).
+
+## Why kSemi+IN+count>=1 is NYI
+
+For IN, `Apply.inBodyKey` becomes a `Join.rightKey` at
+`terminusSemi`, and the IN equi check is computed at the Join
+boundary. Per-outer LIMIT must apply to body rows **before** the equi
+check (`IN matches if any of first N body rows = lhs`). The current
+`terminusSemi` collapses IN equi into the Join in one shot — there is
+no insertion point for a per-outer LIMIT between body emission and
+equi evaluation. A clean rewrite would restructure the IN path to
+expose body rows individually (e.g., split equi pair into existence
+mark + post-mark predicate), then apply per-outer LIMIT via the same
+window mechanism as kLeft.
+
+## Termination contribution
+
+`Limit` peels in one step. The recursive rewrite on the inner Apply
+continues peeling Limit's child operators (Filter, Project, Aggregate,
+…) and terminates at the inner Apply's terminus. Limit peel does not
+re-enter the driver iteration loop above itself.
+
+## What this rule does NOT do
+
+- **Handle `OFFSET`.** Non-zero `Limit.offset` raises `VELOX_USER_CHECK`.
+  Per-outer OFFSET via window's `row_number > offset AND row_number <=
+  offset + count` is a small extension when needed.
+- **Honor body's intrinsic ORDER BY.** Without an explicit `Sort`
+  inside body, `row_number()` has no `ORDER BY` and the row pick is
+  non-deterministic — matching SQL `LIMIT` semantics. When `Sort`
+  becomes peelable, its keys can flow into the Window's `orderKeys`.
+- **Optimize `count = 1` to `EnforceDistinct`.** Could fire a tighter
+  rewrite for the common scalar `LIMIT 1` shape; for now the general
+  Window+Filter handles it.

--- a/axiom/optimizer/v2/docs/Decorrelate-outer-refs-design.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-outer-refs-design.md
@@ -1,0 +1,433 @@
+# Decorrelate — Outer-Reference Resolution Design
+
+## The gap this addresses
+
+Today's `v2/DecorrelatePass.cpp` pulls correlation **predicates** out (via
+`PushDown.runFilter`) and builds a recovery skeleton for **Aggregate**
+body shapes. It does NOT resolve outer-column references that appear in
+body **expressions** outside of those two contexts:
+
+- `Project` expression list (e.g., `SELECT outer_a + 1`)
+- `Aggregate` function arguments (e.g., `SELECT max(u.a + t.b) FROM u`)
+- `Aggregate` FILTER condition (e.g., `SELECT count(*) FILTER (WHERE outer_x)`)
+- `Sort` key expressions
+- `Window` partition / order / arg expressions
+- `Join` ON-condition subterms
+- `Unnest` expressions
+
+These outer references survive into the body's expressions after
+decorrelate runs. At Velox emit time, the body becomes a self-contained
+subtree (the right side of `Apply→Join`), and Velox resolves column
+references by NAME against each operator's input schema. An outer-ref
+that's not in the body's input schema produces:
+
+- `Field not found: <name>. Available fields are: …` (Velox can't
+  resolve the reference)
+- or, masked today by an aggressive `Project` passthrough that leaks
+  outer columns up the body chain so they appear in `body.outputColumns`
+  by coincidence — which in turn causes
+  `Duplicate column name found on join's left and right sides: <name>`
+  when the leaked outer column collides with L's column at the
+  collapsed Join.
+
+Five tests in the SQL suite hit this category today. More will appear
+as we implement more body shapes (Window, Join in body, etc.) without
+fixing the underlying gap.
+
+## Scope of this design
+
+Specify the algorithm — including IR shapes, column lifecycle, and
+schema invariants — for decorrelating any correlated `Apply` whose body
+references outer columns in any expression position. Verify the algorithm
+against concrete walkthroughs of representative body shapes before
+implementing.
+
+Out of scope: NYI per-operator body handlers (`Window`, `Limit`, `Sort`,
+`Unnest`, multi-leaf `Join` / `UnionAll`) — each will follow the same
+algorithm when added; specifics are left to those handlers.
+
+## Mechanism
+
+The paper's algorithm (Neumann 2024, §3.3): **D-join push-through with
+expression substitution**. The dependent join (`L ⋈D body`) pushes down
+through each body operator, and at each level the operator's expressions
+that reference outer columns get substituted to reference columns the
+body now produces (post-push).
+
+At the leaves, the D-join becomes a regular relational join with L.
+Above the leaves, every operator sees L's columns in its input schema
+and outer-ref expressions resolve naturally.
+
+### v2 instantiation
+
+A single per-Apply tagged outer node:
+
+```
+tagged_L = AssignUniqueId(L)
+```
+
+is built once at `Decorrelator::rewriteApply` for correlated Applies.
+It carries L's columns plus an `__rownum` id (BIGINT, unique per L row),
+serving two roles:
+
+1. The "L side" of the materialization join at the body leaf
+2. The grouping key for the per-outer collapse at Apply collapse
+
+The body is then rewritten via two coordinated passes:
+
+**Pass 1 — PushDown** (current behavior, mostly unchanged):
+- Walks the body bottom-up
+- `Filter`: pulls correlated predicates up into `correlationFilter`;
+  non-correlated predicates either stay as Filter (current) OR rewrite
+  to `Project(p AS _kept)` (current)
+- `Aggregate`: builds the recovery skeleton (current — to be extended
+  to use the shared `tagged_L` from above rather than building its own)
+- `Project`: rebuilds with passed-through schema (current)
+
+Returns `(body_pushed, correlationFilter, kept, recovered)`.
+
+**Pass 2 — leaf wrap + Apply collapse** (new, non-recovered correlated only):
+- Walks `body_pushed` to find its single leaf (`Scan` / `Values`)
+- Replaces the leaf with
+  `Join(tagged_L, Project(leaf, _include := true), kLeft, filter=correlationFilter)`
+- Walks back up rebuilding each ancestor operator, extending each
+  `Project`'s output schema to include the new columns (`L.cols`,
+  `__rownum`, `_include`) so they survive to the top
+- At Apply collapse, builds a per-outer `Aggregate` (GROUP BY `[__rownum, L.cols]`):
+  - `kLeft` scalar: `arbitrary(IF(_include AND AND(kept), apply.resultColumn, NULL))`
+  - `kLeftSemiProject`: `bool_or(_include AND AND(kept))`
+- Final `Project` shapes the collapsed output to `apply.outputColumns`
+
+Multi-leaf body (`Join`, `UnionAll`, nested `Apply` in body): NYI —
+sharing `tagged_L` across multiple leaves would create a DAG that v2
+IR doesn't support; cloning would produce distinct ids and break the
+per-outer collapse.
+
+### Substitution map (Column*-identity in v2)
+
+The paper's substitution map is `outer_column → body_visible_expr`. In
+v2 IR, columns are identified by `ColumnCP` pointers, and Velox emit
+resolves references by NAME against each operator's input schema.
+
+**Key insight:** v2's leaf wrap uses `tagged_L` whose `outputColumns`
+include L's columns by the SAME `ColumnCP` identities. After the leaf
+wrap, the body's leaf is `Join(tagged_L, …)` whose outputs include
+those exact L columns by name. Expressions higher up in the body that
+reference outer L columns (by Column* / by name) resolve against this
+joined input schema.
+
+Substitution is therefore **identity at the Column* level** — no
+expression rewriting is needed for normal correlated references. The
+work is the schema wrapping (leaf wrap), not the expression walk.
+
+**Exception — naming collisions:** if `L.outputColumns` and `body's
+leaf.outputColumns` share a column name (different `Column*`, same
+name), `Join(L, leaf)` produces a duplicate name and Velox rejects.
+This requires renaming, which IS substitution: replace body-side
+column refs by name with a fresh alias.
+
+In practice, naming collisions arise from translate's handling of
+identity-passthrough subqueries: `(SELECT a) FROM t` translates body
+to `Project(NoFromValues, [outer_a], [outer_a])` where the inner
+Project's output column IS the outer's `t.a` Column* (translate's
+identity-Project elision). Apply's `resultColumn` = outer `t.a`,
+which then appears in Apply.outputColumns twice (once from L, once
+as resultColumn).
+
+This is a TRANSLATE-side issue that should be fixed independently:
+when `liftSubquery`'s body output column is already in `applyTarget`'s
+output schema, wrap the body in an aliasing Project that exposes a
+fresh column. With that translate fix, naming collisions don't reach
+Decorrelate. (See "Open issue" below.)
+
+## Walkthroughs
+
+For each shape: lp form → v2 translate output → Decorrelate steps →
+Velox-emit-able plan. Verify schema correctness at every step.
+
+Notation:
+- `t` = outer relation with column `t.a`
+- `u` = inner relation with column `u.a` (and possibly more)
+- Column identities written as `t.a`, `u.a` (the actual ColumnCP); names
+  given when distinct from identity
+- `Apply.outputColumns = input.outputColumns + apply.resultColumn` (per
+  v2 IR contract)
+
+### Shape A — uncorrelated scalar (baseline; no change)
+
+```sql
+SELECT (SELECT max(u.a) FROM u) FROM t
+```
+
+lp body: `Aggregate(Scan(u), [max(u.a) AS m])`.
+
+v2 translate emits `Join(kInner, t, EnforceSingleRow(Aggregate(...)))`
+directly — uncorrelated scalars bypass Apply entirely. No decorrelate
+work needed.
+
+✓ Already works. No change.
+
+### Shape B — correlated scalar over Filter(Scan), no outer ref in expressions
+
+```sql
+SELECT (SELECT u.b FROM u WHERE u.a = t.a) FROM t
+```
+
+lp body: `Project([u.b], Filter(u.a = t.a, Scan(u)))`.
+
+v2 translate: `Apply(kLeft, t, body, correlations=[t.a], resultColumn=u.b)`.
+
+**PushDown pass** (mostly current behavior):
+- `runProject([u.b], …)` — recurses into Filter
+- `runFilter(u.a = t.a, …)` — predicate references outer t.a → pulled into `correlationFilter`. Recurses into Scan(u). Returns `(Scan(u), u.a=t.a, {}, false)`. Filter handler returns `(Scan(u), u.a=t.a, {}, false)` (predicates all pulled, no Filter rebuilt).
+- `runProject` returns `(Project(Scan(u), [u.b], [u.b]), u.a=t.a, {}, false)`.
+
+**Apply collapse** — non-recovered correlated, new path:
+- `tagged_L = AssignUniqueId(t)`, output `[t.a, __rownum]`
+- `injectLeafWrap` walks body, finds Scan(u) leaf:
+  - `marked_u = Project(u, [u.a, _include := true])`, output `[u.a, _include]`
+  - `wrap = Join(tagged_L, marked_u, kLeft, filter=u.a=t.a)`, output `[t.a, __rownum, u.a, _include]`
+- Walking up: `Project([u.b], wrap)` — but wait, `u.b` referenced; need it in scope. The original body had `Project(Filter(Scan(u)), [u.b])`, so the leaf is Scan(u) which has `[u.a, u.b]` (both cols). After leaf wrap, `wrap.outputColumns = [t.a, __rownum, u.a, u.b, _include]`. Project([u.b]) above resolves.
+  - Project's outputs need to passthrough `__rownum, t.a, _include` so they survive to Apply collapse: outputs become `[u.b, __rownum, t.a, _include]`. Exprs: `[u.b, __rownum, t.a, _include]` (all passthrough columns).
+- Per-outer Aggregate: GROUP BY `[__rownum, t.a]`, agg `arbitrary(IF(_include, u.b, NULL))`.
+  - Output: `[__rownum, t.a, u.b]`.
+- Final Project: `[t.a, u.b]` matching `apply.outputColumns`.
+
+Velox emit-time schema check:
+- Scan(u): `[u.a, u.b]` ✓
+- Project(marker): input `[u.a, u.b]`, output `[u.a, u.b, _include]` ✓
+- Join(kLeft, tagged_L, marked_u, filter=u.a=t.a):
+  - tagged_L (left) cols: `[t.a, __rownum]` (names: "a", "__rownum")
+  - marked_u (right) cols: `[u.a, u.b, _include]` (names: "a", "b", "_include")
+  - **NAME COLLISION**: both sides have column named "a" (t.a is "a", u.a is "a")
+  - Velox rejects ✗
+
+This shape hits the duplicate-name problem at the leaf wrap. Need to
+rename one side's "a" before the join.
+
+**Resolution:** at leaf wrap construction, detect name collisions
+between `tagged_L.outputColumns` and `marked_leaf.outputColumns`. For
+each collision, alias one side via a renaming Project. By convention,
+rename body-side (leaf side) — the outer's names are user-facing and
+shouldn't be modified.
+
+Continuing with renaming applied:
+- `marked_u_renamed = Project(marked_u, [u.a AS u_a_renamed, u.b, _include])`, output `[u_a_renamed, u.b, _include]`
+- BUT: the `u.a` in the `u.a = t.a` filter is the SAME Column* as `marked_u`'s u.a, and Velox resolves by name — after rename, the filter's "u.a" would not resolve. Need to substitute.
+- This is the substitution map at work: rename `u.a` → `u_a_renamed` in the join filter expression.
+
+This case needs both:
+1. The leaf-wrap renaming Project on the body side
+2. An expression-level substitution of body-side column refs that got renamed (applied to the join filter)
+
+The expression substitution is narrowly scoped: it only affects expressions that reference body-side columns that were renamed during leaf wrap. Other expressions (referencing outer columns, referencing body columns that weren't renamed) pass through unchanged.
+
+### Shape C — `(SELECT a) FROM t` (the failing l317)
+
+```sql
+SELECT (SELECT a) FROM t
+```
+
+lp body: `Project(NoFromValues, [outer_t.a])` — the inner Project's
+single expression resolves to outer's t.a; translate's identity-Project
+elision makes Project's outputColumn the SAME `t.a` Column*.
+
+v2 translate: `Apply(kLeft, t, body=Project(NoFromValues, [t.a], [t.a]), correlations=[t.a], resultColumn=t.a)`.
+
+**The original sin** — `resultColumn = t.a` is the SAME column already
+in `applyTarget=t`'s outputColumns. So `apply.outputColumns = [t.a, t.a]`
+(duplicate). This is a translate-side bug that no amount of Decorrelate
+work can paper over — Apply's claimed output schema is malformed at
+construction time.
+
+**Translate-side fix** (separate from Decorrelate):
+
+In `liftSubquery`, after computing `resultColumn = bodyOut[0]`, check
+if `resultColumn` is already in `applyTarget->outputColumns()`. If so,
+allocate a fresh aliasing column and wrap body in
+`Project(body, [bodyOut[0]], [fresh_alias])`. Apply's `resultColumn`
+becomes `fresh_alias`.
+
+With this fix, `apply.outputColumns = [t.a, fresh_alias_for_a]`, no
+duplicate. The Decorrelate algorithm proceeds normally.
+
+**Known design gap:**
+The Translate-side fix is design-correct but **not sufficient**.
+Decorrelate's Project peel (Rule A in
+`Decorrelate-project-rules.md`) peels the alias wrap, exposing the
+un-aliased originalBody underneath. The resulting inner Apply has
+`outputColumns = input.cols ++ originalBody.cols` = duplicate. The
+terminus / lifted-Project chain propagates the duplicate to a
+Velox Project that fails `PlanConsistencyChecker`.
+
+Full Shape C correctness needs Decorrelate's Project peel to apply
+the same aliasing trick recursively when constructing the inner
+Apply. See `Decorrelate-project-rules.md` §"Known design gap —
+Shape C composition" for the proposed completion.
+
+**Decorrelate after translate fix:**
+
+Body = `Project(Project(NoFromValues, [t.a], [t.a]), [t.a], [fresh_a])`.
+
+- PushDown: nested Projects, both pass-through (no Filter to pull). Returns body unchanged.
+- Apply collapse non-recovered:
+  - `tagged_L = AssignUniqueId(t)` → `[t.a, __rownum]`
+  - `injectLeafWrap` walks body, finds NoFromValues leaf:
+    - `marked_leaf = Project(NoFromValues, [_include := true])`, output `[_include]`
+    - `wrap = Join(tagged_L, marked_leaf, kLeft, filter=null)`, output `[t.a, __rownum, _include]`
+    - No name collision (NoFromValues contributes no columns named "a")
+  - Walking up: inner Project `[t.a]` over wrap — resolves ✓. Extends output schema: `[t.a, __rownum, _include]` (no addition since t.a, __rownum, _include all present).
+  - Outer Project `[fresh_a]` over inner — resolves (fresh_a = expr referencing t.a via the inner Project's t.a output). Extends output: `[fresh_a, __rownum, t.a, _include]`.
+- Per-outer Aggregate: GROUP BY `[__rownum, t.a]`, agg `arbitrary(IF(_include, fresh_a, NULL))`, output `[__rownum, t.a, fresh_a]`.
+- Final Project: `[t.a, fresh_a]` matching `apply.outputColumns`.
+
+Velox schema check at each operator: ✓ no duplicates, all refs resolve.
+
+### Shape D — correlated semi (EXISTS) over Filter(Scan)
+
+```sql
+SELECT EXISTS (SELECT 1 FROM u WHERE u.a = t.a) FROM t
+```
+
+lp body: `Project([1], Filter(u.a = t.a, Scan(u)))` (or similar — the
+projected value is irrelevant for EXISTS).
+
+v2 translate: `Apply(kLeftSemiProject, t, body, correlations=[t.a], resultColumn=fresh_mark)`.
+
+**Decorrelate:**
+
+- PushDown pulls `u.a = t.a` to correlationFilter, returns body's Project unchanged.
+- Apply collapse non-recovered semi:
+  - `tagged_L = AssignUniqueId(t)`, `wrap = Join(tagged_L, marked_u, kLeft, filter=u.a=t.a)`.
+  - (Same name-collision issue as Shape B if u.a and t.a both named "a" — needs rename.)
+  - Per-outer Aggregate: GROUP BY `[__rownum, t.a]`, agg `bool_or(_include)`, output `[__rownum, t.a, fresh_mark]`.
+  - Final Project: `[t.a, fresh_mark]` matching `apply.outputColumns`.
+
+Verifies: for unmatched outer rows, the LEFT JOIN pads `_include = NULL`,
+`bool_or(NULL) = NULL` which resolves to false in BOOLEAN context. Mark
+is false. ✓
+
+For matched outer rows, `_include = true`, `bool_or(true) = true`. Mark
+is true. ✓
+
+### Shape E — correlated scalar over Aggregate(Filter(Scan)) — count(*)
+
+```sql
+SELECT (SELECT count(*) FROM u WHERE u.a = t.a) FROM t
+```
+
+Currently working. Recovery path. Walkthrough for completeness, to
+verify the new design keeps it working:
+
+lp body: `Aggregate([count(*)], Filter(u.a = t.a, Scan(u)))`.
+
+v2 translate: `Apply(kLeft, t, body, correlations=[t.a], resultColumn=count_result)`.
+
+**Decorrelate** (uses recovery, sharing tagged_L):
+
+- `tagged_L = AssignUniqueId(t)` at Apply level (already in place).
+- PushDown.runAggregate:
+  - Recurses into Filter → pulls `u.a = t.a` into `correlationFilter`. Returns `(Scan(u), u.a=t.a, {}, false)`.
+  - Builds recovery using `tagged_L` (no longer builds its own):
+    - `marked_u = Project(u, _include := true)`
+    - `joined = Join(tagged_L, marked_u, kLeft, filter=u.a=t.a)` — **same name-collision issue**.
+    - Recovery Aggregate: GROUP BY `[__rownum, t.a]`, agg `count() FILTER (_include) AS count_result`, output `[__rownum, t.a, count_result, _matched]`.
+  - Returns `(recovered, null, {}, true)`.
+- Apply collapse recovered (existing path, mostly): final Project `[t.a, count_result]` matching `apply.outputColumns`. ✓
+
+Name-collision concern same as Shapes B/D — the recovery's LEFT JOIN
+needs the rename too. Currently masked because t and u happen to have
+different actual column identities in the test set; would surface for
+queries where they share names.
+
+### Shape F — correlated scalar over Filter(Aggregate(...)) — HAVING
+
+```sql
+SELECT (SELECT count(*) FROM u WHERE u.a = t.a HAVING count(*) > 0) FROM t
+```
+
+Currently working. Recovery + post-aggregate Filter folded as IF.
+
+(Mostly same as Shape E, with the addition of the post-aggregate
+Filter rewritten to `IF(having_predicate, count_result, NULL)` at the
+final Project. No new issues for this design.)
+
+### Shape G — correlated scalar over Project(Aggregate(...)) with outer ref in Project expr
+
+```sql
+SELECT (SELECT count(*) + t.a FROM u WHERE u.a = t.a) FROM t
+```
+
+This is the next layer of the structural gap — currently fails because
+the Project's expression `count(*) + t.a` references outer `t.a` which
+isn't in the body's input scope after recovery.
+
+lp body: `Project([count_star + t.a], Aggregate([count(*)], Filter(u.a = t.a, Scan(u))))`.
+
+v2 translate: `Apply(kLeft, t, body, correlations=[t.a], resultColumn=sum_result)`.
+
+**Decorrelate:**
+
+- PushDown:
+  - runProject recurses into Aggregate.
+  - runAggregate builds recovery (Shape E behavior). Returns `(recovered, null, {}, true)`. `recovered.outputColumns = [__rownum, t.a, count_result, _matched]`.
+  - Back in runProject: `Project([count_star + t.a], recovered)`. The expression references `t.a` — does it resolve against `recovered`?
+    - `recovered.outputColumns` includes `t.a` (from `tagged_L`'s groupingKeys passthrough). ✓
+  - Project's outputs need passthrough so downstream (Apply collapse) gets `__rownum`, `_matched`, `t.a`: outputs become `[sum_result, __rownum, t.a, _matched]`.
+- Apply collapse recovered:
+  - Final Project: `[t.a, sum_result]` matching `apply.outputColumns`. ✓
+
+Velox schema check:
+- recovered output: `[__rownum, t.a, count_result, _matched]` — t.a is in scope.
+- Project: expr `count_star + t.a`, input has both — ✓.
+
+Shape G ACTUALLY WORKS today via the recovery path + Project passthrough, BECAUSE the recovery's groupingKeys carry L.cols (`t.a` is in `tagged_L.outputColumns` which the recovery joins+groups by). The passthrough then propagates `t.a` to the Project's output, and Apply collapse uses it.
+
+The failure is in shape C — non-Aggregate body. The recovery doesn't fire there.
+
+## Summary of decisions
+
+1. **Tagged_L is shared** between Aggregate-recovery and (when added) leaf wrap. Built once at Apply level.
+2. **Leaf wrap** for non-recovered correlated bodies: replace single leaf with `Join(tagged_L, marked_leaf, kLeft, filter=correlationFilter)`. NYI multi-leaf bodies (substrate gap: needs DAG support).
+3. **Naming-collision rename** at leaf wrap (and at recovery LEFT JOIN): when L.outputColumns and body-side outputColumns share a column name (different ColumnCP), insert an aliasing Project on the body side and substitute body-side column refs in any expression that survives past the rename point (notably the join filter).
+4. **Project passthrough through body chain**: must extend Project's output schema with the new columns introduced at the leaf wrap (`__rownum`, `L.cols`, `_include`) so they survive to Apply collapse. Same mechanism used by the current passthrough; the change is making it bounded (only the recovery / leaf-wrap-introduced columns, not arbitrary inner columns).
+5. **Per-outer Aggregate at Apply collapse** for non-recovered:
+   - `kLeft` scalar: `arbitrary(IF(_include AND AND(kept), apply.resultColumn, NULL))`
+   - `kLeftSemiProject`: `bool_or(_include AND AND(kept))`
+6. **Translate-side fix for identity-projection collision** (`(SELECT a) FROM t`): in `liftSubquery`, when `bodyOut[0]` is already in `applyTarget->outputColumns()`, wrap body in an aliasing Project and use the alias as `resultColumn`. This eliminates the Apply.outputColumns duplicate independent of any Decorrelate work.
+
+## Open issue — translate-side fix vs Decorrelate-side rename
+
+The naming collision arises in two places:
+- Apply.outputColumns has L.cols + resultColumn, where resultColumn IS an outer column (Shape C). Fix: translate-side rename in `liftSubquery`.
+- Leaf wrap / recovery LEFT JOIN has `tagged_L.cols` + `body_side.cols` with shared names (Shapes B, D, E). Fix: Decorrelate-side rename at join construction.
+
+These are independent and BOTH need fixing. The translate-side fix is small and tractable. The Decorrelate-side rename is a slightly bigger change because it requires substitution into the join filter (only column refs that got renamed need substituting — narrow scope).
+
+## Implementation order
+
+1. Translate-side rename in `liftSubquery` (Shape C). Independent, no Decorrelate change. ~10 lines + comment.
+2. Decorrelate-side rename at recovery LEFT JOIN (affects existing recovery; verifies the rename mechanism doesn't regress current 632/50). ~30 lines.
+3. Hoist `tagged_L` construction to Apply level; pass to PushDown (already attempted; verified to maintain 632/50 in isolation). ~20 lines.
+4. Apply-collapse non-recovered leaf-wrap path + per-outer Aggregate (Shapes B, D). ~100 lines.
+5. Bounded passthrough in Project handler (only `tagged_L.outputColumns + _include`, not arbitrary). ~20 lines.
+6. Decorrelate-side rename at leaf wrap, with filter-expression substitution (Shapes B, D, E refinement). ~40 lines.
+
+Each step verified to maintain or improve the test pass count before
+moving to the next. Total: ~220 lines net, in 6 commits.
+
+## What this design does NOT solve
+
+- **Multi-leaf bodies** (Join, UnionAll, nested Apply in body): NYI per
+  substrate gap. Solving requires v2 IR DAG support OR per-leaf cloned
+  `tagged_L` (with the cloned ids breaking per-outer aggregation —
+  acceptable only if the body shape has no Aggregate above).
+- **Window in correlated body**: own per-operator recovery, paper §4.4.
+  Outer-ref resolution above follows the same leaf-wrap mechanism once
+  the Window handler is added.
+- **Sort + Limit in correlated body**: per-outer ORDER BY / LIMIT needs
+  window-function rewrite, paper §4.4.
+- **Outer refs in `Aggregate` FILTER condition** (e.g., `count(*)
+  FILTER (WHERE outer_x > 0)`): the Filter condition is on a body
+  aggregate. After leaf wrap or recovery, outer cols are visible in
+  the input — should work, but needs walkthrough to verify.

--- a/axiom/optimizer/v2/docs/Decorrelate-project-rules.md
+++ b/axiom/optimizer/v2/docs/Decorrelate-project-rules.md
@@ -1,0 +1,195 @@
+# Decorrelate Project Rules
+
+*Companion to:*
+- *`Decorrelate-driver.md` — driver loop, terminus, NYI guards.*
+- *`Decorrelate-agg-rules.md` — Aggregate peel.*
+
+Peels a `Project` from `body`. Shape depends on `Apply.kind`:
+
+- **kLeft** — Project lifts above Apply (body cols flow through
+  Apply.outputColumns; Project's expressions remain unchanged). Rule A.
+- **kLeftSemiProject** — Project dissolves into the mark predicate
+  (`inBodyKey` substituted via Project's expressions; body becomes
+  Project's child; no Project above Apply). Rule B.
+
+## Mental model
+
+Project's role in a correlated body: transform child rows into new
+output cols, possibly referencing outer (L) cols inside expressions.
+The peel pulls Project out of body — *where* depends on kind because
+body cols flow through differently per kind.
+
+```
+kLeft:
+  Apply (kind, body = Project(child, exprs))
+    ↓
+  Project(exprs)
+    └ Apply (kind, body = child)
+
+kLeftSemiProject:
+  Apply (kSemi, body = Project(child, exprs), inBodyKey = c)
+    ↓ (substitute c → expr_for_c)
+  Apply (kSemi, body = child, inBodyKey = expr_for_c)
+```
+
+## Rule A — `kLeft`
+
+**Before:**
+
+```
+- Apply (kind, filter = F, body = Project(child, exprs → out_cols))
+  - input = L
+```
+
+**After:**
+
+```
+- Project: out_cols computed via exprs
+                  // exprs reference body cols (now child cols) and
+                  // L cols, all visible in the new Apply.outputColumns
+  - Apply (kind, filter = F, body = child)
+    - input = L
+```
+
+Where:
+- `Apply.outputColumns` shifts from `input.cols ++ Project's out_cols`
+  to `input.cols ++ child.cols` (the relaxed contract: body's cols
+  pass through).
+- The lifted Project above Apply reproduces the original Apply's
+  outputs: `input.cols ++ out_cols`, with `out_cols` computed from
+  exprs that reference child cols and L cols (all in the new Apply's
+  outputColumns).
+- Apply's `kind`, `filter`, `enforceSingleRow`, `markColumn`, `inLhs`,
+  `inBodyKey` are unchanged.
+
+**Correlated Project benefit:** if exprs reference L cols, those refs
+are now above Apply (not in body). `correlationColumns` recomputation
+sees only refs in the new body (`child`). If Project was the last
+carrier of correlations, the next driver iteration hits terminus.
+
+## Rule B — `kLeftSemiProject`
+
+The Project's output cols feed into mark derivation, specifically the
+IN equi-pair `(inLhs, inBodyKey)`. Lifting Project above Apply doesn't
+work because `kLeftSemiProject.outputColumns` is
+`input.cols ++ markColumn` — body cols (Project's outputs) aren't
+visible above Apply.
+
+**Before:**
+
+```
+- Apply (kSemi, filter = F, body = Project(child, exprs → out_cols),
+         inLhs = lhs_expr, inBodyKey = bk_col)
+  - input = L
+```
+
+where `bk_col ∈ out_cols` (i.e., `inBodyKey` references one of
+Project's output cols).
+
+**After:**
+
+```
+- Apply (kSemi, filter = F, body = child,
+         inLhs = lhs_expr, inBodyKey = bk_expr)
+  - input = L
+```
+
+where `bk_expr` is the Project's expression that produced `bk_col` —
+substituted in place. `bk_expr` references child cols (and possibly L
+cols); both are valid at the new Apply boundary.
+
+For EXISTS (`inLhs == nullptr`, `inBodyKey == nullptr`), there's
+nothing to substitute — body just becomes `child`, no expression
+rewrite needed.
+
+If `Apply.filter` references any of Project's output cols, substitute
+them too via the same `out_col → expr` map.
+
+**Correlated Project benefit (same as Rule A):** Project's L refs end
+up in substituted expressions, possibly raising correlation into
+`inBodyKey` or `filter` (both at Apply boundary). Body
+(`child`) becomes simpler. `correlationColumns` recomputation may
+empty out.
+
+## Column identity / aliasing
+
+The peel tracks column identity across the lift / substitute:
+
+- For Rule A: `newBody`'s `outputColumns` flow into the inner Apply's
+  `outputColumns` by identity (body cols that alias an input col
+  collapse to a single slot). The lifted Project reproduces the
+  original output schema, wrapping each of the original Project's exprs
+  in `IF(includeMarker, expr, NULL)` so they read NULL on pad rows
+  post-Join.
+- For Rule B: the substitution `bk_col → bk_expr` is a Column-ref
+  rewrite. If `bk_expr` references other Project output cols (rare —
+  would require Project chaining we don't normally see), the
+  substitution recurses.
+
+The rule describes the lift / substitute *conceptually*; the
+implementation mints nodes/columns via `Builder` and rewrites
+expressions via `ExprFactory::substitute`.
+
+## Termination contribution
+
+Project peel removes Project from body uniformly. Body shrinks by one
+operator. If Project was the only carrier of correlation (its exprs
+referenced L cols and nothing below did), the next iteration hits
+terminus.
+
+## What this rule does NOT do
+
+- **Push Project below other body operators.** Peel only lifts /
+  dissolves; no internal reorganization of body.
+- **Combine adjacent Projects.** A Project above the lifted Apply and
+  another Project further above are not fused. Downstream
+  constant-folding / project-merge passes handle that.
+- **Handle Project chaining inside body.** If body =
+  `Project(Project(child, ...), ...)`, the outer Project peels first
+  (this rule), then the inner Project peels on the next iteration.
+
+## Known design gap — Shape C composition
+
+`Decorrelate-outer-refs-design.md` specifies the **Shape C fix in
+Translate**: when a scalar subquery's body output column is the same
+(or same-named-as) an outer input column (e.g., `SELECT (SELECT a)
+FROM t`), Translate wraps body in `Project(body, [body.col],
+[fresh_alias])` so `Apply.outputColumns` doesn't have duplicate
+names.
+
+What the design did NOT anticipate: **Project peel undoes the alias
+wrap.** Rule A peels the alias Project, exposing the un-aliased
+original body underneath. The resulting inner Apply has
+`outputColumns = input.cols ++ originalBody.cols`, which once again
+contains the duplicate. The lifted Project / terminus chain
+propagates the duplicate to a Velox Project, which fails
+`PlanConsistencyChecker` at emit time.
+
+To close: Rule A's `projectPeelLeft` needs to detect when
+`newBody.outputColumns` would collide (by name) with
+`input.outputColumns`, and apply the same aliasing trick recursively
+when constructing the inner Apply. This is non-trivial because:
+
+- Each colliding body col needs its own alias.
+- The lifted Project above must restore body's original output
+  schema using the aliased cols (via `replaceInputs` substitution,
+  similar to F_post handling).
+- Multi-col body bodies need parallel aliases.
+
+For now: Translate's Shape C fix is design-correct but partial; the
+Decorrelate completion is NYI. Tests like `SELECT (SELECT a) FROM
+t`, `SELECT (SELECT t.a) FROM t` still fail loudly with "Duplicate
+output column" at emit-time PlanConsistencyChecker.
+
+## NYI / edge cases
+
+- **`bk_expr` is itself a Project of another Project**: substitution
+  recurses cleanly in principle; flag if implementation hits an
+  unexpected nesting depth.
+- **`bk_expr` references L cols only** (the `t.x IN (SELECT t.y FROM
+  u)` case): after substitution, `inBodyKey` references L cols, making
+  the mark predicate `(L_col = L_col)` — trivially true. Translate
+  should catch this earlier; flag if it reaches the peel.
+- **Project's output col referenced both by `inBodyKey` AND by
+  `Apply.filter`**: substitute consistently in both places via the
+  same map.

--- a/axiom/optimizer/v2/docs/Decorrelate.md
+++ b/axiom/optimizer/v2/docs/Decorrelate.md
@@ -1,0 +1,86 @@
+# v2 Decorrelate — Overview
+
+*Overview of the decorrelate pass, pointing at the doc family below. The
+design rationale, alternatives considered, and rejected paths live in
+`Decorrelate-design-rationale.md`.*
+
+## Doc family
+
+Specialized docs cover separate concerns; each is short and focused:
+
+- **`Decorrelate-driver.md`** — driver loop, per-peel dispatch,
+  `correlationColumns` recomputation, terminus detection.
+- **`Decorrelate-filter-rules.md`** — Filter peel (uniformly absorbs
+  predicates into `Apply.filter`).
+- **`Decorrelate-project-rules.md`** — Project peel (Rule A lifts above
+  Apply for kLeft; Rule B substitutes into mark predicate for
+  kLeftSemiProject).
+- **`Decorrelate-agg-rules.md`** — Aggregate peel. Case 4 (kLeft +
+  non-empty F_post + non-empty gby) NYI.
+- **`Decorrelate-enforce-single-row.md`** — `Apply.enforceSingleRow`
+  lowering at terminus (kLeft only: `AssignUniqueId` + LEFT JOIN +
+  `EnforceDistinct` on the id).
+- **`Decorrelate-design-rationale.md`** — alternatives considered,
+  rejected paths, why-we-can't-just-follow-the-paper.
+- **`Decorrelate-outer-refs-design.md`** — outer-reference resolution
+  (companion concern).
+
+## What decorrelate does
+
+Turns each `Apply` (a "true dependent join" produced by translate) into
+a `Join` (or a richer post-Join structure for some cases) by iteratively
+peeling correlations out of `Apply.body`. Runs after translate, before
+any later pass.
+
+## Algorithmic heritage
+
+Framework derived from Neumann (2024) "Improving Unnesting of Complex
+Queries" (top-down) and Neumann & Kemper (2015) "Unnesting Arbitrary
+Queries" (bottom-up).
+
+The **iterative-pushdown framework** is from that line. The **specific
+lifted shapes** are designed from scratch — the paper's shapes assume
+DAG execution / materialization that we don't have, which makes them
+unsafe (correctness) or inefficient (distributed cost) in our setting.
+See `Decorrelate-design-rationale.md` §"Why we can't just follow the
+paper" for the full constraint analysis.
+
+## Apply IR shape
+
+Authoritative contract: `v2/Node.h` `Apply` class doc. Summary:
+
+- 11 fields: `input`, `body`, `correlationColumns`, `kind`, `filter`,
+  `enforceSingleRow`, `markColumn`, `inLhs`, `inBodyKey`,
+  `includeMarker`, `outputColumns`.
+- `kind ∈ {kLeft, kLeftSemiProject}`. Uncorrelated scalars are lowered
+  directly by translate to `Join(kInner, input, EnforceSingleRow(body))`
+  — they do not reach Apply.
+- `filter`: residual predicates that ride with Apply through iteration;
+  become `Join.filter` at terminus.
+- `enforceSingleRow`: scalar-context assertion flag. Lowered at terminus
+  per ESR doc. Invariant: false for `kLeftSemiProject`.
+- `correlationColumns`: `input` cols the current `body` still references.
+  Recomputed by driver after every peel; empty → terminus.
+- `markColumn`: non-null iff `kLeftSemiProject`; BOOLEAN; holds the
+  mark output.
+- `inLhs` / `inBodyKey`: IN-only equi pair; both null for scalar /
+  EXISTS.
+- `includeMarker`: pad-row marker column for `kLeft` (non-null iff
+  `kind == kLeft`); reads `true` on real body rows, NULL on pad rows
+  after terminus.
+
+## Driver / peel-rule mental model
+
+```
+driver(apply):
+  loop:
+    recompute correlationColumns from body
+    if empty → terminus (Apply → Join, + optional ESR wrap)
+    rule = dispatch(body's outermost operator)
+    apply = rule.apply(apply)   // peel, possibly NYI
+```
+
+Each peel rule produces a transformed tree (often containing a new
+inner Apply); driver re-enters on that.
+
+See `Decorrelate-driver.md` for the full driver spec.

--- a/axiom/optimizer/v2/tests/AlgebraicPropertiesTest.cpp
+++ b/axiom/optimizer/v2/tests/AlgebraicPropertiesTest.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <array>
+
+#include <fmt/core.h>
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/v2/AlgebraicProperties.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+using JoinType = velox::core::JoinType;
+
+constexpr std::array<JoinType, 3> kSupportedTypes{
+    JoinType::kInner,
+    JoinType::kLeft,
+    JoinType::kFull,
+};
+
+std::string pairTrace(JoinType child, JoinType parent) {
+  return fmt::format(
+      "(child={}, parent={})",
+      velox::core::JoinTypeName::toName(child),
+      velox::core::JoinTypeName::toName(parent));
+}
+
+// Verifies every cell of the (child, parent) table.
+TEST(AlgebraicPropertiesTest, table) {
+  auto expect = [](JoinType child,
+                   JoinType parent,
+                   bool associative,
+                   bool leftAsscom,
+                   bool rightAsscom) {
+    SCOPED_TRACE(pairTrace(child, parent));
+    const auto actual = AlgebraicProperties::derive(child, parent);
+    EXPECT_EQ(actual.associative, associative);
+    EXPECT_EQ(actual.leftAsscom, leftAsscom);
+    EXPECT_EQ(actual.rightAsscom, rightAsscom);
+  };
+
+  // child = kInner
+  expect(JoinType::kInner, JoinType::kInner, true, true, true);
+  expect(JoinType::kInner, JoinType::kLeft, true, true, false);
+  expect(JoinType::kInner, JoinType::kFull, false, false, false);
+
+  // child = kLeft
+  expect(JoinType::kLeft, JoinType::kInner, false, true, false);
+  expect(JoinType::kLeft, JoinType::kLeft, false, true, false);
+  expect(JoinType::kLeft, JoinType::kFull, false, false, false);
+
+  // child = kFull
+  expect(JoinType::kFull, JoinType::kInner, false, false, false);
+  expect(JoinType::kFull, JoinType::kLeft, false, false, false);
+  expect(JoinType::kFull, JoinType::kFull, false, false, false);
+
+  // child = semi/anti
+  expect(JoinType::kLeftSemiFilter, JoinType::kInner, false, true, false);
+  expect(JoinType::kAnti, JoinType::kInner, false, true, false);
+  expect(JoinType::kLeftSemiFilter, JoinType::kLeft, false, true, false);
+  expect(JoinType::kAnti, JoinType::kLeft, false, true, false);
+  expect(JoinType::kLeftSemiFilter, JoinType::kFull, false, false, false);
+  expect(JoinType::kAnti, JoinType::kFull, false, false, false);
+
+  // parent = semi/anti
+  expect(JoinType::kInner, JoinType::kLeftSemiFilter, true, true, false);
+  expect(JoinType::kInner, JoinType::kAnti, true, true, false);
+  expect(JoinType::kLeft, JoinType::kLeftSemiFilter, false, true, false);
+  expect(JoinType::kLeft, JoinType::kAnti, false, true, false);
+  expect(JoinType::kFull, JoinType::kLeftSemiFilter, false, false, false);
+  expect(JoinType::kFull, JoinType::kAnti, false, false, false);
+
+  // semi under semi
+  expect(
+      JoinType::kLeftSemiFilter, JoinType::kLeftSemiFilter, false, true, false);
+  expect(JoinType::kAnti, JoinType::kAnti, false, true, false);
+  expect(JoinType::kLeftSemiFilter, JoinType::kAnti, false, true, false);
+  expect(JoinType::kAnti, JoinType::kLeftSemiFilter, false, true, false);
+
+  // kLeftSemiProject reorders like kLeftSemiFilter.
+  expect(JoinType::kLeftSemiProject, JoinType::kInner, false, true, false);
+}
+
+// For a commutative child, associativity implies left-asscom (and
+// symmetrically, a commutative parent implies right-asscom). Only
+// `kInner` and `kFull` are commutative in this subset.
+TEST(AlgebraicPropertiesTest, asscomImpliedByCommAndAssoc) {
+  auto isCommutative = [](JoinType type) {
+    return type == JoinType::kInner || type == JoinType::kFull;
+  };
+
+  for (JoinType child : kSupportedTypes) {
+    for (JoinType parent : kSupportedTypes) {
+      SCOPED_TRACE(pairTrace(child, parent));
+      const auto props = AlgebraicProperties::derive(child, parent);
+      if (isCommutative(child) && props.associative) {
+        EXPECT_TRUE(props.leftAsscom);
+      }
+      if (isCommutative(parent) && props.associative) {
+        EXPECT_TRUE(props.rightAsscom);
+      }
+    }
+  }
+}
+
+// `leftAsscom` and `rightAsscom` are symmetric under argument swap.
+TEST(AlgebraicPropertiesTest, asscomSymmetry) {
+  for (JoinType lhs : kSupportedTypes) {
+    for (JoinType rhs : kSupportedTypes) {
+      SCOPED_TRACE(pairTrace(lhs, rhs));
+      const auto forward = AlgebraicProperties::derive(lhs, rhs);
+      const auto swapped = AlgebraicProperties::derive(rhs, lhs);
+      EXPECT_EQ(forward.leftAsscom, swapped.leftAsscom);
+      EXPECT_EQ(forward.rightAsscom, swapped.rightAsscom);
+    }
+  }
+}
+
+TEST(AlgebraicPropertiesTest, unsupportedJoinTypeThrows) {
+  // kRight and kRightSemi* must be normalized to their left forms +
+  // operand swap by callers.
+  VELOX_ASSERT_THROW(
+      AlgebraicProperties::derive(JoinType::kRight, JoinType::kInner),
+      "callers must normalize");
+  VELOX_ASSERT_THROW(
+      AlgebraicProperties::derive(JoinType::kRightSemiFilter, JoinType::kInner),
+      "callers must normalize");
+  // Counting variants stay opaque leaves and are not reorderable.
+  VELOX_ASSERT_THROW(
+      AlgebraicProperties::derive(JoinType::kCountingAnti, JoinType::kInner),
+      "Algebraic properties not defined for join type");
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_executable(axiom_optimizer_v2_test JoinHypergraphTest.cpp RelationSetTest.cpp)
+add_executable(
+  axiom_optimizer_v2_test
+  AlgebraicPropertiesTest.cpp
+  JoinHypergraphTest.cpp
+  RelationSetTest.cpp
+)
 
 add_test(NAME axiom_optimizer_v2_test COMMAND axiom_optimizer_v2_test)
 

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Meta Platforms, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(axiom_optimizer_v2_test JoinHypergraphTest.cpp RelationSetTest.cpp)
+
+add_test(NAME axiom_optimizer_v2_test COMMAND axiom_optimizer_v2_test)
+
+target_link_libraries(axiom_optimizer_v2_test axiom_optimizer_v2 GTest::gtest GTest::gtest_main)

--- a/axiom/optimizer/v2/tests/JoinHypergraphTest.cpp
+++ b/axiom/optimizer/v2/tests/JoinHypergraphTest.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/JoinHypergraph.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/tests/UnitTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+class JoinHypergraphTest : public UnitTestBase {
+ protected:
+  NodeCP makeLeaf() {
+    optimizer::ColumnVector columns{makeColumn("a", velox::BIGINT())};
+    return builder_->makeEmptyValues(std::move(columns));
+  }
+
+  ExprCP makePredicate() {
+    return builder_->makeBoolean(true);
+  }
+};
+
+// Builds a 3-relation hypergraph and verifies that checkConsistency
+// rejects it until enough edges connect every relation.
+TEST_F(JoinHypergraphTest, connectivity) {
+  JoinHypergraph graph;
+  const int8_t aId = graph.addRelation(makeLeaf(), 100, {});
+  const int8_t bId = graph.addRelation(makeLeaf(), 200, {});
+  const int8_t cId = graph.addRelation(makeLeaf(), 300, {});
+
+  VELOX_ASSERT_THROW(graph.checkConsistency(), "not connected");
+
+  RelationSet aSet;
+  aSet.add(aId);
+  RelationSet bSet;
+  bSet.add(bId);
+  RelationSet abSet{aSet};
+  abSet.unionSet(bSet);
+  graph.addEdge(
+      JoinEdge{
+          aSet,
+          bSet,
+          ExprVector{makePredicate()},
+          ExprVector{makePredicate()},
+          ExprVector{},
+          velox::core::JoinType::kInner,
+          /*nullAware=*/false,
+          /*nullAsValue=*/false},
+      abSet);
+  VELOX_ASSERT_THROW(graph.checkConsistency(), "not connected");
+
+  RelationSet cSet;
+  cSet.add(cId);
+  RelationSet bcSet{bSet};
+  bcSet.unionSet(cSet);
+  graph.addEdge(
+      JoinEdge{
+          bSet,
+          cSet,
+          ExprVector{makePredicate()},
+          ExprVector{makePredicate()},
+          ExprVector{},
+          velox::core::JoinType::kInner,
+          /*nullAware=*/false,
+          /*nullAsValue=*/false},
+      bcSet);
+  ASSERT_NO_THROW(graph.checkConsistency());
+}
+
+// Relation ids are bounded by `RelationSet::kMaxRelations`. The
+// 65th addRelation must fail.
+TEST_F(JoinHypergraphTest, maxRelations) {
+  JoinHypergraph graph;
+  for (int i = 0; i < RelationSet::kMaxRelations; ++i) {
+    graph.addRelation(makeLeaf(), 100, {});
+  }
+  VELOX_ASSERT_THROW(
+      graph.addRelation(makeLeaf(), 100, {}),
+      "exceeds the per-hypergraph relation cap");
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test

--- a/axiom/optimizer/v2/tests/RelationSetTest.cpp
+++ b/axiom/optimizer/v2/tests/RelationSetTest.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/v2/RelationSet.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+TEST(RelationSetTest, emptyAndAdd) {
+  RelationSet set;
+  EXPECT_TRUE(set.empty());
+  EXPECT_EQ(set.size(), 0);
+  EXPECT_FALSE(set.contains(0));
+
+  set.add(0);
+  set.add(63);
+  EXPECT_FALSE(set.empty());
+  EXPECT_EQ(set.size(), 2);
+  EXPECT_TRUE(set.contains(0));
+  EXPECT_TRUE(set.contains(63));
+  EXPECT_FALSE(set.contains(1));
+}
+
+TEST(RelationSetTest, eraseAndClear) {
+  RelationSet set;
+  set.add(5);
+  set.add(10);
+  set.erase(5);
+  EXPECT_FALSE(set.contains(5));
+  EXPECT_TRUE(set.contains(10));
+
+  set.clear();
+  EXPECT_TRUE(set.empty());
+}
+
+TEST(RelationSetTest, setOperations) {
+  RelationSet a;
+  a.add(1);
+  a.add(3);
+  RelationSet b;
+  b.add(3);
+  b.add(5);
+
+  EXPECT_TRUE(a.hasIntersection(b));
+
+  RelationSet u{a};
+  u.unionSet(b);
+  EXPECT_EQ(u.size(), 3);
+  EXPECT_TRUE(u.contains(1));
+  EXPECT_TRUE(u.contains(3));
+  EXPECT_TRUE(u.contains(5));
+
+  RelationSet i{a};
+  i.intersect(b);
+  EXPECT_EQ(i.size(), 1);
+  EXPECT_TRUE(i.contains(3));
+
+  RelationSet d{a};
+  d.except(b);
+  EXPECT_EQ(d.size(), 1);
+  EXPECT_TRUE(d.contains(1));
+}
+
+TEST(RelationSetTest, subset) {
+  RelationSet sub;
+  sub.add(2);
+  RelationSet super;
+  super.add(2);
+  super.add(7);
+
+  EXPECT_TRUE(sub.isSubset(super));
+  EXPECT_FALSE(super.isSubset(sub));
+  EXPECT_TRUE(RelationSet{}.isSubset(super));
+}
+
+TEST(RelationSetTest, forEachAscendingOrder) {
+  RelationSet set;
+  set.add(7);
+  set.add(2);
+  set.add(40);
+
+  std::vector<int32_t> ids;
+  set.forEach([&](int32_t id) { ids.push_back(id); });
+
+  const std::vector<int32_t> expected{2, 7, 40};
+  EXPECT_EQ(ids, expected);
+}
+
+TEST(RelationSetTest, anyOfShortCircuits) {
+  RelationSet set;
+  set.add(0);
+  set.add(1);
+  set.add(2);
+
+  int visited = 0;
+  const bool found = set.anyOf([&](int32_t id) {
+    ++visited;
+    return id == 1;
+  });
+  EXPECT_TRUE(found);
+  EXPECT_EQ(visited, 2);
+}
+
+#ifndef NDEBUG
+TEST(RelationSetTest, outOfRangeId) {
+  RelationSet set;
+  VELOX_ASSERT_THROW(set.add(64), "(64 vs. 64)");
+  VELOX_ASSERT_THROW(set.add(-1), "(-1 vs. 0)");
+}
+#endif
+
+TEST(RelationSetTest, equalityAndHash) {
+  RelationSet a;
+  a.add(1);
+  a.add(5);
+  RelationSet b;
+  b.add(5);
+  b.add(1);
+
+  EXPECT_EQ(a, b);
+  EXPECT_EQ(a.hash(), b.hash());
+  EXPECT_EQ(std::hash<RelationSet>{}(a), a.hash());
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test

--- a/axiom/optimizer/v2/tests/UnitTestBase.h
+++ b/axiom/optimizer/v2/tests/UnitTestBase.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <memory>
+#include <string_view>
+
+#include "axiom/optimizer/PlanObject.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/memory/Memory.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+
+/// Base for unit tests that construct optimizer IR directly via
+/// `make<T>` / `Builder` rather than going through the full
+/// SQL/Logical Plan → translate → emit pipeline. Sets up the per-test
+/// `QueryGraphContext`, arena allocator, and Velox memory pool so
+/// `queryCtx()` is valid for the duration of the test.
+///
+/// Use this for substrate-level tests (RelationSet, Relation,
+/// JoinHypergraph, NodePrinter, etc.). For tests that need a full
+/// pipeline, inherit from `QueryTestBase` instead.
+class UnitTestBase : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    velox::memory::MemoryManager::testingSetInstance({});
+    pool_ = velox::memory::memoryManager()->addLeafPool(
+        ::testing::UnitTest::GetInstance()->current_test_info()->name());
+    allocator_ = std::make_unique<velox::HashStringAllocator>(pool_.get());
+    context_ = std::make_unique<optimizer::QueryGraphContext>(*allocator_);
+    optimizer::queryCtx() = context_.get();
+    builder_ = std::make_unique<Builder>();
+  }
+
+  void TearDown() override {
+    builder_.reset();
+    optimizer::queryCtx() = nullptr;
+    context_.reset();
+    allocator_.reset();
+    pool_.reset();
+  }
+
+  /// Synthesizes a `Column` with a `prefix`-derived unique name and
+  /// the given Velox type. NDV is unknown.
+  optimizer::ColumnCP makeColumn(
+      std::string_view prefix,
+      const velox::TypePtr& type) {
+    return optimizer::Column::create(
+        prefix, optimizer::Value(optimizer::queryCtx()->toType(type)));
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::HashStringAllocator> allocator_;
+  std::unique_ptr<optimizer::QueryGraphContext> context_;
+  std::unique_ptr<Builder> builder_;
+};
+
+} // namespace facebook::axiom::optimizer::v2::test


### PR DESCRIPTION
Summary:

The bucketed-execution and write test suites ran only under the v1 optimizer. Run each under both v1 and v2 so the existing plan-shape and correctness checks guard v2's bucketed planning and table writes.

The harness lives in `QueryTestBase`: a `useV2_` flag selects the optimizer inside `optimize()`, and `AXIOM_INSTANTIATE_V1_V2` instantiates each `TEST_P` suite once per optimizer (`V1/…` and `V2/…`). Each fixture sets `useV2_` from the gtest parameter.

Where v2's bucketed plan differs from v1, the plan-shape assertion is gated to v1 and carries a TODO; v2's result correctness is still checked via `assertSameAsSingleNode`. Several divergences are v1 gaps rather than v2 regressions — cases where v1 leaves bucketed co-location unused, and one where v1 co-buckets a null-aware `NOT IN` build without replication and can drop matches.

Reviewed By: amitkdutta

Differential Revision: D111350605
