### PR TITLE
fix: Remove internal split-enum TODO from ConnectorSplitManager interface (#1580)

### DIFF
--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -125,8 +125,6 @@ class ConnectorSplitManager {
   /// When 'partitionType' is non-null, the connector tags each emitted Split
   /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
   /// for the non-bucketed case.
-  // TODO: Instrument PrismSplitManager with runtimeStats for split enumeration
-  // timing.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,


### PR DESCRIPTION
Summary:

Removes a TODO on the ConnectorSplitManager interface about wiring runtimeStats for split-enumeration timing. That is an implementation concern, not part of the interface contract.

Differential Revision: D112032358


