### PR TITLE
fix: Classify parser and analyzer errors as user errors (#1570)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -536,6 +536,15 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
         .errorSource = e.errorSource()};
     finalize();
     throw;
+  } catch (const presto::PrestoSqlError& e) {
+    const auto classification = presto::classify(e.kind());
+    completionInfo.errorInfo = ErrorInfo{
+        .message = e.what(),
+        .messageTemplate = messageTemplateOf(e),
+        .errorCode = std::string(classification.errorCode),
+        .errorSource = std::string(classification.errorSource)};
+    finalize();
+    throw;
   } catch (const std::exception& e) {
     // Non-Velox exceptions carry no error code or source.
     completionInfo.errorInfo =

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -1265,6 +1265,32 @@ TEST_F(SqlQueryRunnerTest, completionCallbackOnParseFailure) {
   EXPECT_EQ(captured.timing.execute, 0);
 }
 
+TEST_F(SqlQueryRunnerTest, classifiesSyntaxErrorAsUser) {
+  QueryCompletionInfo captured;
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT * FROM",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+  ASSERT_TRUE(captured.errorInfo.has_value());
+  EXPECT_EQ(captured.errorInfo->errorSource, error_source::kErrorSourceUser);
+  EXPECT_EQ(captured.errorInfo->errorCode, "SYNTAX_ERROR");
+}
+
+TEST_F(SqlQueryRunnerTest, classifiesSemanticErrorAsUser) {
+  QueryCompletionInfo captured;
+  EXPECT_THROW(
+      runner_->run(
+          "SELECT * FROM nonexistent_table",
+          {.onComplete =
+               [&](const QueryCompletionInfo& info) { captured = info; }}),
+      std::exception);
+  ASSERT_TRUE(captured.errorInfo.has_value());
+  EXPECT_EQ(captured.errorInfo->errorSource, error_source::kErrorSourceUser);
+  EXPECT_EQ(captured.errorInfo->errorCode, "GENERIC_USER_ERROR");
+}
+
 TEST_F(SqlQueryRunnerTest, completionCallbackOnPermissionCheckFailure) {
   QueryCompletionInfo captured;
 

--- a/axiom/sql/presto/PrestoSqlError.cpp
+++ b/axiom/sql/presto/PrestoSqlError.cpp
@@ -16,6 +16,8 @@
 
 #include "axiom/sql/presto/PrestoSqlError.h"
 
+#include "velox/common/base/VeloxException.h"
+
 namespace axiom::sql::presto {
 
 namespace {
@@ -57,6 +59,17 @@ AXIOM_DEFINE_ENUM_NAME(PrestoSqlErrorKind, prestoSqlErrorKindNames);
         message);
   }
   return fmt::format("{} at {}:{}: {}", prefix, line, column, message);
+}
+
+PrestoErrorClassification classify(PrestoSqlErrorKind kind) {
+  const std::string_view user = facebook::velox::error_source::kErrorSourceUser;
+  switch (kind) {
+    case PrestoSqlErrorKind::kSyntax:
+      return {user, "SYNTAX_ERROR"};
+    case PrestoSqlErrorKind::kSemantic:
+      return {user, "GENERIC_USER_ERROR"};
+  }
+  VELOX_UNREACHABLE();
 }
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/PrestoSqlError.h
+++ b/axiom/sql/presto/PrestoSqlError.h
@@ -121,6 +121,19 @@ class PrestoSqlError : public std::exception {
   PrestoSqlErrorKind kind_;
 };
 
+/// Error source and Presto error code that a PrestoSqlError should surface
+/// with, so every conversion boundary classifies parser and analyzer failures
+/// identically.
+struct PrestoErrorClassification {
+  /// Velox error source; always the user source for parser/analyzer errors.
+  std::string_view errorSource;
+  /// Presto error code name, e.g. SYNTAX_ERROR.
+  std::string_view errorCode;
+};
+
+/// Returns the user-error classification for an error kind.
+PrestoErrorClassification classify(PrestoSqlErrorKind kind);
+
 /// Throws PrestoSqlError with kSyntax kind if `condition` is false.
 /// @param condition  Boolean expression to check.
 /// @param location   A raw NodeLocation whose `line` is 1-based (as stored


### PR DESCRIPTION
Summary:

Parser and analyzer errors were not classified consistently. The CLI runner logged them with an empty error source and code, so a syntax error like

    SELECT * FROM

was recorded as an unclassified failure instead of a user error, mis-bucketing failure metrics.

Add a shared `classify()` helper next to `PrestoSqlError` that maps the error kind to a user-error code — syntax to `SYNTAX_ERROR`, analysis to `GENERIC_USER_ERROR`. The CLI runner now catches `PrestoSqlError` explicitly and sets the source and code from `classify(kind())`. The helper is the one place these errors are classified, so every consumer stays in sync.

Reviewed By: HeidiHan0000

Differential Revision: D111750304


