### PR TITLE
feat(optimizer): Support TABLESAMPLE SYSTEM (#1581)

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -108,6 +108,13 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
     return result.results[0];
   }
 
+  // Runs 'sql', which must return a single row and a single column, and returns
+  // that value.
+  template <typename T>
+  T fetchSingleValue(std::string_view sql) {
+    return fetchSingleRow(sql)->childAt(0)->variantAt(0).value<T>();
+  }
+
   void assertSchemas(const std::vector<std::string>& expected) {
     auto result = run("SHOW SCHEMAS");
     ASSERT_FALSE(result.message.has_value());
@@ -950,8 +957,7 @@ TEST_F(SqlQueryRunnerTest, showTables) {
 TEST_F(SqlQueryRunnerTest, showCreateTable) {
   {
     run("CREATE TABLE t1 (id INTEGER, name VARCHAR)");
-    auto row = fetchSingleRow("SHOW CREATE TABLE t1");
-    auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+    auto ddl = fetchSingleValue<std::string>("SHOW CREATE TABLE t1");
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t1\" (\n"
@@ -966,8 +972,7 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
     // CREATE TABLE statement.
     run("CREATE TABLE t2 (a INTEGER, b VARCHAR) "
         "WITH (hidden = ARRAY['h1', 'h2'])");
-    auto row = fetchSingleRow("SHOW CREATE TABLE t2");
-    auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+    auto ddl = fetchSingleValue<std::string>("SHOW CREATE TABLE t2");
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t2\" (\n"
@@ -990,8 +995,7 @@ TEST_F(SqlQueryRunnerTest, showCreateView) {
       ROW({"a", "b"}, {INTEGER(), VARCHAR()}),
       "SELECT 1 AS a, 'x' AS b");
 
-  auto row = fetchSingleRow("SHOW CREATE VIEW v1");
-  auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+  auto ddl = fetchSingleValue<std::string>("SHOW CREATE VIEW v1");
   EXPECT_EQ(
       ddl,
       "CREATE VIEW test.\"default\".\"v1\" AS\n"
@@ -999,6 +1003,41 @@ TEST_F(SqlQueryRunnerTest, showCreateView) {
 
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       run("SHOW CREATE VIEW no_such_view"), "View not found");
+}
+
+TEST_F(SqlQueryRunnerTest, tableSampleSystem) {
+  // One split per appended row vector, so sampling drops whole splits.
+  testConnector_->addTable("sampled", ROW("x", INTEGER()));
+  auto vector = makeRowVector({makeFlatVector<int32_t>({1})});
+  constexpr int64_t kNumSplits = 1000;
+  for (int64_t i = 0; i < kNumSplits; ++i) {
+    testConnector_->appendData("sampled", vector);
+  }
+
+  auto sample = [&](double percentage) {
+    return fetchSingleValue<int64_t>(fmt::format(
+        "SELECT count(*) FROM sampled TABLESAMPLE SYSTEM ({})", percentage));
+  };
+
+  EXPECT_EQ(
+      fetchSingleValue<int64_t>("SELECT count(*) FROM sampled"), kNumSplits);
+
+  // 0% produces an empty result; 100% is a no-op passthrough.
+  EXPECT_EQ(sample(0), 0);
+  EXPECT_EQ(sample(100), kNumSplits);
+
+  // Intermediate rates keep some but not all splits. Counts are exact because
+  // the split coin flip is deterministically seeded.
+  EXPECT_EQ(sample(0.1), 2);
+  EXPECT_EQ(sample(1), 10);
+  EXPECT_EQ(sample(20), 176);
+  EXPECT_EQ(sample(50), 493);
+
+  // SYSTEM sampling has no single split source to sample over a join.
+  VELOX_ASSERT_THROW(
+      run("SELECT count(*) FROM (SELECT a.x FROM sampled a, sampled b) "
+          "TABLESAMPLE SYSTEM (50)"),
+      "TABLESAMPLE SYSTEM is only supported directly over a table");
 }
 
 TEST_F(SqlQueryRunnerTest, generateQueryIdDefault) {

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -125,11 +125,18 @@ class ConnectorSplitManager {
   /// When 'partitionType' is non-null, the connector tags each emitted Split
   /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
   /// for the non-bucketed case.
+  ///
+  /// When 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
+  /// split with that probability, in the open interval (0, 100); the caller
+  /// handles the 0 and 100 endpoints. The sampling happens during split
+  /// enumeration so unselected splits are never produced. A connector that does
+  /// not support sampling must fail rather than ignore it.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) = 0;
 };
 

--- a/axiom/connectors/file/core/FileConnectorMetadata.cpp
+++ b/axiom/connectors/file/core/FileConnectorMetadata.cpp
@@ -96,7 +96,11 @@ FileConnectorMetadata::SplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
   VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
   // The file list was resolved once during planning (see findTable); reuse it

--- a/axiom/connectors/file/core/FileConnectorMetadata.h
+++ b/axiom/connectors/file/core/FileConnectorMetadata.h
@@ -81,6 +81,7 @@ class FileConnectorMetadata : public ConnectorMetadata {
         const velox::connector::ConnectorTableHandlePtr& tableHandle,
         const std::vector<PartitionHandlePtr>& partitions,
         const std::shared_ptr<PartitionType>& partitionType,
+        std::optional<double> samplePercentage,
         QueryRuntimeStats& runtimeStats) override;
   };
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -321,7 +321,11 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& partitionType,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
   auto metadata = ConnectorMetadataRegistry::get(tableHandle->connectorId());

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -77,6 +77,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -149,7 +149,11 @@ std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   return std::make_shared<SystemSplitSource>(tableHandle->connectorId());
 }
 

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -118,6 +118,7 @@ class SystemSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -340,7 +340,12 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
 
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
+      session,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      /*samplePercentage=*/std::nullopt,
+      noopStats);
   ASSERT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,6 +17,7 @@
 #include "axiom/connectors/tests/TestConnector.h"
 
 #include <algorithm>
+#include <random>
 #include <utility>
 
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
@@ -454,11 +455,13 @@ TestSplitManager::co_listPartitions(
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
-    const ConnectorSessionPtr& /*session*/,
+    const ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& partitions,
     const std::shared_ptr<PartitionType>& partitionType,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_CHECK_NOT_NULL(session);
   const auto& testTable = findTestTableForHandle(tableHandle);
 
   std::vector<size_t> dataIndices;
@@ -487,6 +490,30 @@ std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
       dataIndices.push_back(i);
     }
   }
+
+  if (samplePercentage.has_value()) {
+    // Drop whole splits (one per data index) at enumeration time, so unselected
+    // splits are never produced.
+    const bool bucketed = !dataBucketIds.empty();
+
+    const auto seed = folly::to<uint32_t>(
+        session->property(TestConfigProvider::kSampleSeed).value());
+    std::mt19937 rng(seed);
+    std::bernoulli_distribution keep(*samplePercentage / 100.0);
+    std::vector<size_t> sampledIndices;
+    std::vector<int32_t> sampledBucketIds;
+    for (size_t i = 0; i < dataIndices.size(); ++i) {
+      if (keep(rng)) {
+        sampledIndices.push_back(dataIndices[i]);
+        if (bucketed) {
+          sampledBucketIds.push_back(dataBucketIds[i]);
+        }
+      }
+    }
+    dataIndices = std::move(sampledIndices);
+    dataBucketIds = std::move(sampledBucketIds);
+  }
+
   return std::make_shared<TestSplitSource>(
       tableHandle->connectorId(),
       std::move(dataIndices),

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -300,6 +300,7 @@ class TestSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 
@@ -726,6 +727,10 @@ class TestConfigProvider : public velox::config::ConfigProvider {
   /// verify a session property reaches connector split-generation.
   static constexpr const char* kListPartitionsError = "list_partitions_error";
 
+  /// Seed for the TABLESAMPLE SYSTEM split coin flip. Defaults to a fixed
+  /// value so sampled split sets are reproducible across test runs.
+  static constexpr const char* kSampleSeed = "sample_seed";
+
   std::vector<velox::config::ConfigProperty> properties() const override {
     return {
         {kCollectColumnStatistics,
@@ -736,6 +741,10 @@ class TestConfigProvider : public velox::config::ConfigProvider {
          velox::config::ConfigPropertyType::kString,
          "",
          "Test-only: if non-empty, co_listPartitions throws this message."},
+        {kSampleSeed,
+         velox::config::ConfigPropertyType::kString,
+         "42",
+         "Test-only: seed for TABLESAMPLE SYSTEM split sampling."},
     };
   }
 

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -166,7 +166,12 @@ CO_TEST_F(TestConnectorTest, splitManager) {
       co_await splitManager->co_listPartitions(session, tableHandle);
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
+      session,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      /*samplePercentage=*/std::nullopt,
+      noopStats);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
@@ -631,7 +636,12 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
   QueryRuntimeStats noopStats;
   auto source = splitManager->getSplitSource(
-      session, tableHandle, partitions, partitionType, noopStats);
+      session,
+      tableHandle,
+      partitions,
+      partitionType,
+      /*samplePercentage=*/std::nullopt,
+      noopStats);
   std::vector<int32_t> observedGroupIds;
   while (true) {
     auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -88,7 +88,11 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   auto* tpchTableHandle =
       dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
           tableHandle.get());

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -63,6 +63,7 @@ class TpchSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -223,6 +223,7 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
       tableHandle,
       partitions,
       /*partitionType=*/nullptr,
+      /*samplePercentage=*/std::nullopt,
       noopStats);
   CO_ASSERT_NE(splitSource, nullptr);
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -170,6 +170,15 @@ bool FunctionRegistry::registerLike(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerRandom(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (random_.has_value() && random_.value() != name) {
+    return false;
+  }
+  random_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerRowNumber(std::string_view name) {
   VELOX_USER_CHECK(!name.empty());
   if (rowNumber_.has_value() && rowNumber_.value() != name) {
@@ -408,6 +417,7 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerIsNull(fullName("is_null"));
   registry->registerBetween(fullName("between"));
   registry->registerLike(fullName("like"));
+  registry->registerRandom(fullName("rand"));
   registry->registerRowNumber(fullName("row_number"));
   registry->registerRank(fullName("rank"));
   registry->registerDenseRank(fullName("dense_rank"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -421,6 +421,18 @@ class FunctionRegistry {
     return like_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'rand', i.e.
+  /// returns a pseudo-random double in [0, 1). Used to implement BERNOULLI
+  /// sampling as a filter.
+  /// @return true if successfully registered, false if a different 'random'
+  /// function is already registered.
+  bool registerRandom(std::string_view name);
+
+  /// Returns the name of the 'random' function.
+  const std::optional<std::string>& random() const {
+    return random_;
+  }
+
   /// Registers function 'name' that has semantics of 'row_number' window
   /// function, i.e. assigns sequential numbers to rows within a partition.
   /// @return true if successfully registered, false if a different
@@ -535,6 +547,7 @@ class FunctionRegistry {
   std::optional<std::string> isNull_;
   std::optional<std::string> between_;
   std::optional<std::string> like_;
+  std::optional<std::string> random_;
 
   // Aggregate functions.
   std::optional<std::string> arbitrary_;

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -437,6 +437,11 @@ std::string MultiFragmentPlan::toString(
                  if (addContext != nullptr) {
                    addContext(planNodeId, indentation, stream);
                  }
+                 if (auto sampled = fragment.sampledScans.find(planNodeId);
+                     sampled != fragment.sampledScans.end()) {
+                   stream << indentation << "sample: " << sampled->second << "%"
+                          << std::endl;
+                 }
                  auto it = planNodeToIndices.find(planNodeId);
                  if (it != planNodeToIndices.end()) {
                    if (it->second.size() == 1) {

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -161,6 +161,11 @@ struct ExecutableFragment {
       velox::core::PlanNodeId,
       std::shared_ptr<connector::PartitionType>>
       groupedNodes;
+
+  /// Sample percentage per scan node for TABLESAMPLE SYSTEM. The split source
+  /// for the scan emits each split with this probability, in the open interval
+  /// (0, 100). Empty when no scan in this fragment is sampled.
+  folly::F14FastMap<velox::core::PlanNodeId, double> sampledScans;
 };
 
 /// Describes a distributed plan handed to a Runner for parallel/distributed

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -220,6 +220,31 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
   // Apply results.
   for (auto& [baseTable, taskIndex, columnIndices] : tableTasks) {
     applyFilteredStats(*baseTable, results[taskIndex], columnIndices);
+    applySampleRate(*baseTable);
+  }
+}
+
+void Optimization::applySampleRate(BaseTable& baseTable) {
+  if (!baseTable.sampledPercentage.has_value() ||
+      !baseTable.filteredCardinality.has_value()) {
+    return;
+  }
+
+  // TABLESAMPLE SYSTEM is an additional selectivity on the scan, applied on top
+  // of the filter selectivity. Scale the filtered cardinality, floored at 1 so
+  // downstream estimates never divide by zero.
+  const float sampledCardinality = std::max<float>(
+      1,
+      *baseTable.filteredCardinality * (*baseTable.sampledPercentage / 100.0f));
+  baseTable.filteredCardinality = sampledCardinality;
+
+  // A column cannot have more distinct values than the sampled row count.
+  for (auto* column : baseTable.columns) {
+    const auto& value = column->value();
+    if (value.cardinality.has_value() &&
+        *value.cardinality > sampledCardinality) {
+      const_cast<Value&>(value).cardinality = sampledCardinality;
+    }
   }
 }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -437,6 +437,11 @@ class Optimization {
       const std::optional<connector::FilteredTableStats>& stats,
       const std::vector<size_t>& columnIndices);
 
+  // Folds a TABLESAMPLE SYSTEM rate into 'baseTable' by scaling
+  // filteredCardinality and capping column NDVs at the sampled row count. No-op
+  // when the table is not sampled. Called after applyFilteredStats.
+  void applySampleRate(BaseTable& baseTable);
+
   const OptimizerSessionPtr optimizerSession_;
 
   const runner::RunnerSessionPtr runnerSession_;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1161,6 +1161,11 @@ struct BaseTable : public TableObject {
 
   SubfieldSet payloadSubfields;
 
+  /// TABLESAMPLE SYSTEM percentage in the open interval (0, 100). When set,
+  /// split generation for this scan emits each split with this probability.
+  /// nullopt = no sampling.
+  std::optional<float> sampledPercentage;
+
   std::optional<float> cardinality() const override {
     return filteredCardinality;
   }

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -385,6 +385,10 @@ void QueryGraphContext::populateFunctionNames() {
     functionNames_.like = this->toName(like.value());
   }
 
+  if (auto random = registry->random()) {
+    functionNames_.random = this->toName(random.value());
+  }
+
   if (auto rowNumber = registry->rowNumber()) {
     functionNames_.rowNumber = this->toName(rowNumber.value());
   }

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -331,6 +331,7 @@ struct FunctionNames {
   Name isNull{nullptr};
   Name between{nullptr};
   Name like{nullptr};
+  Name random{nullptr};
 
   /// Aggregate functions.
   Name arbitrary{nullptr};

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -4386,24 +4386,45 @@ void ToGraph::applySampling(
   VELOX_USER_CHECK_GE(percentage, 0, "Sampling percentage must be >= 0");
   VELOX_USER_CHECK_LE(percentage, 100, "Sampling percentage must be <= 100");
 
+  // Handle the endpoints here so the sample methods below only deal with a
+  // percentage in the open interval (0, 100).
   if (percentage == 100) {
     makeQueryGraph(*sample.onlyInput(), allowedInDt, orderObservedAbove);
     return;
   }
 
-  // TODO Optimize the case when percentage == 0.
-  // TODO Figure out how to avoid hard-coding "rand" and "lt".
+  if (percentage == 0) {
+    makeEmptyValuesTable(sample);
+    return;
+  }
 
   switch (sample.sampleMethod()) {
-    case lp::SampleNode::SampleMethod::kSystem:
-      VELOX_NYI("SYSTEM sampling is not supported yet");
+    case lp::SampleNode::SampleMethod::kSystem: {
+      // SYSTEM sampling drops whole splits, so it needs a single table scan.
+      // Reject anything else rather than falling back to per-row sampling,
+      // which is the cost SYSTEM exists to avoid.
+      const auto& input = *sample.onlyInput();
+      auto* outerDt = std::exchange(currentDt_, newDt());
+      makeQueryGraph(input, kAllAllowedInDt, orderObservedAbove);
+      VELOX_USER_CHECK(
+          currentDt_->tables.size() == 1 &&
+              currentDt_->tables[0]->is(PlanType::kTableNode),
+          "TABLESAMPLE SYSTEM is only supported directly over a table");
+      const_cast<BaseTable*>(currentDt_->tables[0]->as<BaseTable>())
+          ->sampledPercentage = static_cast<float>(percentage);
+      finalizeDt(sample, outerDt);
       break;
+    }
     case lp::SampleNode::SampleMethod::kBernoulli: {
       // Implement using filter(rand() < percentage / 100.0).
+      VELOX_USER_CHECK_NOT_NULL(
+          functionNames_.random,
+          "BERNOULLI sampling requires a registered 'rand' function");
       auto predicate = std::make_shared<lp::CallExpr>(
           velox::BOOLEAN(),
-          "lt",
-          std::make_shared<lp::CallExpr>(velox::DOUBLE(), "rand"),
+          functionNames_.lt,
+          std::make_shared<lp::CallExpr>(
+              velox::DOUBLE(), functionNames_.random),
           std::make_shared<lp::ConstantExpr>(
               velox::DOUBLE(),
               std::make_shared<velox::Variant>(percentage / 100.0)));

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1427,7 +1427,7 @@ velox::core::TypedExprPtr toAndWithAliases(
 
 velox::core::PlanNodePtr ToVelox::makeScan(
     const TableScan& scan,
-    ExecutableFragment& /*fragment*/,
+    ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& /*stages*/) {
   columnAlteredTypes_.clear();
 
@@ -1482,6 +1482,10 @@ velox::core::PlanNodePtr ToVelox::makeScan(
           scanId, outputType, tableHandle, assignments);
 
   relationOpToNodeId_.insert_or_assign(&scan, scanId);
+
+  if (scan.baseTable->sampledPercentage.has_value()) {
+    fragment.sampledScans.emplace(scanId, *scan.baseTable->sampledPercentage);
+  }
 
   if (filter != nullptr) {
     result =

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(
   SubfieldTest.cpp
   SubqueryTest.cpp
   SyntacticJoinOrderTest.cpp
+  TableSampleTest.cpp
   FeatureGen.cpp
   Genies.cpp
   BucketedExecutionPlanTest.cpp

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -831,31 +831,6 @@ TEST_F(PlanTest, values) {
   }
 }
 
-TEST_F(PlanTest, tablesample) {
-  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
-
-  auto makeLogicalPlan = [&](double percentage) {
-    return lp::PlanBuilder(makeContext())
-        .tableScan("t")
-        .sample(percentage, lp::SampleNode::SampleMethod::kBernoulli)
-        .build();
-  };
-
-  {
-    auto plan = toSingleNodePlan(makeLogicalPlan(10));
-
-    auto matcher = matchScan("t").filter("rand() < 0.1").build();
-    AXIOM_ASSERT_PLAN(plan, matcher);
-  }
-
-  {
-    auto plan = toSingleNodePlan(makeLogicalPlan(100));
-
-    auto matcher = matchScan("t").build();
-    AXIOM_ASSERT_PLAN(plan, matcher);
-  }
-}
-
 TEST_F(PlanTest, limitBeforeProject) {
   testConnector_->addTable("t", ROW({"a", "b"}, {INTEGER(), INTEGER()}));
   {

--- a/axiom/optimizer/tests/TableSampleTest.cpp
+++ b/axiom/optimizer/tests/TableSampleTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class TableSampleTest : public test::QueryTestBase {
+ protected:
+  lp::LogicalPlanNodePtr parseSampledScan(const std::string& sample) {
+    return parseSelect(
+        "SELECT * FROM t TABLESAMPLE " + sample, kTestConnectorId);
+  }
+};
+
+TEST_F(TableSampleTest, bernoulli) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  // BERNOULLI samples each row independently, lowered to filter(rand() < p).
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSampledScan("BERNOULLI (10)")),
+      matchScan("t").filter("rand() < 0.1").build());
+
+  // 100% is a no-op passthrough.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSampledScan("BERNOULLI (100)")),
+      matchScan("t").build());
+
+  // 0% produces an empty result.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSampledScan("BERNOULLI (0)")),
+      matchValues().build());
+}
+
+TEST_F(TableSampleTest, system) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  // Returns the single fragment's plan node and its sampled-scan map.
+  auto planSampled = [&](const std::string& sample) {
+    auto result =
+        planVelox(parseSampledScan(sample), {.numWorkers = 1, .numDrivers = 1});
+    EXPECT_EQ(result.plan->fragments().size(), 1);
+    const auto& fragment = result.plan->fragments().at(0);
+    return std::make_pair(fragment.fragment.planNode, fragment.sampledScans);
+  };
+
+  // SYSTEM samples whole splits, so the percentage rides on the scan's split
+  // generation with no per-row filter.
+  {
+    const auto& [plan, sampledScans] = planSampled("SYSTEM (50)");
+    AXIOM_ASSERT_PLAN(plan, matchScan("t").build());
+    ASSERT_EQ(sampledScans.size(), 1);
+    EXPECT_EQ(sampledScans.begin()->second, 50);
+  }
+
+  // 100% is a no-op passthrough: a plain scan with nothing sampled.
+  {
+    const auto& [plan, sampledScans] = planSampled("SYSTEM (100)");
+    AXIOM_ASSERT_PLAN(plan, matchScan("t").build());
+    EXPECT_TRUE(sampledScans.empty());
+  }
+
+  // 0% produces an empty result: no scan, nothing sampled.
+  {
+    const auto& [plan, sampledScans] = planSampled("SYSTEM (0)");
+    AXIOM_ASSERT_PLAN(plan, matchValues().build());
+    EXPECT_TRUE(sampledScans.empty());
+  }
+}
+
+TEST_F(TableSampleTest, explainShowsSampleRate) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  auto explain = [&](const std::string& sample) {
+    return planVelox(
+               parseSampledScan(sample), {.numWorkers = 1, .numDrivers = 1})
+        .plan->toString();
+  };
+
+  EXPECT_EQ(
+      explain("SYSTEM (50)"),
+      "Fragment 0: fragment1 SINGLE:\n"
+      "-- TableScan[0][\"default\".\"t\"] -> a:INTEGER, b:INTEGER\n"
+      "   sample: 50%\n\n");
+
+  // A fractional rate in scientific notation is accepted.
+  EXPECT_EQ(
+      explain("SYSTEM (1E-1)"),
+      "Fragment 0: fragment1 SINGLE:\n"
+      "-- TableScan[0][\"default\".\"t\"] -> a:INTEGER, b:INTEGER\n"
+      "   sample: 0.1%\n\n");
+}
+
+TEST_F(TableSampleTest, sampledCardinality) {
+  testConnector_->addTable("big", ROW({"bk", "bv"}, BIGINT()))
+      ->setStats(100'000, {{"bk", {.numDistinct = 100'000}}});
+  testConnector_->addTable("small", ROW({"sk", "sv"}, BIGINT()))
+      ->setStats(1'000, {{"sk", {.numDistinct = 1'000}}});
+
+  auto planSingleNode = [&](const std::string& big) {
+    return toSingleNodePlan(parseSelect(
+        "SELECT * FROM " + big + " JOIN small ON bk = sk", kTestConnectorId));
+  };
+
+  // Unsampled, 'small' (1K rows) is the smaller side.
+  AXIOM_ASSERT_PLAN(
+      planSingleNode("big"),
+      matchScan("big").hashJoinInner(matchScan("small").build()).build());
+
+  // Sampling 'big' to 0.5% (~500 rows) makes it the smaller side.
+  AXIOM_ASSERT_PLAN(
+      planSingleNode("big TABLESAMPLE SYSTEM (0.5)"),
+      matchScan("small").hashJoinInner(matchScan("big").build()).build());
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -64,7 +64,11 @@ std::shared_ptr<connector::SplitSource>
 SimpleSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& /* session */,
     const velox::core::TableScanNode& scan,
-    const std::shared_ptr<connector::PartitionType>& /*partitionType*/) {
+    const std::shared_ptr<connector::PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported for pre-materialized splits");
   auto it = nodeSplitMap_.find(scan.id());
   if (it == nodeSplitMap_.end()) {
     VELOX_FAIL("Splits are not provided for scan {}", scan.id());
@@ -76,7 +80,8 @@ std::shared_ptr<connector::SplitSource>
 ConnectorSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
     const velox::core::TableScanNode& scan,
-    const std::shared_ptr<connector::PartitionType>& partitionType) {
+    const std::shared_ptr<connector::PartitionType>& partitionType,
+    std::optional<double> samplePercentage) {
   const auto& handle = scan.tableHandle();
   auto metadata =
       connector::ConnectorMetadataRegistry::get(handle->connectorId());
@@ -99,7 +104,12 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
-      session, handle, partitions, partitionType, runtimeStats_);
+      session,
+      handle,
+      partitions,
+      partitionType,
+      samplePercentage,
+      runtimeStats_);
 }
 
 namespace {
@@ -468,8 +478,10 @@ void LocalRunner::start() {
 std::shared_ptr<connector::SplitSource> LocalRunner::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
     const velox::core::TableScanNode& scan,
-    const std::shared_ptr<connector::PartitionType>& partitionType) {
-  return splitSourceFactory_->splitSourceForScan(session, scan, partitionType);
+    const std::shared_ptr<connector::PartitionType>& partitionType,
+    std::optional<double> samplePercentage) {
+  return splitSourceFactory_->splitSourceForScan(
+      session, scan, partitionType, samplePercentage);
 }
 
 void LocalRunner::cancelTasks() {
@@ -734,10 +746,16 @@ void LocalRunner::makeStages(
             it != fragment.groupedNodes.end()) {
           partitionType = it->second;
         }
+        std::optional<double> samplePercentage;
+        if (auto it = fragment.sampledScans.find(scan->id());
+            it != fragment.sampledScans.end()) {
+          samplePercentage = it->second;
+        }
         auto source = splitSourceForScan(
             session_->toConnectorSession(scan->tableHandle()->connectorId()),
             *scan,
-            partitionType);
+            partitionType,
+            samplePercentage);
         splitScope_.add(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -40,11 +40,14 @@ class SplitSourceFactory {
   /// Returns a splitSource for one TableScan across all Tasks of
   /// the fragment. The source will be invoked to produce splits for
   /// each individual worker running the scan. When 'partitionType' is
-  /// non-null, emitted Splits are tagged with a groupId.
+  /// non-null, emitted Splits are tagged with a groupId. When
+  /// 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
+  /// split with that probability.
   virtual std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) = 0;
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) = 0;
 };
 
 class SimpleSplitSourceFactory : public SplitSourceFactory {
@@ -59,7 +62,8 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) override;
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override;
 
  private:
   folly::F14FastMap<
@@ -77,7 +81,8 @@ class ConnectorSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) override;
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override;
 
  protected:
   QueryRuntimeStats& runtimeStats_;
@@ -199,7 +204,8 @@ class LocalRunner : public Runner,
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType);
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage);
 
   // Aggregates the live per-fragment task stats. This is the in-progress
   // snapshot returned by stats() before the run completes. Caller must hold

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -72,9 +72,12 @@ class GatedSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) override {
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override {
     return std::make_shared<GatedSplitSource>(
-        inner_.splitSourceForScan(session, scan, partitionType), gate_);
+        inner_.splitSourceForScan(
+            session, scan, partitionType, samplePercentage),
+        gate_);
   }
 
  private:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/138


TABLESAMPLE SYSTEM previously failed to plan:

    SELECT * FROM t TABLESAMPLE SYSTEM (10)

    SYSTEM sampling is not supported yet

It now runs as split-level sampling: the connector emits each split with the sample probability during split enumeration, so unselected splits are never produced. That is the point of SYSTEM — BERNOULLI keeps each row with rand() < p, while SYSTEM skips whole splits.

The rate travels from the scan to execution through a new ExecutableFragment::sampledScans map, which the runner passes to ConnectorSplitManager::getSplitSource. The optimizer resolves the 0 and 100 endpoints itself (empty result and passthrough), so a connector only ever sees a rate in (0, 100), and a connector that does not implement sampling fails rather than ignoring it. EXPLAIN shows the rate under the sampled scan.

The rate also feeds cost estimation: a sampled scan's cardinality is scaled by the rate and its column NDVs are capped at the sampled row count, so join ordering and build-side selection treat a heavily-sampled table as small.

SYSTEM needs a single table scan to sample. Over a join or other multi-source input it fails rather than falling back to per-row sampling — the cost SYSTEM exists to avoid.

bypass-github-export-checks

Reviewed By: amitkdutta

Differential Revision: D112036900
