### PR TITLE
fix(optimizer): Avoid cross join in syntactic fallback (#1569)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -896,6 +896,16 @@ std::optional<JoinCandidate> reducingJoins(
   return reducing;
 }
 
+// Returns true if every table referenced by the join's left keys is placed.
+bool leftKeysPlaced(const PlanState& state, JoinEdgeP join) {
+  for (auto key : join->leftKeys()) {
+    if (!key->allTables().isSubset(state.placed())) {
+      return false;
+    }
+  }
+  return true;
+}
+
 // Calls 'func' with join, joined table and fanout for the joinable tables.
 template <typename Func>
 void forJoinedTables(const PlanState& state, Func func) {
@@ -910,15 +920,7 @@ void forJoinedTables(const PlanState& state, Func func) {
         if (!visited.insert(join).second) {
           continue;
         }
-        bool usable = true;
-        for (auto key : join->leftKeys()) {
-          if (!key->allTables().isSubset(state.placed())) {
-            // All items that the left key depends on must be placed.
-            usable = false;
-            break;
-          }
-        }
-        if (usable &&
+        if (leftKeysPlaced(state, join) &&
             (state.mayConsiderNext(join->rightTable()) || join->markColumn() ||
              join->rowNumberColumn())) {
           func(join, join->rightTable(), join->lrFanout());
@@ -955,6 +957,28 @@ void addExtraEdges(PlanState& state, JoinCandidate& candidate) {
     }
   }
 }
+
+// Equi-join candidate connecting 'table' to an already-placed table via a plain
+// inner join, or nullopt if there is none.
+std::optional<JoinCandidate> equiJoinCandidate(
+    const PlanState& state,
+    PlanObjectCP table) {
+  for (auto* join : joinedBy(table)) {
+    if (join->numKeys() == 0 || !state.dt->hasJoin(join)) {
+      continue;
+    }
+    // A directed inner join (CROSS JOIN UNNEST) is not freely reorderable.
+    if (!join->isInner() || join->directed()) {
+      continue;
+    }
+    auto* other = join->otherSide(table);
+    if (other && state.isPlaced(other)) {
+      // 'other' is the placed side, so this is the fan-out into 'table'.
+      return JoinCandidate{join, table, join->otherTable(other).second};
+    }
+  }
+  return std::nullopt;
+}
 } // namespace
 
 std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
@@ -973,6 +997,22 @@ std::vector<JoinCandidate> Optimization::nextJoins(PlanState& state) {
       });
 
   if (candidates.empty()) {
+    // In the internal syntactic pass (only when the user did not pin the
+    // order), place the earliest table in join order that has an equi-join to a
+    // placed table, avoiding a cross join.
+    if (state.syntacticJoinOrder() && !options().syntacticJoinOrder) {
+      for (auto id : state.dt->joinOrder) {
+        auto* object = queryCtx()->objectAt(id);
+        if (state.isPlaced(object)) {
+          continue;
+        }
+        if (auto candidate = equiJoinCandidate(state, object)) {
+          addExtraEdges(state, *candidate);
+          return {std::move(*candidate)};
+        }
+      }
+    }
+
     // There are no join edges. There could still be cross joins.
     state.dt->startTables.forEach([&](PlanObjectCP object) {
       if (!state.isPlaced(object) && state.mayConsiderNext(object)) {

--- a/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
+++ b/axiom/optimizer/tests/UnknownStatsJoinTest.cpp
@@ -30,6 +30,17 @@ class UnknownStatsJoinTest : public test::QueryTestBase {
   velox::core::PlanNodePtr plan(const std::string& sql) {
     return toSingleNodePlan(parseSelect(sql, kTestConnectorId));
   }
+
+  // 't' and 'u' join only through 'v', whose join-key NDV is absent, so the
+  // join cost is unknown.
+  void addSharedJoinTableSchema() {
+    testConnector_->addTable("t", ROW({"a", "k"}, BIGINT()))
+        ->setStats(1'000'000, {{"k", {.numDistinct = 1'000'000}}});
+    testConnector_->addTable("u", ROW({"b", "k"}, BIGINT()))
+        ->setStats(1'000, {{"k", {.numDistinct = 1'000}}});
+    testConnector_->addTable("v", ROW({"x", "y"}, BIGINT()))
+        ->setStats(100'000, {});
+  }
 };
 
 TEST_F(UnknownStatsJoinTest, singleJoin) {
@@ -125,6 +136,98 @@ TEST_F(UnknownStatsJoinTest, joinWithUnknownTableCardinality) {
 
   AXIOM_ASSERT_PLAN(plan(query), matchJoin("u", "t"));
   AXIOM_ASSERT_PLAN(plan(altQuery), matchJoin("t", "u"));
+}
+
+// Two large tables join only through 'v'; the fallback must hash-join through
+// it rather than cross-join the two.
+TEST_F(UnknownStatsJoinTest, sharedTableJoinAvoidsCrossJoin) {
+  addSharedJoinTableSchema();
+
+  const auto query =
+      "SELECT count(*) FROM t, u, v WHERE t.k = v.x AND u.k = v.y";
+
+  // Fallback on: hash-join 't' and 'u' through 'v'.
+  optimizerOptions_.syntacticJoinOrder = false;
+  AXIOM_ASSERT_PLAN(
+      plan(query),
+      matchScan("t")
+          .hashJoinInner(matchScan("v").build())
+          .hashJoinInner(matchScan("u").build())
+          .aggregation()
+          .build());
+
+  // Pinned order disables the fallback: the literal order cross-joins 't', 'u'.
+  optimizerOptions_.syntacticJoinOrder = true;
+  AXIOM_ASSERT_PLAN(
+      plan(query),
+      matchScan("t")
+          .nestedLoopJoin(matchScan("u").build())
+          .hashJoinInner(matchScan("v").build())
+          .aggregation()
+          .build());
+}
+
+// An expression equi-key ('t.k + 0') behaves the same under the flag toggle.
+TEST_F(UnknownStatsJoinTest, sharedTableJoinAvoidsCrossJoinExpressionKey) {
+  addSharedJoinTableSchema();
+
+  const auto query =
+      "SELECT count(*) FROM t, u, v WHERE t.k + 0 = v.x AND u.k = v.y";
+
+  // Fallback on: hash-join through 'v' on the projected key.
+  optimizerOptions_.syntacticJoinOrder = false;
+  AXIOM_ASSERT_PLAN(
+      plan(query),
+      matchScan("t")
+          .project()
+          .hashJoinInner(matchScan("v").build())
+          .hashJoinInner(matchScan("u").build())
+          .aggregation()
+          .build());
+
+  // Pinned order disables the fallback: the literal order cross-joins 't', 'u'.
+  optimizerOptions_.syntacticJoinOrder = true;
+  AXIOM_ASSERT_PLAN(
+      plan(query),
+      matchScan("t")
+          .nestedLoopJoin(matchScan("u").build())
+          .project()
+          .hashJoinInner(matchScan("v").build())
+          .aggregation()
+          .build());
+}
+
+// Guard: 'w' has no equi-join to any table, so it still cross-joins even while
+// 't' and 'u' hash-join through the shared table 'v'.
+TEST_F(UnknownStatsJoinTest, crossJoinWhenNoEquiPartner) {
+  addSharedJoinTableSchema();
+  testConnector_->addTable("w", ROW({"c", "k"}, BIGINT()));
+
+  const auto query =
+      "SELECT count(*) FROM t, u, v, w WHERE t.k = v.x AND u.k = v.y";
+
+  // Fallback on: 't'/'u' hash-join through 'v'; 'w' has no partner, so it
+  // crosses.
+  optimizerOptions_.syntacticJoinOrder = false;
+  AXIOM_ASSERT_PLAN(
+      plan(query),
+      matchScan("t")
+          .hashJoinInner(matchScan("v").build())
+          .hashJoinInner(matchScan("u").build())
+          .nestedLoopJoin(matchScan("w").build())
+          .aggregation()
+          .build());
+
+  // Pinned order: the literal order cross-joins the unkeyed tables.
+  optimizerOptions_.syntacticJoinOrder = true;
+  AXIOM_ASSERT_PLAN(
+      plan(query),
+      matchScan("t")
+          .nestedLoopJoin(matchScan("u").build())
+          .hashJoinInner(matchScan("v").build())
+          .nestedLoopJoin(matchScan("w").build())
+          .aggregation()
+          .build());
 }
 
 // The join sampler must tolerate an unknown build-side cardinality.


### PR DESCRIPTION
Summary:

When a join key's distinct-value count is unknown, every keyed join order has an unknown cost, so cost-based enumeration drops them all and the optimizer falls back to the query's syntactic (as-written) order. Following that order literally, two large tables that share no join key end up connected by a cross join that broadcasts one against the other and can exhaust a worker's memory.

For example:

    SELECT count(*) FROM t, u, v WHERE t.a = v.x AND u.k = v.y

where t and u are large tables joined only through v (join-key NDV missing), so the fallback cross-joins t and u before joining v.

The fallback now prefers an available equi-join to an already-placed table over a cross join, placing the earliest such table in join order so the graph stays fully keyed. It reorders only inner joins; outer joins are left to the normal enumeration path, an explicit `optimizer.syntactic_join_order=true` request is unaffected, and a table with no equi-join to a placed table still gets a cross join.

Reviewed By: mbasmanova

Differential Revision: D110093915


