### PR TITLE
fix(parser): Support the TABLE query shorthand

### DIFF
--- a/axiom/graphviz/LogicalPlanDotPrinter.cpp
+++ b/axiom/graphviz/LogicalPlanDotPrinter.cpp
@@ -265,6 +265,37 @@ class DotPrinterVisitor : public PlanNodeVisitor {
     visitInputs(node, ctx);
   }
 
+  void visit(const LateralJoinNode& node, PlanNodeVisitorContext& ctx)
+      const override {
+    auto& context = static_cast<Context&>(ctx);
+    printNodeStart(
+        context.out,
+        node,
+        fmt::format("Lateral Join {}", JoinTypeName::toName(node.joinType())),
+        kPalette.header);
+
+    if (node.condition() != nullptr) {
+      printHighlightedRow(
+          context.out,
+          fmt::format(
+              "ON: {}",
+              escapeHtml(truncate(ExprPrinter::toText(*node.condition())))));
+    }
+
+    printNodeEnd(context.out);
+
+    // Collect and render subqueries from the condition.
+    if (node.condition() != nullptr) {
+      auto subqueries = collectSubqueries(*node.condition());
+      for (const auto* subquery : subqueries) {
+        renderSubqueryInCluster(context, node, *subquery->subquery());
+      }
+    }
+
+    printEdgeToInputs(context.out, node);
+    visitInputs(node, ctx);
+  }
+
   void visit(const SortNode& node, PlanNodeVisitorContext& ctx) const override {
     auto& context = static_cast<Context&>(ctx);
     printNodeStart(context.out, node, "Sort", kPalette.header);

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -38,6 +38,7 @@ const auto& nodeKindNames() {
       {NodeKind::kOutput, "OUTPUT"},
       {NodeKind::kFixedPoint, "FIXED_POINT"},
       {NodeKind::kRecursiveReference, "RECURSIVE_REFERENCE"},
+      {NodeKind::kLateralJoin, "LATERAL_JOIN"},
   };
   return kNames;
 }
@@ -172,6 +173,7 @@ void LogicalPlanNode::registerSerDe() {
   registry.Register("ProjectNode", ProjectNode::create);
   registry.Register("AggregateNode", AggregateNode::create);
   registry.Register("JoinNode", JoinNode::create);
+  registry.Register("LateralJoinNode", LateralJoinNode::create);
   registry.Register("SortNode", SortNode::create);
   registry.Register("LimitNode", LimitNode::create);
   registry.Register("SetNode", SetNode::create);
@@ -857,6 +859,56 @@ void JoinNode::accept(
 
 bool JoinNode::equalTo(const LogicalPlanNode& other) const {
   const auto* rhs = other.as<JoinNode>();
+  return joinType_ == rhs->joinType_ &&
+      Expr::equalNullableExprs(condition_, rhs->condition_);
+}
+
+folly::dynamic LateralJoinNode::serialize() const {
+  auto obj = serializeBase("LateralJoinNode");
+  obj["joinType"] = JoinTypeName::toName(joinType_);
+  if (condition_) {
+    obj["condition"] = condition_->serialize();
+  }
+  return obj;
+}
+
+// static
+LogicalPlanNodePtr LateralJoinNode::create(
+    const folly::dynamic& obj,
+    void* context) {
+  auto inputs = deserializeNodeInputs(obj, context);
+  VELOX_CHECK_EQ(inputs.size(), 2);
+  ExprPtr condition = nullptr;
+  if (obj.count("condition")) {
+    condition = deserializeExpr(obj["condition"], context);
+  }
+  return std::make_shared<LateralJoinNode>(
+      obj["id"].asString(),
+      inputs[0],
+      inputs[1],
+      JoinTypeName::toJoinType(obj["joinType"].asString()),
+      std::move(condition));
+}
+
+// static
+velox::RowTypePtr LateralJoinNode::makeOutputType(
+    const LogicalPlanNodePtr& left,
+    const LogicalPlanNodePtr& right) {
+  auto type = left->outputType()->unionWith(right->outputType());
+
+  UniqueNameChecker::check(type->names());
+
+  return type;
+}
+
+void LateralJoinNode::accept(
+    const PlanNodeVisitor& visitor,
+    PlanNodeVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
+bool LateralJoinNode::equalTo(const LogicalPlanNode& other) const {
+  const auto* rhs = other.as<LateralJoinNode>();
   return joinType_ == rhs->joinType_ &&
       Expr::equalNullableExprs(condition_, rhs->condition_);
 }

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -40,6 +40,7 @@ enum class NodeKind {
   kOutput = 12,
   kFixedPoint = 13,
   kRecursiveReference = 14,
+  kLateralJoin = 15,
 };
 
 AXIOM_DECLARE_ENUM_NAME(NodeKind)
@@ -527,6 +528,73 @@ class JoinNode : public LogicalPlanNode {
 };
 
 using JoinNodePtr = std::shared_ptr<const JoinNode>;
+
+/// A lateral (dependent) join: for each row of the left input, the right input
+/// is evaluated with that left row's columns in scope, and the results are
+/// joined. Unlike JoinNode, whose two inputs are independent, the RIGHT input
+/// of a lateral join may reference the left input's columns (the correlation);
+/// the left input may not reference the right. The output schema is all left
+/// columns followed by all right columns.
+///
+/// Only kInner and kLeft are allowed. kRight and kFull would require the right
+/// side to be evaluable independently of the left to preserve unmatched right
+/// rows, which contradicts the right side depending on the left.
+class LateralJoinNode : public LogicalPlanNode {
+ public:
+  /// @param condition Optional ON predicate, which may reference either side.
+  /// If nullptr, the output is the per-left-row cross product with the right.
+  LateralJoinNode(
+      std::string id,
+      const LogicalPlanNodePtr& left,
+      const LogicalPlanNodePtr& right,
+      JoinType joinType,
+      ExprPtr condition)
+      : LogicalPlanNode{NodeKind::kLateralJoin, std::move(id), {left, right}, makeOutputType(left, right)},
+        joinType_{joinType},
+        condition_{std::move(condition)} {
+    VELOX_USER_CHECK(
+        joinType_ == JoinType::kInner || joinType_ == JoinType::kLeft,
+        "LATERAL join supports only INNER and LEFT join types");
+    if (condition_ != nullptr) {
+      VELOX_USER_CHECK_EQ(condition_->typeKind(), velox::TypeKind::BOOLEAN);
+    }
+  }
+
+  const LogicalPlanNodePtr& left() const {
+    return inputAt(0);
+  }
+
+  const LogicalPlanNodePtr& right() const {
+    return inputAt(1);
+  }
+
+  JoinType joinType() const {
+    return joinType_;
+  }
+
+  const ExprPtr& condition() const {
+    return condition_;
+  }
+
+  void accept(const PlanNodeVisitor& visitor, PlanNodeVisitorContext& context)
+      const override;
+
+  folly::dynamic serialize() const override;
+
+  static LogicalPlanNodePtr create(const folly::dynamic& obj, void* context);
+
+ private:
+  bool equalTo(const LogicalPlanNode& other) const override;
+
+  static velox::RowTypePtr makeOutputType(
+      const LogicalPlanNodePtr& left,
+      const LogicalPlanNodePtr& right);
+
+  const JoinType joinType_;
+  const ExprPtr condition_;
+};
+
+using LateralJoinNodePtr = std::shared_ptr<const LateralJoinNode>;
 
 /// Sort rows based on one or more sort fields. The output schema for this node
 /// matches the input. This node doesn't change the cardinality of the dataset.

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1237,6 +1237,44 @@ PlanBuilder& PlanBuilder::join(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::lateralJoin(
+    const PlanBuilder& right,
+    const std::string& condition,
+    JoinType joinType) {
+  std::optional<ExprApi> conditionExpr;
+  if (!condition.empty()) {
+    conditionExpr = sqlParser_->parseExpr(condition);
+  }
+
+  return lateralJoin(right, conditionExpr, joinType);
+}
+
+PlanBuilder& PlanBuilder::lateralJoin(
+    const PlanBuilder& right,
+    const std::optional<ExprApi>& condition,
+    JoinType joinType) {
+  VELOX_USER_CHECK_NOT_NULL(node_, "Lateral join node cannot be a leaf node");
+  VELOX_USER_CHECK_NOT_NULL(right.node_);
+
+  outputMapping_->merge(*right.outputMapping_);
+
+  auto inputRowType = node_->outputType()->unionWith(right.node_->outputType());
+
+  ExprPtr expr;
+  if (condition.has_value()) {
+    expr = resolver_.resolveScalarTypes(
+        condition->expr(), [&](const auto& alias, const auto& name) {
+          return resolveJoinInputName(
+              alias, name, *outputMapping_, inputRowType, outerScope_);
+        });
+  }
+
+  node_ = std::make_shared<LateralJoinNode>(
+      nextId(), std::move(node_), right.node_, joinType, std::move(expr));
+
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::joinUsing(
     const PlanBuilder& right,
     const std::vector<std::string>& columns,

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -498,6 +498,21 @@ class PlanBuilder {
       const std::optional<ExprApi>& condition,
       JoinType joinType);
 
+  /// Lateral (dependent) join: the 'right' plan may reference the left's
+  /// columns. Build 'right' with this builder's scope as its outer scope (see
+  /// the 'outerScope' constructor argument). Only kInner and kLeft are allowed.
+  PlanBuilder& lateralJoin(
+      const PlanBuilder& right,
+      const std::string& condition,
+      JoinType joinType);
+
+  /// @overload Takes an optional ExprApi condition. Pass std::nullopt for
+  /// CROSS JOIN LATERAL.
+  PlanBuilder& lateralJoin(
+      const PlanBuilder& right,
+      const std::optional<ExprApi>& condition,
+      JoinType joinType);
+
   /// Joins using named columns (SQL JOIN USING semantics). Produces a single
   /// copy of each USING column in the output followed by non-USING columns from
   /// both sides in their original order. For FULL OUTER joins, USING columns

--- a/axiom/logical_plan/PlanNodeVisitor.h
+++ b/axiom/logical_plan/PlanNodeVisitor.h
@@ -47,6 +47,10 @@ class PlanNodeVisitor {
   virtual void visit(const JoinNode& node, PlanNodeVisitorContext& context)
       const = 0;
 
+  virtual void visit(
+      const LateralJoinNode& node,
+      PlanNodeVisitorContext& context) const = 0;
+
   virtual void visit(const SortNode& node, PlanNodeVisitorContext& context)
       const = 0;
 

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -137,6 +137,16 @@ class ToTextVisitor : public PlanNodeVisitor {
         context);
   }
 
+  void visit(const LateralJoinNode& node, PlanNodeVisitorContext& context)
+      const override {
+    appendNode(
+        fmt::format("LateralJoin {}", JoinTypeName::toName(node.joinType())),
+        node,
+        node.condition() != nullptr ? ExprPrinter::toText(*node.condition())
+                                    : "",
+        context);
+  }
+
   void visit(const SortNode& node, PlanNodeVisitorContext& context)
       const override {
     auto& myContext = static_cast<Context&>(context);
@@ -403,6 +413,15 @@ class CollectExprStatsPlanNodeVisitor : public PlanNodeVisitor {
   }
 
   void visit(const JoinNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& stats = static_cast<Context&>(context).stats;
+    if (node.condition() != nullptr) {
+      collectExprStats(*node.condition(), stats);
+    }
+    visitInputs(node, context);
+  }
+
+  void visit(const LateralJoinNode& node, PlanNodeVisitorContext& context)
       const override {
     auto& stats = static_cast<Context&>(context).stats;
     if (node.condition() != nullptr) {
@@ -690,6 +709,29 @@ class SummarizeToTextVisitor : public PlanNodeVisitor {
   }
 
   void visit(const JoinNode& node, PlanNodeVisitorContext& context)
+      const override {
+    auto& myContext = static_cast<Context&>(context);
+    appendHeader(
+        fmt::format(
+            "{} {}",
+            NodeKindName::toName(node.kind()),
+            JoinTypeName::toName(node.joinType())),
+        node,
+        myContext);
+
+    if (!myContext.skeletonOnly) {
+      const auto indent = makeIndent(myContext.indent + 3);
+      if (node.condition() != nullptr) {
+        myContext.out << indent << "condition: ";
+        myContext.appendExpression(*node.condition());
+        myContext.out << std::endl;
+      }
+    }
+
+    appendInputs(node, myContext);
+  }
+
+  void visit(const LateralJoinNode& node, PlanNodeVisitorContext& context)
       const override {
     auto& myContext = static_cast<Context&>(context);
     appendHeader(

--- a/axiom/logical_plan/tests/LogicalPlanNodeEqualityTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeEqualityTest.cpp
@@ -237,6 +237,56 @@ TEST_F(LogicalPlanNodeEqualityTest, joinNodeEquality) {
   EXPECT_EQ(*makeCrossJoin(), *makeCrossJoin());
 }
 
+TEST_F(LogicalPlanNodeEqualityTest, lateralJoinNodeEquality) {
+  std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
+  std::vector<std::vector<std::string>> rightRows = {{"1", "2"}};
+
+  auto makeLateral = [&rows, &rightRows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .lateralJoin(
+            PlanBuilder().values({"a", "b"}, rightRows),
+            "x = a",
+            JoinType::kInner)
+        .planNode();
+  };
+
+  EXPECT_EQ(*makeLateral(), *makeLateral());
+
+  // Different join type.
+  auto lateralLeft = PlanBuilder()
+                         .values({"x", "y"}, rows)
+                         .lateralJoin(
+                             PlanBuilder().values({"a", "b"}, rightRows),
+                             "x = a",
+                             JoinType::kLeft)
+                         .planNode();
+  EXPECT_NE(*makeLateral(), *lateralLeft);
+
+  // No condition (cross) vs with condition.
+  auto makeCross = [&rows, &rightRows] {
+    return PlanBuilder()
+        .values({"x", "y"}, rows)
+        .lateralJoin(
+            PlanBuilder().values({"a", "b"}, rightRows),
+            std::nullopt,
+            JoinType::kInner)
+        .planNode();
+  };
+  EXPECT_NE(*makeLateral(), *makeCross());
+  EXPECT_EQ(*makeCross(), *makeCross());
+
+  // A lateral join differs from a regular join of the same shape.
+  auto regularJoin = PlanBuilder()
+                         .values({"x", "y"}, rows)
+                         .join(
+                             PlanBuilder().values({"a", "b"}, rightRows),
+                             "x = a",
+                             JoinType::kInner)
+                         .planNode();
+  EXPECT_NE(*makeLateral(), *regularJoin);
+}
+
 TEST_F(LogicalPlanNodeEqualityTest, sortNodeEquality) {
   std::vector<std::vector<std::string>> rows = {{"1", "10"}, {"2", "20"}};
   auto makeNode = [&rows] {

--- a/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
+++ b/axiom/logical_plan/tests/LogicalPlanNodeSerdeTest.cpp
@@ -209,6 +209,32 @@ TEST_F(LogicalPlanNodeSerdeTest, joinNodeCrossJoin) {
   testRoundTrip(plan);
 }
 
+TEST_F(LogicalPlanNodeSerdeTest, lateralJoinNode) {
+  auto right = PlanBuilder().values(
+      ROW({"b"}, {BIGINT()}), std::vector<Variant>{Variant::row({1LL})});
+
+  auto plan =
+      PlanBuilder()
+          .values(
+              ROW({"a"}, {BIGINT()}), std::vector<Variant>{Variant::row({1LL})})
+          .lateralJoin(right, "a = b", JoinType::kLeft)
+          .build();
+  testRoundTrip(plan);
+}
+
+TEST_F(LogicalPlanNodeSerdeTest, lateralJoinNodeCross) {
+  auto right = PlanBuilder().values(
+      ROW({"b"}, {BIGINT()}), std::vector<Variant>{Variant::row({1LL})});
+
+  auto plan =
+      PlanBuilder()
+          .values(
+              ROW({"a"}, {BIGINT()}), std::vector<Variant>{Variant::row({1LL})})
+          .lateralJoin(right, std::nullopt, JoinType::kInner)
+          .build();
+  testRoundTrip(plan);
+}
+
 TEST_F(LogicalPlanNodeSerdeTest, sortNode) {
   auto plan = PlanBuilder()
                   .values(

--- a/axiom/optimizer/SubfieldTracker.cpp
+++ b/axiom/optimizer/SubfieldTracker.cpp
@@ -584,6 +584,13 @@ void SubfieldTracker::markControl(
     const lp::LogicalPlanNode& node,
     const MarkFieldsAccessedContext& context) {
   const auto kind = node.kind();
+
+  // Reject before the recursion below descends into the correlated body,
+  // where the outer reference cannot resolve against the body's own scope.
+  if (kind == lp::NodeKind::kLateralJoin) {
+    VELOX_NYI("Unsupported PlanNode {}", lp::NodeKindName::toName(kind));
+  }
+
   if (kind == lp::NodeKind::kJoin) {
     const auto* join = node.as<lp::JoinNode>();
     if (const auto& condition = join->condition()) {

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -904,3 +904,73 @@ SELECT t.a IN (
 -- error_v1: 0 vs. 1
 -- error_v2: Scalar sub-query has returned multiple rows
 SELECT (SELECT max(u.a) FROM u WHERE u.a > t.a GROUP BY u.a % 2) FROM t
+----
+-- LATERAL join tests.
+--
+-- CROSS JOIN LATERAL whose no-FROM body projects an outer column.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+WITH t(x) AS (VALUES (1), (2), (3))
+SELECT t.x, g.y
+FROM t
+CROSS JOIN LATERAL (SELECT t.x + 1 AS y) g
+----
+-- CROSS JOIN LATERAL with a correlated WHERE; INNER drops outer rows whose
+-- body is empty.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+WITH t(x) AS (VALUES (1), (2), (9)),
+     u(a) AS (VALUES (1), (2))
+SELECT t.x, g.m
+FROM t
+CROSS JOIN LATERAL (SELECT u.a AS m FROM u WHERE u.a = t.x) g
+----
+-- CROSS JOIN LATERAL whose body returns several rows per outer row.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+WITH t(x) AS (VALUES (2), (4)),
+     u(a) AS (VALUES (1), (2), (3))
+SELECT t.x, g.m
+FROM t
+CROSS JOIN LATERAL (SELECT u.a AS m FROM u WHERE u.a < t.x) g
+----
+-- CROSS JOIN LATERAL whose body produces multiple columns: a body column and
+-- an expression combining the body with an outer column.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+WITH t(x) AS (VALUES (2), (4)),
+     u(a) AS (VALUES (1), (2), (3))
+SELECT t.x, g.a, g.b
+FROM t
+CROSS JOIN LATERAL (SELECT u.a AS a, u.a + t.x AS b FROM u WHERE u.a < t.x) g
+----
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+-- error_v2: INNER LATERAL over an Aggregate body is not yet supported
+WITH t(x) AS (VALUES (1), (2)),
+     u(a) AS (VALUES (1), (2), (3))
+SELECT t.x, g.c
+FROM t
+CROSS JOIN LATERAL (SELECT count(*) AS c FROM u WHERE u.a = t.x) g
+----
+-- LEFT JOIN LATERAL: a matched outer fans out to several rows; an outer whose
+-- body rows are all rejected by the ON survives NULL-padded.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+WITH t(x) AS (VALUES (1), (4)),
+     u(a) AS (VALUES (1), (2), (3), (4))
+SELECT t.x, g.m
+FROM t
+LEFT JOIN LATERAL (SELECT u.a AS m FROM u WHERE u.a <= t.x) g ON g.m < t.x
+----
+-- INNER JOIN LATERAL with an ON condition combining outer and lateral
+-- columns.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+WITH t(x) AS (VALUES (1), (2), (3)),
+     u(a) AS (VALUES (1), (2), (3), (4))
+SELECT t.x, g.m
+FROM t
+INNER JOIN LATERAL (SELECT u.a AS m FROM u) g ON g.m = t.x + 1
+----
+-- A subquery inside a LATERAL ON condition is not supported.
+-- error_v1: Unsupported PlanNode LATERAL_JOIN
+-- error_v2: Subquery in a LATERAL join ON condition is not supported
+WITH t(x) AS (VALUES (1), (2)),
+     u(a) AS (VALUES (1), (2), (3))
+SELECT t.x, g.m
+FROM t
+INNER JOIN LATERAL (SELECT u.a AS m FROM u) g ON g.m IN (SELECT t.x)

--- a/axiom/optimizer/v2/DecorrelatePass.cpp
+++ b/axiom/optimizer/v2/DecorrelatePass.cpp
@@ -175,7 +175,7 @@ class Decorrelator : public NodeRewriter<> {
         if (node->isLeftSemiProject()) {
           return projectPeelSemi(node, input, body, accumulatedFilter);
         }
-        return projectPeelLeft(node, input, body, accumulatedFilter);
+        return projectPeelNonSemi(node, input, body, accumulatedFilter);
       }
 
       if (body->is(NodeType::kAggregate)) {
@@ -202,19 +202,22 @@ class Decorrelator : public NodeRewriter<> {
   }
 
  private:
-  // Project peel (Rule A): Project lifts above Apply. Apply's body
-  // becomes Project's child; the lifted Project above the decorrelated
-  // inner Apply reproduces the original output schema using Project's
-  // original exprs (which may reference L cols, now visible above the
-  // inner Apply per the relaxed contract).
+  // Project peel (Rule A) for non-semi kinds (kLeft, kInner): Project
+  // lifts above Apply. Apply's body becomes Project's child; the lifted
+  // Project above the decorrelated inner Apply reproduces the original
+  // output schema using Project's original exprs (which may reference L
+  // cols, now visible above the inner Apply per the relaxed contract).
+  //
+  // kLeft carries pad rows and the includeMarker; kInner has neither.
   //
   // Recurses on the inner Apply so the driver continues peeling whatever
   // remains in body (more Filters / Projects below, or terminus).
-  NodeCP projectPeelLeft(
+  NodeCP projectPeelNonSemi(
       ApplyCP node,
       NodeCP input,
       NodeCP body,
       ExprVector accumulatedFilter) {
+    const bool hasMarker = node->isLeft();
     const Project* projectBody = body->as<Project>();
     NodeCP newBody = projectBody->input();
 
@@ -237,7 +240,9 @@ class Decorrelator : public NodeRewriter<> {
         input->outputColumns().size() + newBody->outputColumns().size() + 1);
     appendAll(innerOutputColumns, input->outputColumns());
     appendUnique(innerOutputColumns, newBody->outputColumns());
-    innerOutputColumns.push_back(node->includeMarker());
+    if (hasMarker) {
+      innerOutputColumns.push_back(node->includeMarker());
+    }
 
     // Recompute correlations for the inner body. Project peel may have
     // lifted outer-column refs out of body (into the lifted Project
@@ -262,21 +267,16 @@ class Decorrelator : public NodeRewriter<> {
     // Recurse: continue peeling whatever's in newBody, or hit terminus.
     NodeCP decorrelatedInner = rewrite(innerApply);
 
-    // Build lifted Project. Its exprs reproduce the original Apply's
-    // output schema:
-    //   input.cols → pass-through.
-    //   Project's original output cols → IF(_include, expr, NULL) so
-    //     non-default-null exprs evaluate to NULL on pad rows post-Join.
-    //     Skip cols that already appear in input — they collapse to the
-    //     same slot.
-    //   includeMarker → pass-through.
+    // Build lifted Project reproducing the original Apply output schema:
+    // input cols pass through; each Project output col is recomputed from its
+    // original expr (per-kind handling below); cols already present in input
+    // collapse to the same slot.
     ExprVector liftedExprs;
     liftedExprs.reserve(
         input->outputColumns().size() + projectBody->exprs().size() + 1);
     appendAll(liftedExprs, input->outputColumns());
     PlanObjectSet liftedSeen =
         PlanObjectSet::fromObjects(input->outputColumns());
-    ColumnCP includeMarker = node->includeMarker();
     const auto& projectOutputs = projectBody->outputColumns();
     for (size_t i = 0; i < projectBody->exprs().size(); ++i) {
       ColumnCP outputColumn = projectOutputs[i];
@@ -285,11 +285,19 @@ class Decorrelator : public NodeRewriter<> {
       }
       liftedSeen.add(outputColumn);
       ExprCP expr = projectBody->exprs()[i];
-      const Literal* nullLiteral = builder().makeNull(expr->value().type);
-      liftedExprs.push_back(
-          exprFactory_.makeIf(includeMarker, expr, nullLiteral));
+      if (hasMarker) {
+        // kLeft: NULL out non-default-null exprs on pad rows.
+        const Literal* nullLiteral = builder().makeNull(expr->value().type);
+        liftedExprs.push_back(
+            exprFactory_.makeIf(node->includeMarker(), expr, nullLiteral));
+      } else {
+        // kInner: no pad rows, expr passes through unchanged.
+        liftedExprs.push_back(expr);
+      }
     }
-    liftedExprs.push_back(includeMarker);
+    if (hasMarker) {
+      liftedExprs.push_back(node->includeMarker());
+    }
 
     return builder().make<Project>(Project::Key{
         decorrelatedInner,
@@ -379,6 +387,10 @@ class Decorrelator : public NodeRewriter<> {
       VELOX_NYI(
           "Decorrelate: kLeftSemiProject IN over Limit with count >= 1 "
           "not yet implemented (LIMIT must precede the IN equi check)");
+    }
+    if (node->isInner()) {
+      VELOX_NYI(
+          "Decorrelate: INNER LATERAL over a Limit body is not yet supported");
     }
     VELOX_USER_CHECK(
         node->isLeft(),
@@ -595,6 +607,11 @@ class Decorrelator : public NodeRewriter<> {
           joinBody,
           std::move(joinPredicate),
           std::move(accumulatedFilter));
+    }
+
+    if (node->isInner()) {
+      VELOX_NYI(
+          "Decorrelate: INNER LATERAL over a Join body is not yet supported");
     }
 
     VELOX_FAIL(
@@ -1022,6 +1039,11 @@ class Decorrelator : public NodeRewriter<> {
       NodeCP input,
       NodeCP body,
       ExprVector accumulatedFilter) {
+    if (node->isInner()) {
+      VELOX_NYI(
+          "Decorrelate: INNER LATERAL over an AssignUniqueId body is not "
+          "yet supported");
+    }
     AssignUniqueIdCP assignUniqueIdBody = body->as<AssignUniqueId>();
     NodeCP newBody = assignUniqueIdBody->input();
     ColumnCP idColumn = assignUniqueIdBody->idColumn();
@@ -1118,6 +1140,11 @@ class Decorrelator : public NodeRewriter<> {
 
     if (node->isLeftSemiProject()) {
       return aggregatePeelSemi(node, input, body, accumulatedFilter);
+    }
+    if (node->isInner()) {
+      VELOX_NYI(
+          "Decorrelate: INNER LATERAL over an Aggregate body is not yet "
+          "supported");
     }
     if (!node->isLeft()) {
       VELOX_NYI(
@@ -1660,6 +1687,8 @@ class Decorrelator : public NodeRewriter<> {
   // Builds the terminus shape from a fully-peeled Apply.
   NodeCP terminus(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
     switch (apply->kind()) {
+      case velox::core::JoinType::kInner:
+        return terminusInner(apply, input, body, filter);
       case velox::core::JoinType::kLeft:
         return terminusLeft(apply, input, body, filter);
       case velox::core::JoinType::kLeftSemiProject:
@@ -1768,6 +1797,28 @@ class Decorrelator : public NodeRewriter<> {
     return builder().make<Project>(Project::Key{
         enforced,
         std::move(finalExprs),
+        apply->outputColumns(),
+    });
+  }
+
+  NodeCP
+  terminusInner(ApplyCP apply, NodeCP input, NodeCP body, ExprVector filter) {
+    // Plain INNER JOIN: no cardinality assertion, no include marker. Body and
+    // input columns are disjoint (correlation columns live on the Apply, not
+    // in body output), so the output is input ++ body with no collision.
+    JoinCondition::Split split = JoinCondition::splitEquiKeys(
+        filter,
+        PlanObjectSet::fromObjects(input->outputColumns()),
+        PlanObjectSet::fromObjects(body->outputColumns()));
+    return builder().make<Join>(Join::Key{
+        input,
+        body,
+        velox::core::JoinType::kInner,
+        std::move(split.leftKeys),
+        std::move(split.rightKeys),
+        std::move(split.residual),
+        /*nullAware=*/false,
+        /*nullAsValue=*/false,
         apply->outputColumns(),
     });
   }

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1562,30 +1562,42 @@ Apply::Apply(Key key)
   VELOX_CHECK_NOT_NULL(inputs_[0]);
   VELOX_CHECK_NOT_NULL(inputs_[1]);
 
-  // Allowed kinds at Apply: correlated scalar (kLeft) and EXISTS/IN
-  // (kLeftSemiProject). Uncorrelated scalars are lowered directly to
-  // cross-join + EnforceSingleRow at translate time — no Apply. kAnti
-  // / kLeftSemiFilter emerge from the post-decorrelate peephole, never
-  // at Apply.
+  // Allowed kinds at Apply: correlated scalar / LEFT lateral (kLeft),
+  // CROSS/INNER lateral (kInner), and EXISTS/IN (kLeftSemiProject).
+  // Uncorrelated scalars are lowered directly to cross-join +
+  // EnforceSingleRow at translate time — no Apply. kAnti / kLeftSemiFilter
+  // emerge from the post-decorrelate peephole, never at Apply.
   const bool isLeft = kind_ == velox::core::JoinType::kLeft;
+  const bool isInner = kind_ == velox::core::JoinType::kInner;
   VELOX_CHECK(
-      isLeft || kind_ == velox::core::JoinType::kLeftSemiProject,
-      "Apply.kind must be kLeft / kLeftSemiProject; got: {}",
+      isLeft || isInner || kind_ == velox::core::JoinType::kLeftSemiProject,
+      "Apply.kind must be kInner / kLeft / kLeftSemiProject; got: {}",
       kind_);
 
-  if (isLeft) {
-    VELOX_CHECK_NOT_NULL(
-        includeMarker_, "kLeft Apply requires an includeMarker");
-    VELOX_CHECK_EQ(
-        includeMarker_->value().type->kind(),
-        velox::TypeKind::BOOLEAN,
-        "Apply.includeMarker must be BOOLEAN");
+  if (isLeft || isInner) {
+    // Scalar / lateral: markColumn and the IN pair are semi/IN-only.
     VELOX_CHECK_NULL(
         markColumn_,
-        "markColumn is kLeftSemiProject-only; kLeft leaves it null");
+        "markColumn is kLeftSemiProject-only; kLeft/kInner leave it null");
     VELOX_CHECK_NULL(inLhs_, "inLhs is IN-only; non-semi Apply leaves it null");
     VELOX_CHECK_NULL(
         inBodyKey_, "inBodyKey is IN-only; non-semi Apply leaves it null");
+    if (isLeft) {
+      VELOX_CHECK_NOT_NULL(
+          includeMarker_, "kLeft Apply requires an includeMarker");
+      VELOX_CHECK_EQ(
+          includeMarker_->value().type->kind(),
+          velox::TypeKind::BOOLEAN,
+          "Apply.includeMarker must be BOOLEAN");
+    } else {
+      // kInner has no NULL-pad rows, so no includeMarker, and (as a
+      // table-valued lateral) no cardinality assertion.
+      VELOX_CHECK_NULL(
+          includeMarker_, "kInner Apply must not have an includeMarker");
+      VELOX_CHECK(
+          !enforceSingleRow_,
+          "kInner Apply must have enforceSingleRow == false");
+    }
   } else {
     VELOX_CHECK_NULL(
         includeMarker_, "includeMarker is kLeft-only; kSemi leaves it null");
@@ -1621,12 +1633,15 @@ Apply::Apply(Key key)
         outputColumns()[i] == inputCols[i],
         "Apply.outputColumns prefix must match input.outputColumns");
   }
-  if (isLeft) {
+  if (isLeft || isInner) {
+    // kLeft ends with the includeMarker slot; kInner has no marker.
+    const size_t markerSlots = isLeft ? 1 : 0;
     VELOX_CHECK_GE(
         outputColumns().size(),
-        inputCols.size() + 1,
-        "kLeft Apply.outputColumns shorter than input + includeMarker");
-    const size_t bodySlots = outputColumns().size() - inputCols.size() - 1;
+        inputCols.size() + markerSlots,
+        "kLeft/kInner Apply.outputColumns shorter than input (+ includeMarker)");
+    const size_t bodySlots =
+        outputColumns().size() - inputCols.size() - markerSlots;
     VELOX_CHECK_LE(
         bodySlots,
         inputs_[1]->outputColumns().size(),
@@ -1639,9 +1654,11 @@ Apply::Apply(Key key)
           "Apply.outputColumns body cols must be unique vs input and each other");
       seen.add(column);
     }
-    VELOX_CHECK(
-        outputColumns().back() == includeMarker_,
-        "Apply.outputColumns must end with includeMarker for kLeft");
+    if (isLeft) {
+      VELOX_CHECK(
+          outputColumns().back() == includeMarker_,
+          "Apply.outputColumns must end with includeMarker for kLeft");
+    }
   } else {
     VELOX_CHECK_EQ(
         outputColumns().size(),

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1369,13 +1369,18 @@ using TopNRowNumberCP = const TopNRowNumber*;
 ///
 /// Per-kind semantics:
 ///
-///   kLeft             Correlated scalar / lateral subquery. Left-outer-join
+///   kLeft             Correlated scalar / LEFT JOIN LATERAL. Left-outer-join
 ///                     semantics. Body may produce N rows per outer. Output:
 ///                     `input.outputColumns ++ unique(body.outputColumns)
 ///                     ++ [includeMarker]` — a body column already in input
 ///                     occupies a single output slot. (NULL-padded for
 ///                     outers with no match; `includeMarker` is `true`
 ///                     on real rows, NULL on pad rows.)
+///   kInner            CROSS / INNER JOIN LATERAL. Inner-join semantics: no
+///                     NULL-padded rows and hence no `includeMarker`; outers
+///                     with no matching body row are dropped. Body may produce
+///                     N rows per outer. Output:
+///                     `input.outputColumns ++ unique(body.outputColumns)`.
 ///   kLeftSemiProject  EXISTS / IN. Output:
 ///                     `input.outputColumns ++ markColumn` — a fresh BOOLEAN
 ///                     true iff any body row exists for the outer
@@ -1457,6 +1462,10 @@ class Apply : public Node {
 
   bool isLeft() const {
     return kind_ == velox::core::JoinType::kLeft;
+  }
+
+  bool isInner() const {
+    return kind_ == velox::core::JoinType::kInner;
   }
 
   bool isLeftSemiProject() const {

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -405,6 +405,9 @@ class Translator {
       const LpNameSet& required);
   Translated translateSet(const lp::SetNode& set, const LpNameSet& required);
   Translated translateJoin(const lp::JoinNode& join, const LpNameSet& required);
+  Translated translateLateralJoin(
+      const lp::LateralJoinNode& join,
+      const LpNameSet& required);
   Translated translateTableWrite(
       const lp::TableWriteNode& tableWrite,
       const LpNameSet& required);
@@ -620,6 +623,8 @@ Translated Translator::translateNode(
       return translateSet(*node.as<lp::SetNode>(), required);
     case lp::NodeKind::kJoin:
       return translateJoin(*node.as<lp::JoinNode>(), required);
+    case lp::NodeKind::kLateralJoin:
+      return translateLateralJoin(*node.as<lp::LateralJoinNode>(), required);
     case lp::NodeKind::kTableWrite:
       return translateTableWrite(*node.as<lp::TableWriteNode>(), required);
     case lp::NodeKind::kOutput:
@@ -1786,6 +1791,67 @@ Translated Translator::translateJoin(
        /*nullAsValue=*/false,
        std::move(outputColumns)});
   return {joinNode, std::move(merged)};
+}
+
+Translated Translator::translateLateralJoin(
+    const lp::LateralJoinNode& join,
+    const LpNameSet& /*required*/) {
+  // Keep all columns of both sides: the body may correlate on any left
+  // column, and the Apply output is input.columns ++ body.columns. Unused
+  // columns are pruned in a later pass.
+  Translated left =
+      translateNode(*join.left(), allNames(*join.left()->outputType()));
+
+  // With the left scope pushed, the body's references to left columns are
+  // captured as the Apply's correlation.
+  subqueries_.push(left.scope);
+  Translated right =
+      translateNode(*join.right(), allNames(*join.right()->outputType()));
+  ColumnVector correlationColumns = subqueries_.pop();
+
+  // The ON condition may read either side.
+  Scope merged = left.scope;
+  for (auto& [name, column] : right.scope) {
+    merged[name] = column;
+  }
+
+  ExprVector filter;
+  if (join.condition() != nullptr) {
+    if (containsSubquery(*join.condition())) {
+      VELOX_NYI("Subquery in a LATERAL join ON condition is not supported");
+    }
+    ExprCP condition =
+        translateExpr(*join.condition(), merged, /*applyTarget=*/nullptr);
+    filter = ExprFactory::flattenAnd(condition);
+  }
+
+  // CROSS / INNER JOIN LATERAL -> kInner (outers with no body row are
+  // dropped, no pad rows). LEFT JOIN LATERAL -> kLeft (NULL-padded).
+  const velox::core::JoinType kind = join.joinType() == lp::JoinType::kLeft
+      ? velox::core::JoinType::kLeft
+      : velox::core::JoinType::kInner;
+
+  ColumnVector outputColumns = left.node->outputColumns();
+  appendUnique(outputColumns, right.node->outputColumns());
+  ColumnCP includeMarker = nullptr;
+  if (kind == velox::core::JoinType::kLeft) {
+    includeMarker = Column::createBoolean("_include");
+    outputColumns.push_back(includeMarker);
+  }
+
+  auto* apply = builder_.make<Apply>(
+      {left.node,
+       right.node,
+       std::move(correlationColumns),
+       kind,
+       std::move(filter),
+       /*enforceSingleRow=*/false,
+       /*markColumn=*/nullptr,
+       /*inLhs=*/nullptr,
+       /*inBodyKey=*/nullptr,
+       includeMarker,
+       std::move(outputColumns)});
+  return {apply, std::move(merged)};
 }
 
 ExprCP Translator::translateExpr(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -398,6 +398,21 @@ class RelationPlanner : public AstVisitor {
     }
   }
 
+  static bool isLateral(const RelationPtr& relation) {
+    if (relation->is(NodeType::kAliasedRelation)) {
+      return relation->as<AliasedRelation>()->relation()->is(
+          NodeType::kLateral);
+    }
+    return relation->is(NodeType::kLateral);
+  }
+
+  // Plans a LATERAL relation's body, which may reference the enclosing join's
+  // left side through the builder's outer scope.
+  void processLateral(const Lateral& lateral) {
+    processQuery(lateral.query()->as<Query>());
+    displayNames_.accumulate(*builder_, /*relationAlias=*/std::nullopt);
+  }
+
   void processQueryBody(const QueryBodyPtr& queryBody) {
     if (queryBody->is(NodeType::kQuerySpecification)) {
       visitQuerySpecification(
@@ -486,6 +501,8 @@ class RelationPlanner : public AstVisitor {
         return processTableSubquery(*relation->as<TableSubquery>());
       case NodeType::kUnnest:
         return processUnnest(*relation->as<Unnest>());
+      case NodeType::kLateral:
+        return processLateral(*relation->as<Lateral>());
       case NodeType::kJoin:
         return processJoin(*relation->as<Join>());
       default:
@@ -681,6 +698,19 @@ class RelationPlanner : public AstVisitor {
       return;
     }
 
+    // A LATERAL right side may reference the left. The right is planned with
+    // the left's scope as its outer scope, so the correlation resolves; a
+    // LateralJoinNode records the dependency for the optimizer to decorrelate.
+    const bool lateral = isLateral(join.right());
+    const auto joinType = toJoinType(join.joinType());
+    if (lateral) {
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          joinType == lp::JoinType::kInner || joinType == lp::JoinType::kLeft,
+          join.location(),
+          "LATERAL",
+          "LATERAL is only supported with CROSS, INNER, or LEFT JOIN");
+    }
+
     auto leftBuilder = builder_;
     auto leftScope = leftBuilder->scope();
 
@@ -717,8 +747,17 @@ class RelationPlanner : public AstVisitor {
         condition = toExpr(criteria->as<JoinOn>()->expression());
 
         builder_ = leftBuilder;
-        builder_->join(*rightBuilder, condition, toJoinType(join.joinType()));
+        if (lateral) {
+          builder_->lateralJoin(*rightBuilder, condition, joinType);
+        } else {
+          builder_->join(*rightBuilder, condition, joinType);
+        }
       } else if (criteria->is(NodeType::kJoinUsing)) {
+        AXIOM_PRESTO_SEMANTIC_CHECK(
+            !lateral,
+            criteria->location(),
+            "LATERAL",
+            "LATERAL does not support USING");
         const auto* joinUsing = criteria->as<JoinUsing>();
         std::vector<std::string> columns;
         columns.reserve(joinUsing->columns().size());
@@ -727,8 +766,7 @@ class RelationPlanner : public AstVisitor {
         }
 
         builder_ = leftBuilder;
-        builder_->joinUsing(
-            *rightBuilder, columns, toJoinType(join.joinType()));
+        builder_->joinUsing(*rightBuilder, columns, joinType);
       } else {
         AXIOM_PRESTO_SYNTAX_FAIL(
             criteria->location(),
@@ -738,7 +776,11 @@ class RelationPlanner : public AstVisitor {
       }
     } else {
       builder_ = leftBuilder;
-      builder_->join(*rightBuilder, std::nullopt, toJoinType(join.joinType()));
+      if (lateral) {
+        builder_->lateralJoin(*rightBuilder, std::nullopt, joinType);
+      } else {
+        builder_->join(*rightBuilder, std::nullopt, joinType);
+      }
     }
   }
 

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1383,6 +1383,27 @@ class RelationPlanner : public AstVisitor {
     node->query()->accept(this);
   }
 
+  // `TABLE t` as a query body is shorthand for `SELECT * FROM t`.
+  void visitTable(Table* node) override {
+    auto select = std::make_shared<Select>(
+        node->location(),
+        /*distinct=*/false,
+        std::vector<std::shared_ptr<SelectItem>>{std::make_shared<AllColumns>(
+            node->location(),
+            /*prefix=*/nullptr,
+            std::vector<std::shared_ptr<Identifier>>{},
+            std::vector<ReplaceItem>{})});
+    auto querySpec = std::make_shared<QuerySpecification>(
+        node->location(),
+        std::move(select),
+        std::make_shared<Table>(node->location(), node->name()),
+        /*where=*/nullptr,
+        /*groupBy=*/nullptr,
+        /*having=*/nullptr,
+        /*window=*/nullptr);
+    visitQuerySpecification(querySpec.get(), /*orderBy=*/nullptr);
+  }
+
   void visitQuerySpecification(QuerySpecification* node) override {
     visitQuerySpecification(node, /*orderBy=*/nullptr);
   }

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1770,7 +1770,8 @@ std::any AstBuilder::visitUnnest(PrestoSqlParser::UnnestContext* ctx) {
 
 std::any AstBuilder::visitLateral(PrestoSqlParser::LateralContext* ctx) {
   trace("visitLateral");
-  return visitChildren("visitLateral", ctx);
+  return std::static_pointer_cast<Relation>(std::make_shared<Lateral>(
+      getLocation(ctx), visitTyped<Statement>(ctx->query())));
 }
 
 std::any AstBuilder::visitParenthesizedRelation(

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -524,9 +524,8 @@ std::any AstBuilder::visitAliasedRelation(
 std::any AstBuilder::visitTableName(PrestoSqlParser::TableNameContext* ctx) {
   trace("visitTableName");
 
-  auto name = getQualifiedName(ctx->qualifiedName());
-  return std::static_pointer_cast<Relation>(
-      std::make_shared<Table>(getLocation(ctx), name));
+  return std::static_pointer_cast<Relation>(std::make_shared<Table>(
+      getLocation(ctx), getQualifiedName(ctx->qualifiedName())));
 }
 
 std::any AstBuilder::visitSelectAll(PrestoSqlParser::SelectAllContext* ctx) {
@@ -1527,7 +1526,11 @@ std::any AstBuilder::visitQueryPrimaryDefault(
 
 std::any AstBuilder::visitTable(PrestoSqlParser::TableContext* ctx) {
   trace("visitTable");
-  return visitChildren("visitTable", ctx);
+
+  // `TABLE t` yields a table reference used directly as a query body; Table
+  // is a QueryBody.
+  return std::static_pointer_cast<QueryBody>(std::make_shared<Table>(
+      getLocation(ctx), getQualifiedName(ctx->qualifiedName())));
 }
 
 std::any AstBuilder::visitInlineTable(

--- a/axiom/sql/presto/ast/AstRelations.h
+++ b/axiom/sql/presto/ast/AstRelations.h
@@ -583,10 +583,10 @@ class TableSubquery : public QueryBody {
 
 class Lateral : public Relation {
  public:
-  explicit Lateral(NodeLocation location, const RelationPtr& query)
+  explicit Lateral(NodeLocation location, const StatementPtr& query)
       : Relation(NodeType::kLateral, location), query_(query) {}
 
-  const RelationPtr& query() const {
+  const StatementPtr& query() const {
     return query_;
   }
   void accept(AstVisitor* visitor) override;
@@ -601,7 +601,7 @@ class Lateral : public Relation {
   }
 
  private:
-  RelationPtr query_;
+  StatementPtr query_;
 };
 
 class Unnest : public Relation {

--- a/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
+++ b/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
@@ -1366,16 +1366,21 @@ TEST(AstEqualityTest, tableSubqueryNotEqual) {
   EXPECT_FALSE(*a == *b);
 }
 
+std::shared_ptr<Statement> makeLateralQuery(const std::string& table) {
+  return std::make_shared<Query>(
+      loc(), nullptr, makeQuerySpec(emptySelect(), makeTable(table)));
+}
+
 TEST(AstEqualityTest, lateralEquals) {
-  auto a = std::make_shared<Lateral>(loc(0, 0), makeTable("t"));
-  auto b = std::make_shared<Lateral>(loc(5, 5), makeTable("t"));
+  auto a = std::make_shared<Lateral>(loc(0, 0), makeLateralQuery("t"));
+  auto b = std::make_shared<Lateral>(loc(5, 5), makeLateralQuery("t"));
   EXPECT_TRUE(*a == *b);
   EXPECT_EQ(a->hash(), b->hash());
 }
 
 TEST(AstEqualityTest, lateralNotEqual) {
-  auto a = std::make_shared<Lateral>(loc(), makeTable("t1"));
-  auto b = std::make_shared<Lateral>(loc(), makeTable("t2"));
+  auto a = std::make_shared<Lateral>(loc(), makeLateralQuery("t1"));
+  auto b = std::make_shared<Lateral>(loc(), makeLateralQuery("t2"));
   EXPECT_FALSE(*a == *b);
 }
 

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -697,6 +697,16 @@ LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::join(
   return *this;
 }
 
+LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::lateralJoin(
+    const std::shared_ptr<LogicalPlanMatcher>& rightMatcher,
+    OnMatchCallback onMatch) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<LogicalPlanMatcherImpl<LateralJoinNode>>(
+      std::vector<std::shared_ptr<LogicalPlanMatcher>>{matcher_, rightMatcher},
+      std::move(onMatch));
+  return *this;
+}
+
 LogicalPlanMatcherBuilder& LogicalPlanMatcherBuilder::join(
     const std::shared_ptr<LogicalPlanMatcher>& rightMatcher,
     const std::vector<std::string>& outputAliases) {

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -189,6 +189,11 @@ class LogicalPlanMatcherBuilder {
       const std::shared_ptr<LogicalPlanMatcher>& rightMatcher,
       const std::vector<std::string>& outputAliases);
 
+  /// Matches a LateralJoinNode with the specified right-side matcher.
+  LogicalPlanMatcherBuilder& lateralJoin(
+      const std::shared_ptr<LogicalPlanMatcher>& rightMatcher,
+      OnMatchCallback onMatch = nullptr);
+
   /// Matches a FixedPointNode. The prior chain matches the anchor; the
   /// given matcher matches the step.
   LogicalPlanMatcherBuilder& fixedPoint(

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -97,6 +97,48 @@ TEST_F(PrestoParserTest, unnest) {
   }
 }
 
+TEST_F(PrestoParserTest, lateralJoin) {
+  // CROSS JOIN LATERAL over a body with no FROM (the body references the left
+  // side) builds a LateralJoinNode whose right side is the body.
+  testSelect(
+      "SELECT n_nationkey, d FROM nation "
+      "CROSS JOIN LATERAL (SELECT n_nationkey + 1 AS d) AS x",
+      matchScan("nation")
+          .lateralJoin(matchValues().project().build())
+          .project()
+          .output());
+
+  // A LATERAL body with a FROM clause is a multi-row correlated relation.
+  testSelect(
+      "SELECT nation.n_nationkey, n FROM nation "
+      "CROSS JOIN LATERAL ("
+      "  SELECT n2.n_name AS n FROM nation n2 "
+      "  WHERE n2.n_nationkey = nation.n_regionkey) AS x",
+      matchScan("nation")
+          .lateralJoin(matchScan("nation").filter().project().build())
+          .project()
+          .output());
+
+  // LEFT JOIN LATERAL with an ON condition.
+  testSelect(
+      "SELECT nation.n_nationkey, n FROM nation "
+      "LEFT JOIN LATERAL ("
+      "  SELECT n2.n_name AS n FROM nation n2 "
+      "  WHERE n2.n_nationkey = nation.n_regionkey) AS x ON true",
+      matchScan("nation")
+          .lateralJoin(matchScan("nation").filter().project().build())
+          .project()
+          .output());
+
+  // RIGHT and FULL JOIN LATERAL are rejected: the right side is not preserved,
+  // so it cannot depend on the left.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSelect(
+          "SELECT n_nationkey FROM nation "
+          "RIGHT JOIN LATERAL (SELECT n_nationkey AS d) AS x ON true"),
+      "LATERAL is only supported with CROSS, INNER, or LEFT JOIN");
+}
+
 TEST_F(PrestoParserTest, qualifiedColumnAccess) {
   {
     connector_->addTable("t", ROW({"x"}, {INTEGER()}));

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -184,6 +184,15 @@ TEST_F(PrestoParserTest, qualifiedColumnAccess) {
   }
 }
 
+TEST_F(PrestoParserTest, tableShorthand) {
+  // `TABLE t` is shorthand for `SELECT * FROM t`.
+  auto matcher =
+      matchScan().output({"n_nationkey", "n_name", "n_regionkey", "n_comment"});
+  testSelect("TABLE nation", matcher);
+  testSelect("(TABLE nation)", matcher);
+  testSelect("SELECT * FROM (TABLE nation)", matcher);
+}
+
 TEST_F(PrestoParserTest, selectStar) {
   {
     auto matcher = matchScan().output(


### PR DESCRIPTION
Summary:
`TABLE t` — Presto shorthand for `SELECT * FROM t` — failed to parse:

    visitChildren called with more than one child: 2 (visitTable)

`visitTable` was unimplemented. It now builds a bare `Table` AST node; the parser expands a `Table` query body into `SELECT * FROM t`, so the shorthand takes the same path as an explicit `SELECT *`. It works on its own and nested, e.g. `SELECT * FROM (TABLE t)`.

Differential Revision: D111906113


