### PR TITLE
feat(parser): Support SHOW CREATE VIEW

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -984,6 +984,23 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
       run("SHOW CREATE TABLE no_such_table"), "Table not found");
 }
 
+TEST_F(SqlQueryRunnerTest, showCreateView) {
+  testConnector_->createView(
+      facebook::axiom::SchemaTableName{kDefaultSchema, "v1"},
+      ROW({"a", "b"}, {INTEGER(), VARCHAR()}),
+      "SELECT 1 AS a, 'x' AS b");
+
+  auto row = fetchSingleRow("SHOW CREATE VIEW v1");
+  auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+  EXPECT_EQ(
+      ddl,
+      "CREATE VIEW test.\"default\".\"v1\" AS\n"
+      "SELECT 1 AS a, 'x' AS b");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      run("SHOW CREATE VIEW no_such_view"), "View not found");
+}
+
 TEST_F(SqlQueryRunnerTest, generateQueryIdDefault) {
   // Default generator produces non-empty, unique IDs via run().
   std::string queryId1;

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -337,6 +337,9 @@ SELECT a FROM t WHERE EXISTS (SELECT 1 FROM v)
 -- enforcement. Returns one row per outer row.
 SELECT (SELECT u.a FROM u WHERE u.a = 1) FROM t
 ----
+-- The same uncorrelated scalar subquery referenced twice in one expression.
+SELECT (SELECT max(u.a) FROM u) + (SELECT max(u.a) FROM u) AS s FROM t
+----
 -- Scalar subquery whose SELECT references an outer column. The subquery
 -- has no FROM clause: result is just the outer column.
 SELECT (SELECT a) FROM t

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -200,6 +200,16 @@ bool containsSubquery(const logical_plan::Expr& expr) {
   return false;
 }
 
+// True if 'column' is one of 'node's output columns (by identity).
+bool outputContains(NodeCP node, ColumnCP column) {
+  for (ColumnCP candidate : node->outputColumns()) {
+    if (candidate == column) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Walks 'expr' as a top-level AND chain and appends each non-AND leaf
 // to 'out'.
 void flattenAndConjuncts(
@@ -528,6 +538,15 @@ class Translator {
   ExprFactory exprFactory_;
   ExprSimplifier simplifier_;
   int32_t baseTableCounter_{0};
+
+  // Result column of each scalar subquery already lifted, keyed by its inner
+  // plan. Identical subqueries share one inner plan (hash-consed), so a
+  // repeated reference reuses the lifted column instead of lifting it again
+  // (which would place the same column on both sides of the lift's join). A
+  // cached column is only reused while it is still in the current lift
+  // target's output, so a reference in an unrelated scope re-lifts.
+  folly::F14FastMap<const lp::LogicalPlanNode*, ColumnCP>
+      scalarSubqueryColumns_;
 };
 
 Translated Translator::translateTableWrite(
@@ -1876,12 +1895,24 @@ ExprCP Translator::translateExpr(
       // (no Apply), correlated → kLeft Apply. Scalar shape is signaled
       // by a null `inLhs` (no IN equi to build).
       const auto& subquery = *expr.as<lp::SubqueryExpr>();
-      return liftSubquery(
+      const auto* innerPlan = subquery.subquery().get();
+      if (applyTarget != nullptr) {
+        auto it = scalarSubqueryColumns_.find(innerPlan);
+        if (it != scalarSubqueryColumns_.end() &&
+            outputContains(*applyTarget, it->second)) {
+          return it->second;
+        }
+      }
+      ColumnCP column = liftSubquery(
           subquery,
           velox::core::JoinType::kLeft,
           /*inLhs=*/nullptr,
           scope,
           applyTarget);
+      if (applyTarget != nullptr) {
+        scalarSubqueryColumns_[innerPlan] = column;
+      }
+      return column;
     }
     default:
       VELOX_NYI(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -533,8 +533,7 @@ class RelationPlanner : public AstVisitor {
       if (entry.isRecursive) {
         translateRecursiveCteReference(*entry.withQuery, name);
       } else {
-        // TODO: Change WithQuery to store Query and not Statement.
-        processQuery(dynamic_cast<Query*>(entry.withQuery->query().get()));
+        processQuery(entry.withQuery->query().get());
 
         // Apply CTE column-alias list, e.g. 'WITH t(a, b) AS (...)' renames
         // the underlying SELECT/VALUES output columns to a, b.
@@ -1374,9 +1373,8 @@ class RelationPlanner : public AstVisitor {
         // actually references its own name. Otherwise it's a standard union.
         bool selfReferential = false;
         if (with->isRecursive()) {
-          auto* bodyQuery = dynamic_cast<Query*>(withQuery->query().get());
-          selfReferential = bodyQuery != nullptr &&
-              presto::RecursiveCteValidator::referencesCte(*bodyQuery, cteName);
+          selfReferential = presto::RecursiveCteValidator::referencesCte(
+              *withQuery->query(), cteName);
         }
         ctes_.bind(cteName, CteScope::Entry{withQuery, selfReferential});
       }

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2038,6 +2038,38 @@ SqlStatementPtr parseShowCreateTable(
       });
 }
 
+SqlStatementPtr parseShowCreateView(
+    const ShowCreateView& showCreateView,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  const auto [connectorId, schemaTableName] = toConnectorTable(
+      *showCreateView.name(), defaultConnectorId, defaultSchema);
+
+  const auto view =
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId)
+          ->findView(schemaTableName);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      view != nullptr,
+      showCreateView.name()->location(),
+      showCreateView.name()->suffix(),
+      "View not found: {}",
+      showCreateView.name()->fullyQualifiedName());
+
+  const auto ddl = fmt::format(
+      "CREATE VIEW {}.{} AS\n{}", connectorId, schemaTableName, view->text());
+
+  return std::make_shared<SelectStatement>(
+      lp::PlanBuilder()
+          .values(ROW({"Create View"}, VARCHAR()), {Variant::row({ddl})})
+          .build(),
+      ViewMap{},
+      ReferencedTables{
+          {facebook::axiom::CatalogSchemaTableName{
+              connectorId, schemaTableName}},
+          std::nullopt,
+      });
+}
+
 SqlStatementPtr parseShowStats(
     const ShowStats& showStats,
     const std::string& defaultConnectorId,
@@ -2686,6 +2718,11 @@ SqlStatementPtr doPlan(
   if (query->is(NodeType::kShowCreate)) {
     return parseShowCreateTable(
         *query->as<ShowCreateTable>(), defaultConnectorId, defaultSchema);
+  }
+
+  if (query->is(NodeType::kShowCreateView)) {
+    return parseShowCreateView(
+        *query->as<ShowCreateView>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kShowColumns)) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -513,26 +513,25 @@ class RelationPlanner : public AstVisitor {
     }
   }
 
-  void processTable(const Table& table) {
-    const auto tableName = canonicalizeName(table.name()->suffix());
-
+  // Resolves 'name' as a CTE reference, returning true if handled.
+  bool tryProcessCteReference(const std::string& name) {
     // A recursive binding re-translates its body at each reference site so
     // every reference yields an independent FixedPointNode subtree, since
     // execution does not support DAG plans.
-    if (const auto* anchor = ctes_.anchorFor(tableName)) {
+    if (const auto* anchor = ctes_.anchorFor(name)) {
       builder_ = newBuilder();
       // The recursive-ref name must match the enclosing FixedPointNode's
       // name so the optimizer wires this self-reference to that loop state.
-      builder_->recursiveRef(tableName, *anchor);
-      builder_->as(tableName);
-      displayNames_.accumulate(*builder_, tableName);
-      return;
+      builder_->recursiveRef(name, *anchor);
+      builder_->as(name);
+      displayNames_.accumulate(*builder_, name);
+      return true;
     }
 
-    if (auto hidden = ctes_.hide(tableName)) {
+    if (auto hidden = ctes_.hide(name)) {
       const auto& entry = hidden.entry();
       if (entry.isRecursive) {
-        translateRecursiveCteReference(*entry.withQuery, tableName);
+        translateRecursiveCteReference(*entry.withQuery, name);
       } else {
         // TODO: Change WithQuery to store Query and not Statement.
         processQuery(dynamic_cast<Query*>(entry.withQuery->query().get()));
@@ -541,11 +540,24 @@ class RelationPlanner : public AstVisitor {
         // the underlying SELECT/VALUES output columns to a, b.
         if (const auto& columnAliases = entry.withQuery->columnNames()) {
           displayNames_.captureLastNames(*columnAliases);
-          applyColumnAliases(
-              *columnAliases, entry.withQuery->location(), tableName);
+          applyColumnAliases(*columnAliases, entry.withQuery->location(), name);
         }
       }
-      finalizeCteReference(tableName);
+      finalizeCteReference(name);
+      return true;
+    }
+
+    return false;
+  }
+
+  void processTable(const Table& table) {
+    const auto tableName = canonicalizeName(table.name()->suffix());
+
+    // Only an unqualified single-part name can name a CTE; a qualified
+    // catalog.schema.table reference is always a base table or view, even if
+    // its last component matches a CTE name.
+    if (table.name()->parts().size() == 1 &&
+        tryProcessCteReference(tableName)) {
       return;
     }
 

--- a/axiom/sql/presto/RecursiveCteValidator.cpp
+++ b/axiom/sql/presto/RecursiveCteValidator.cpp
@@ -222,12 +222,7 @@ bool RecursiveCteValidator::referencesCte(
 const Union* RecursiveCteValidator::extractAndValidateRecursiveUnion(
     const WithQuery& withEntry,
     const std::string& cteName) {
-  auto* bodyQuery = dynamic_cast<Query*>(withEntry.query().get());
-  AXIOM_PRESTO_SYNTAX_CHECK(
-      bodyQuery != nullptr,
-      withEntry.location(),
-      cteName,
-      "Recursive CTE body is not a query");
+  const auto* bodyQuery = withEntry.query().get();
   const auto& queryBody = bodyQuery->queryBody();
 
   // Reject set operations other than UNION ALL.

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1651,7 +1651,7 @@ std::any AstBuilder::visitNamedQuery(PrestoSqlParser::NamedQueryContext* ctx) {
   return std::make_shared<WithQuery>(
       getLocation(ctx),
       visitIdentifier(ctx->name),
-      visitTyped<Statement>(ctx->query()),
+      std::dynamic_pointer_cast<Query>(visitTyped<Statement>(ctx->query())),
       columns);
 }
 

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -992,7 +992,8 @@ std::any AstBuilder::visitShowCreateTable(
 std::any AstBuilder::visitShowCreateView(
     PrestoSqlParser::ShowCreateViewContext* ctx) {
   trace("visitShowCreateView");
-  return visitChildren("visitShowCreateView", ctx);
+  return std::static_pointer_cast<Statement>(std::make_shared<ShowCreateView>(
+      getLocation(ctx), getQualifiedName(ctx->qualifiedName())));
 }
 
 std::any AstBuilder::visitShowCreateMaterializedView(

--- a/axiom/sql/presto/ast/AstNode.h
+++ b/axiom/sql/presto/ast/AstNode.h
@@ -184,6 +184,7 @@ enum class NodeType {
   kShowCatalogs,
   kShowFunctions,
   kShowCreate,
+  kShowCreateView,
   kShowCreateFunction,
   kShowSession,
   kShowStats,

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -508,6 +508,25 @@ void WithQuery::accept(AstVisitor* visitor) {
   visitor->visitWithQuery(this);
 }
 
+size_t WithQuery::hash() const {
+  return folly::hash::hash_combine(
+      Node::deepHash(name_),
+      Node::deepHash(query_),
+      columnNames_.has_value() ? Node::deepHashAll(*columnNames_) : 0);
+}
+
+bool WithQuery::equals(const Node& other) const {
+  const auto& o = *other.as<WithQuery>();
+  if (!(Node::deepEqual(name_, o.name_) && Node::deepEqual(query_, o.query_))) {
+    return false;
+  }
+  if (columnNames_.has_value() != o.columnNames_.has_value()) {
+    return false;
+  }
+  return !columnNames_.has_value() ||
+      Node::deepEqualAll(*columnNames_, *o.columnNames_);
+}
+
 void OrderBy::accept(AstVisitor* visitor) {
   visitor->visitOrderBy(this);
 }

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -181,6 +181,7 @@ const auto& nodeTypeNames() {
       {NodeType::kShowCatalogs, "ShowCatalogs"},
       {NodeType::kShowFunctions, "ShowFunctions"},
       {NodeType::kShowCreate, "ShowCreate"},
+      {NodeType::kShowCreateView, "ShowCreateView"},
       {NodeType::kShowCreateFunction, "ShowCreateFunction"},
       {NodeType::kShowSession, "ShowSession"},
       {NodeType::kShowStats, "ShowStats"},
@@ -828,6 +829,10 @@ void ShowTables::accept(AstVisitor* visitor) {
 
 void ShowCreateTable::accept(AstVisitor* visitor) {
   visitor->visitShowCreateTable(this);
+}
+
+void ShowCreateView::accept(AstVisitor* visitor) {
+  visitor->visitShowCreateView(this);
 }
 
 void ShowColumns::accept(AstVisitor* visitor) {

--- a/axiom/sql/presto/ast/AstStatements.h
+++ b/axiom/sql/presto/ast/AstStatements.h
@@ -960,6 +960,24 @@ class ShowCreateTable : public Statement {
   std::shared_ptr<QualifiedName> name_;
 };
 
+/// Represents SHOW CREATE VIEW <view>. Returns the CREATE VIEW DDL statement
+/// as a single-row, single-column result.
+class ShowCreateView : public Statement {
+ public:
+  ShowCreateView(NodeLocation location, std::shared_ptr<QualifiedName> name)
+      : Statement(NodeType::kShowCreateView, location),
+        name_(std::move(name)) {}
+
+  const std::shared_ptr<QualifiedName>& name() const {
+    return name_;
+  }
+
+  void accept(AstVisitor* visitor) override;
+
+ private:
+  std::shared_ptr<QualifiedName> name_;
+};
+
 class ShowColumns : public Statement {
  public:
   explicit ShowColumns(

--- a/axiom/sql/presto/ast/AstSupport.h
+++ b/axiom/sql/presto/ast/AstSupport.h
@@ -26,6 +26,7 @@ namespace axiom::sql::presto {
 
 // Forward declarations
 class OrderBy;
+class Query;
 
 // Support Classes
 
@@ -588,19 +589,21 @@ class WithQuery : public Node {
   WithQuery(
       NodeLocation location,
       const std::shared_ptr<Identifier>& name,
-      const StatementPtr& query,
+      const std::shared_ptr<Query>& query,
       std::optional<std::vector<std::shared_ptr<Identifier>>> columnNames =
           std::nullopt)
       : Node(NodeType::kWithQuery, location),
         name_(name),
         query_(query),
-        columnNames_(std::move(columnNames)) {}
+        columnNames_(std::move(columnNames)) {
+    VELOX_CHECK_NOT_NULL(query_);
+  }
 
   const std::shared_ptr<Identifier>& name() const {
     return name_;
   }
 
-  const StatementPtr& query() const {
+  const std::shared_ptr<Query>& query() const {
     return query_;
   }
 
@@ -611,30 +614,16 @@ class WithQuery : public Node {
 
   void accept(AstVisitor* visitor) override;
 
-  size_t hash() const override {
-    return folly::hash::hash_combine(
-        Node::deepHash(name_),
-        Node::deepHash(query_),
-        columnNames_.has_value() ? Node::deepHashAll(*columnNames_) : 0);
-  }
+  // Defined out-of-line because they hash/compare 'query_', which requires a
+  // complete Query type.
+  size_t hash() const override;
 
  protected:
-  bool equals(const Node& other) const override {
-    const auto& o = *other.as<WithQuery>();
-    if (!(Node::deepEqual(name_, o.name_) &&
-          Node::deepEqual(query_, o.query_))) {
-      return false;
-    }
-    if (columnNames_.has_value() != o.columnNames_.has_value()) {
-      return false;
-    }
-    return !columnNames_.has_value() ||
-        Node::deepEqualAll(*columnNames_, *o.columnNames_);
-  }
+  bool equals(const Node& other) const override;
 
  private:
   std::shared_ptr<Identifier> name_;
-  StatementPtr query_;
+  std::shared_ptr<Query> query_;
   std::optional<std::vector<std::shared_ptr<Identifier>>> columnNames_;
 };
 

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -595,6 +595,10 @@ class AstVisitor {
     defaultVisit(node);
   }
 
+  virtual void visitShowCreateView(ShowCreateView* node) {
+    defaultVisit(node);
+  }
+
   virtual void visitShowColumns(ShowColumns* node) {
     defaultVisit(node);
   }

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -432,6 +432,22 @@ TEST_F(PrestoParserTest, withShadowingBaseTable) {
       matcher);
 }
 
+TEST_F(PrestoParserTest, qualifiedTableNotShadowedByCte) {
+  // A qualified table reference is a base table even when its last component
+  // matches a CTE name; the CTE must not shadow it. Covers both the
+  // catalog.schema.table and schema.table forms.
+  auto matcher = matchScan().project().output({"n_name"});
+  testSelect(
+      "WITH nation AS (SELECT 1 AS x) "
+      "SELECT n.n_name FROM test.default.nation n",
+      matcher);
+
+  testSelect(
+      "WITH nation AS (SELECT 1 AS x) "
+      "SELECT n.n_name FROM default.nation n",
+      matcher);
+}
+
 TEST_F(PrestoParserTest, withMultipleCtes) {
   // Later CTE references earlier CTE.
   testSelect(


### PR DESCRIPTION
Summary:
SHOW CREATE VIEW previously parsed but produced no statement, so the view's DDL could not be inspected. It now returns the CREATE VIEW definition as a single-row result, mirroring SHOW CREATE TABLE:

    SHOW CREATE VIEW v

    CREATE VIEW catalog.schema.v AS
    SELECT ...

The parser resolves the view through connector metadata and wraps the stored view text in a CREATE VIEW statement. An unknown view fails with `View not found`.

Differential Revision: D112008807


