### PR TITLE
test(optimizer): Split SQL test into per-file ctest entries (#1565)

### DIFF
--- a/axiom/optimizer/docs/Testing.md
+++ b/axiom/optimizer/docs/Testing.md
@@ -340,6 +340,8 @@ buck test fbcode//axiom/optimizer/tests:sql -- V2/
 buck test fbcode//axiom/optimizer/tests:sql -- basic
 ```
 
+Under CMake (OSS builds / CI), the SQL test is split into one ctest entry per query file per optimizer version, named `axiom_optimizer_sql_test_v{1,2}_<file>` (e.g. `axiom_optimizer_sql_test_v1_join`), so ctest runs the files in parallel. CMake globs `tests/sql/*.sql` and excludes setup fragments by the `*_setup.sql` naming convention — files ending in `_setup.sql` (e.g. `common_setup.sql`) are spliced into queries via `-- setup_file:` and are not query files, so they get no ctest entry. Every other `.sql` file must be registered with a `registerQueryFile` call in `SqlTest.cpp`.
+
 To add a new correctness test, append a query to the appropriate `.sql` file in `axiom/optimizer/tests/sql/`. No C++ changes needed. A few of the files:
 
 - `basic.sql` — scratch file for local development and quick experiments. Not a dumping ground for checked-in tests.

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -206,17 +206,34 @@ target_link_libraries(
 
 add_executable(axiom_optimizer_sql_test SqlTest.cpp)
 
-add_test(
-  NAME axiom_optimizer_sql_test_v1
-  COMMAND axiom_optimizer_sql_test --gtest_filter=V1/*
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+# One ctest entry per (optimizer version, query .sql file) so ctest runs the
+# files in parallel. Each .sql file has its own heavy per-file SetUpTestCase
+# (DuckDB runner + reference tables), so per-file is the right granularity:
+# gtest_discover_tests or gtest sharding would re-run that setup per test/shard.
+# The registerQueryFile<> list in SqlTest.cpp's main() remains the source of
+# truth for which files are registered. Deleting a registered file makes
+# registration throw, but adding a .sql file without a registerQueryFile<> call
+# is NOT caught here: its ctest entry matches no tests and gtest still exits 0.
+# Keep main()'s list in sync when adding query files.
+file(
+  GLOB _sql_files
+  CONFIGURE_DEPENDS
+  RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/sql
+  ${CMAKE_CURRENT_SOURCE_DIR}/sql/*.sql
 )
-
-add_test(
-  NAME axiom_optimizer_sql_test_v2
-  COMMAND axiom_optimizer_sql_test --gtest_filter=V2/*
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-)
+# Setup fragments (e.g. common_setup.sql) are not query files.
+list(FILTER _sql_files EXCLUDE REGEX "_setup\\.sql$")
+foreach(_ver V1 V2)
+  string(TOLOWER ${_ver} _vlower)
+  foreach(_f ${_sql_files})
+    get_filename_component(_name ${_f} NAME_WE)
+    add_test(
+      NAME axiom_optimizer_sql_test_${_vlower}_${_name}
+      COMMAND axiom_optimizer_sql_test --gtest_filter=${_ver}/SqlTest_${_name}.*
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+  endforeach()
+endforeach()
 
 target_link_libraries(
   axiom_optimizer_sql_test


### PR DESCRIPTION
Summary:

The optimizer SQL test ran as two ctest entries, axiom_optimizer_sql_test_v1 and axiom_optimizer_sql_test_v2, each taking ~11-14 minutes. That is too coarse for CI parallelism: ctest can only schedule the two as whole units. Now each query .sql file gets its own ctest entry per optimizer version (axiom_optimizer_sql_test_v{1,2}_<file>), so ctest runs the files in parallel and wall time drops toward the slowest single file.

CMake globs tests/sql/*.sql, excludes setup fragments by the *_setup.sql naming convention (e.g. common_setup.sql), and emits one add_test per (version, file) filtered to that file's gtest suite. Per-file is the right granularity because each .sql file has its own heavy SetUpTestCase (DuckDB runner plus reference tables); gtest_discover_tests or gtest sharding would re-run that setup per test or per shard. The registerQueryFile<> list in SqlTest.cpp's main() stays the source of truth for which files are registered.

Differential Revision: D111436377


