### PR TITLE
fix(parser): Honor CREATE TABLE LIKE INCLUDING PROPERTIES

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -108,6 +108,13 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
     return result.results[0];
   }
 
+  // Runs 'sql', which must return a single row and a single column, and returns
+  // that value.
+  template <typename T>
+  T fetchSingleValue(std::string_view sql) {
+    return fetchSingleRow(sql)->childAt(0)->variantAt(0).value<T>();
+  }
+
   void assertSchemas(const std::vector<std::string>& expected) {
     auto result = run("SHOW SCHEMAS");
     ASSERT_FALSE(result.message.has_value());
@@ -950,8 +957,7 @@ TEST_F(SqlQueryRunnerTest, showTables) {
 TEST_F(SqlQueryRunnerTest, showCreateTable) {
   {
     run("CREATE TABLE t1 (id INTEGER, name VARCHAR)");
-    auto row = fetchSingleRow("SHOW CREATE TABLE t1");
-    auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+    auto ddl = fetchSingleValue<std::string>("SHOW CREATE TABLE t1");
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t1\" (\n"
@@ -966,8 +972,7 @@ TEST_F(SqlQueryRunnerTest, showCreateTable) {
     // CREATE TABLE statement.
     run("CREATE TABLE t2 (a INTEGER, b VARCHAR) "
         "WITH (hidden = ARRAY['h1', 'h2'])");
-    auto row = fetchSingleRow("SHOW CREATE TABLE t2");
-    auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+    auto ddl = fetchSingleValue<std::string>("SHOW CREATE TABLE t2");
     EXPECT_EQ(
         ddl,
         "CREATE TABLE test.\"default\".\"t2\" (\n"
@@ -990,8 +995,7 @@ TEST_F(SqlQueryRunnerTest, showCreateView) {
       ROW({"a", "b"}, {INTEGER(), VARCHAR()}),
       "SELECT 1 AS a, 'x' AS b");
 
-  auto row = fetchSingleRow("SHOW CREATE VIEW v1");
-  auto ddl = row->childAt(0)->variantAt(0).value<std::string>();
+  auto ddl = fetchSingleValue<std::string>("SHOW CREATE VIEW v1");
   EXPECT_EQ(
       ddl,
       "CREATE VIEW test.\"default\".\"v1\" AS\n"
@@ -999,6 +1003,41 @@ TEST_F(SqlQueryRunnerTest, showCreateView) {
 
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       run("SHOW CREATE VIEW no_such_view"), "View not found");
+}
+
+TEST_F(SqlQueryRunnerTest, tableSampleSystem) {
+  // One split per appended row vector, so sampling drops whole splits.
+  testConnector_->addTable("sampled", ROW("x", INTEGER()));
+  auto vector = makeRowVector({makeFlatVector<int32_t>({1})});
+  constexpr int64_t kNumSplits = 1000;
+  for (int64_t i = 0; i < kNumSplits; ++i) {
+    testConnector_->appendData("sampled", vector);
+  }
+
+  auto sample = [&](double percentage) {
+    return fetchSingleValue<int64_t>(fmt::format(
+        "SELECT count(*) FROM sampled TABLESAMPLE SYSTEM ({})", percentage));
+  };
+
+  EXPECT_EQ(
+      fetchSingleValue<int64_t>("SELECT count(*) FROM sampled"), kNumSplits);
+
+  // 0% produces an empty result; 100% is a no-op passthrough.
+  EXPECT_EQ(sample(0), 0);
+  EXPECT_EQ(sample(100), kNumSplits);
+
+  // Intermediate rates keep some but not all splits. Counts are exact because
+  // the split coin flip is deterministically seeded.
+  EXPECT_EQ(sample(0.1), 2);
+  EXPECT_EQ(sample(1), 10);
+  EXPECT_EQ(sample(20), 176);
+  EXPECT_EQ(sample(50), 493);
+
+  // SYSTEM sampling has no single split source to sample over a join.
+  VELOX_ASSERT_THROW(
+      run("SELECT count(*) FROM (SELECT a.x FROM sampled a, sampled b) "
+          "TABLESAMPLE SYSTEM (50)"),
+      "TABLESAMPLE SYSTEM is only supported directly over a table");
 }
 
 TEST_F(SqlQueryRunnerTest, generateQueryIdDefault) {

--- a/axiom/connectors/ConnectorSplitManager.h
+++ b/axiom/connectors/ConnectorSplitManager.h
@@ -125,11 +125,18 @@ class ConnectorSplitManager {
   /// When 'partitionType' is non-null, the connector tags each emitted Split
   /// with a groupId in [0, partitionType->numPartitions()). Pass 'nullptr'
   /// for the non-bucketed case.
+  ///
+  /// When 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
+  /// split with that probability, in the open interval (0, 100); the caller
+  /// handles the 0 and 100 endpoints. The sampling happens during split
+  /// enumeration so unselected splits are never produced. A connector that does
+  /// not support sampling must fail rather than ignore it.
   virtual std::shared_ptr<SplitSource> getSplitSource(
       const ConnectorSessionPtr& session,
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) = 0;
 };
 

--- a/axiom/connectors/file/core/FileConnectorMetadata.cpp
+++ b/axiom/connectors/file/core/FileConnectorMetadata.cpp
@@ -96,7 +96,11 @@ FileConnectorMetadata::SplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   auto* fileHandle = dynamic_cast<const FileTableHandle*>(tableHandle.get());
   VELOX_CHECK_NOT_NULL(fileHandle, "Expected FileTableHandle");
   // The file list was resolved once during planning (see findTable); reuse it

--- a/axiom/connectors/file/core/FileConnectorMetadata.h
+++ b/axiom/connectors/file/core/FileConnectorMetadata.h
@@ -81,6 +81,7 @@ class FileConnectorMetadata : public ConnectorMetadata {
         const velox::connector::ConnectorTableHandlePtr& tableHandle,
         const std::vector<PartitionHandlePtr>& partitions,
         const std::shared_ptr<PartitionType>& partitionType,
+        std::optional<double> samplePercentage,
         QueryRuntimeStats& runtimeStats) override;
   };
 

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -321,7 +321,11 @@ std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& partitionType,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   // Since there are only unpartitioned tables now, always makes a SplitSource
   // that goes over all the files in the handle's layout.
   auto metadata = ConnectorMetadataRegistry::get(tableHandle->connectorId());

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -77,6 +77,7 @@ class LocalHiveSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/system/SystemConnectorMetadata.cpp
+++ b/axiom/connectors/system/SystemConnectorMetadata.cpp
@@ -149,7 +149,11 @@ std::shared_ptr<SplitSource> SystemSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   return std::make_shared<SystemSplitSource>(tableHandle->connectorId());
 }
 

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -118,6 +118,7 @@ class SystemSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -340,7 +340,12 @@ TEST_F(SystemConnectorMetadataTest, splitSource) {
 
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
+      session,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      /*samplePercentage=*/std::nullopt,
+      noopStats);
   ASSERT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -17,6 +17,7 @@
 #include "axiom/connectors/tests/TestConnector.h"
 
 #include <algorithm>
+#include <random>
 #include <utility>
 
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
@@ -454,11 +455,13 @@ TestSplitManager::co_listPartitions(
 }
 
 std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
-    const ConnectorSessionPtr& /*session*/,
+    const ConnectorSessionPtr& session,
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& partitions,
     const std::shared_ptr<PartitionType>& partitionType,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_CHECK_NOT_NULL(session);
   const auto& testTable = findTestTableForHandle(tableHandle);
 
   std::vector<size_t> dataIndices;
@@ -487,6 +490,30 @@ std::shared_ptr<SplitSource> TestSplitManager::getSplitSource(
       dataIndices.push_back(i);
     }
   }
+
+  if (samplePercentage.has_value()) {
+    // Drop whole splits (one per data index) at enumeration time, so unselected
+    // splits are never produced.
+    const bool bucketed = !dataBucketIds.empty();
+
+    const auto seed = folly::to<uint32_t>(
+        session->property(TestConfigProvider::kSampleSeed).value());
+    std::mt19937 rng(seed);
+    std::bernoulli_distribution keep(*samplePercentage / 100.0);
+    std::vector<size_t> sampledIndices;
+    std::vector<int32_t> sampledBucketIds;
+    for (size_t i = 0; i < dataIndices.size(); ++i) {
+      if (keep(rng)) {
+        sampledIndices.push_back(dataIndices[i]);
+        if (bucketed) {
+          sampledBucketIds.push_back(dataBucketIds[i]);
+        }
+      }
+    }
+    dataIndices = std::move(sampledIndices);
+    dataBucketIds = std::move(sampledBucketIds);
+  }
+
   return std::make_shared<TestSplitSource>(
       tableHandle->connectorId(),
       std::move(dataIndices),

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -300,6 +300,7 @@ class TestSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 
@@ -726,6 +727,10 @@ class TestConfigProvider : public velox::config::ConfigProvider {
   /// verify a session property reaches connector split-generation.
   static constexpr const char* kListPartitionsError = "list_partitions_error";
 
+  /// Seed for the TABLESAMPLE SYSTEM split coin flip. Defaults to a fixed
+  /// value so sampled split sets are reproducible across test runs.
+  static constexpr const char* kSampleSeed = "sample_seed";
+
   std::vector<velox::config::ConfigProperty> properties() const override {
     return {
         {kCollectColumnStatistics,
@@ -736,6 +741,10 @@ class TestConfigProvider : public velox::config::ConfigProvider {
          velox::config::ConfigPropertyType::kString,
          "",
          "Test-only: if non-empty, co_listPartitions throws this message."},
+        {kSampleSeed,
+         velox::config::ConfigPropertyType::kString,
+         "42",
+         "Test-only: seed for TABLESAMPLE SYSTEM split sampling."},
     };
   }
 

--- a/axiom/connectors/tests/TestConnectorTest.cpp
+++ b/axiom/connectors/tests/TestConnectorTest.cpp
@@ -166,7 +166,12 @@ CO_TEST_F(TestConnectorTest, splitManager) {
       co_await splitManager->co_listPartitions(session, tableHandle);
   QueryRuntimeStats noopStats;
   auto splitSource = splitManager->getSplitSource(
-      session, tableHandle, partitions, /*partitionType=*/nullptr, noopStats);
+      session,
+      tableHandle,
+      partitions,
+      /*partitionType=*/nullptr,
+      /*samplePercentage=*/std::nullopt,
+      noopStats);
   EXPECT_NE(splitSource, nullptr);
 
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;
@@ -631,7 +636,12 @@ CO_TEST_F(TestConnectorTest, bucketedTable) {
       kNumGroups, std::vector<TypePtr>{BIGINT()}, schema);
   QueryRuntimeStats noopStats;
   auto source = splitManager->getSplitSource(
-      session, tableHandle, partitions, partitionType, noopStats);
+      session,
+      tableHandle,
+      partitions,
+      partitionType,
+      /*samplePercentage=*/std::nullopt,
+      noopStats);
   std::vector<int32_t> observedGroupIds;
   while (true) {
     auto batch = co_await source->co_getSplits(/*maxSplitCount=*/16);

--- a/axiom/connectors/tpch/TpchConnectorMetadata.cpp
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.cpp
@@ -88,7 +88,11 @@ std::shared_ptr<SplitSource> TpchSplitManager::getSplitSource(
     const velox::connector::ConnectorTableHandlePtr& tableHandle,
     const std::vector<PartitionHandlePtr>& /*partitions*/,
     const std::shared_ptr<PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage,
     QueryRuntimeStats& /*runtimeStats*/) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported by this connector");
   auto* tpchTableHandle =
       dynamic_cast<const velox::connector::tpch::TpchTableHandle*>(
           tableHandle.get());

--- a/axiom/connectors/tpch/TpchConnectorMetadata.h
+++ b/axiom/connectors/tpch/TpchConnectorMetadata.h
@@ -63,6 +63,7 @@ class TpchSplitManager : public ConnectorSplitManager {
       const velox::connector::ConnectorTableHandlePtr& tableHandle,
       const std::vector<PartitionHandlePtr>& partitions,
       const std::shared_ptr<PartitionType>& partitionType,
+      std::optional<double> samplePercentage,
       QueryRuntimeStats& runtimeStats) override;
 };
 

--- a/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
+++ b/axiom/connectors/tpch/tests/TpchConnectorMetadataTest.cpp
@@ -223,6 +223,7 @@ CO_TEST_F(TpchConnectorMetadataTest, splitGeneration) {
       tableHandle,
       partitions,
       /*partitionType=*/nullptr,
+      /*samplePercentage=*/std::nullopt,
       noopStats);
   CO_ASSERT_NE(splitSource, nullptr);
   std::vector<std::shared_ptr<velox::connector::ConnectorSplit>> splits;

--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -237,6 +237,13 @@ class ConstantExpr : public Expr {
         value_->inferType()->toString());
   }
 
+  /// Creates a constant from 'value', inferring its type.
+  static std::shared_ptr<const ConstantExpr> fromVariant(
+      const velox::Variant& value) {
+    return std::make_shared<ConstantExpr>(
+        value.inferType(), std::make_shared<const velox::Variant>(value));
+  }
+
   const std::shared_ptr<const velox::Variant>& value() const {
     return value_;
   }

--- a/axiom/optimizer/FunctionRegistry.cpp
+++ b/axiom/optimizer/FunctionRegistry.cpp
@@ -170,6 +170,15 @@ bool FunctionRegistry::registerLike(std::string_view name) {
   return true;
 }
 
+bool FunctionRegistry::registerRandom(std::string_view name) {
+  VELOX_USER_CHECK(!name.empty());
+  if (random_.has_value() && random_.value() != name) {
+    return false;
+  }
+  random_ = name;
+  return true;
+}
+
 bool FunctionRegistry::registerRowNumber(std::string_view name) {
   VELOX_USER_CHECK(!name.empty());
   if (rowNumber_.has_value() && rowNumber_.value() != name) {
@@ -408,6 +417,7 @@ void FunctionRegistry::registerPrestoFunctions(std::string_view prefix) {
   registry->registerIsNull(fullName("is_null"));
   registry->registerBetween(fullName("between"));
   registry->registerLike(fullName("like"));
+  registry->registerRandom(fullName("rand"));
   registry->registerRowNumber(fullName("row_number"));
   registry->registerRank(fullName("rank"));
   registry->registerDenseRank(fullName("dense_rank"));

--- a/axiom/optimizer/FunctionRegistry.h
+++ b/axiom/optimizer/FunctionRegistry.h
@@ -421,6 +421,18 @@ class FunctionRegistry {
     return like_;
   }
 
+  /// Registers function 'name' that has semantics of Presto's 'rand', i.e.
+  /// returns a pseudo-random double in [0, 1). Used to implement BERNOULLI
+  /// sampling as a filter.
+  /// @return true if successfully registered, false if a different 'random'
+  /// function is already registered.
+  bool registerRandom(std::string_view name);
+
+  /// Returns the name of the 'random' function.
+  const std::optional<std::string>& random() const {
+    return random_;
+  }
+
   /// Registers function 'name' that has semantics of 'row_number' window
   /// function, i.e. assigns sequential numbers to rows within a partition.
   /// @return true if successfully registered, false if a different
@@ -535,6 +547,7 @@ class FunctionRegistry {
   std::optional<std::string> isNull_;
   std::optional<std::string> between_;
   std::optional<std::string> like_;
+  std::optional<std::string> random_;
 
   // Aggregate functions.
   std::optional<std::string> arbitrary_;

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -437,6 +437,11 @@ std::string MultiFragmentPlan::toString(
                  if (addContext != nullptr) {
                    addContext(planNodeId, indentation, stream);
                  }
+                 if (auto sampled = fragment.sampledScans.find(planNodeId);
+                     sampled != fragment.sampledScans.end()) {
+                   stream << indentation << "sample: " << sampled->second << "%"
+                          << std::endl;
+                 }
                  auto it = planNodeToIndices.find(planNodeId);
                  if (it != planNodeToIndices.end()) {
                    if (it->second.size() == 1) {

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -161,6 +161,11 @@ struct ExecutableFragment {
       velox::core::PlanNodeId,
       std::shared_ptr<connector::PartitionType>>
       groupedNodes;
+
+  /// Sample percentage per scan node for TABLESAMPLE SYSTEM. The split source
+  /// for the scan emits each split with this probability, in the open interval
+  /// (0, 100). Empty when no scan in this fragment is sampled.
+  folly::F14FastMap<velox::core::PlanNodeId, double> sampledScans;
 };
 
 /// Describes a distributed plan handed to a Runner for parallel/distributed

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -220,6 +220,31 @@ void Optimization::estimateAllBaseTableSelectivity(DerivedTable& dt) {
   // Apply results.
   for (auto& [baseTable, taskIndex, columnIndices] : tableTasks) {
     applyFilteredStats(*baseTable, results[taskIndex], columnIndices);
+    applySampleRate(*baseTable);
+  }
+}
+
+void Optimization::applySampleRate(BaseTable& baseTable) {
+  if (!baseTable.sampledPercentage.has_value() ||
+      !baseTable.filteredCardinality.has_value()) {
+    return;
+  }
+
+  // TABLESAMPLE SYSTEM is an additional selectivity on the scan, applied on top
+  // of the filter selectivity. Scale the filtered cardinality, floored at 1 so
+  // downstream estimates never divide by zero.
+  const float sampledCardinality = std::max<float>(
+      1,
+      *baseTable.filteredCardinality * (*baseTable.sampledPercentage / 100.0f));
+  baseTable.filteredCardinality = sampledCardinality;
+
+  // A column cannot have more distinct values than the sampled row count.
+  for (auto* column : baseTable.columns) {
+    const auto& value = column->value();
+    if (value.cardinality.has_value() &&
+        *value.cardinality > sampledCardinality) {
+      const_cast<Value&>(value).cardinality = sampledCardinality;
+    }
   }
 }
 

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -437,6 +437,11 @@ class Optimization {
       const std::optional<connector::FilteredTableStats>& stats,
       const std::vector<size_t>& columnIndices);
 
+  // Folds a TABLESAMPLE SYSTEM rate into 'baseTable' by scaling
+  // filteredCardinality and capping column NDVs at the sampled row count. No-op
+  // when the table is not sampled. Called after applyFilteredStats.
+  void applySampleRate(BaseTable& baseTable);
+
   const OptimizerSessionPtr optimizerSession_;
 
   const runner::RunnerSessionPtr runnerSession_;

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1161,6 +1161,11 @@ struct BaseTable : public TableObject {
 
   SubfieldSet payloadSubfields;
 
+  /// TABLESAMPLE SYSTEM percentage in the open interval (0, 100). When set,
+  /// split generation for this scan emits each split with this probability.
+  /// nullopt = no sampling.
+  std::optional<float> sampledPercentage;
+
   std::optional<float> cardinality() const override {
     return filteredCardinality;
   }

--- a/axiom/optimizer/QueryGraphContext.cpp
+++ b/axiom/optimizer/QueryGraphContext.cpp
@@ -385,6 +385,10 @@ void QueryGraphContext::populateFunctionNames() {
     functionNames_.like = this->toName(like.value());
   }
 
+  if (auto random = registry->random()) {
+    functionNames_.random = this->toName(random.value());
+  }
+
   if (auto rowNumber = registry->rowNumber()) {
     functionNames_.rowNumber = this->toName(rowNumber.value());
   }

--- a/axiom/optimizer/QueryGraphContext.h
+++ b/axiom/optimizer/QueryGraphContext.h
@@ -331,6 +331,7 @@ struct FunctionNames {
   Name isNull{nullptr};
   Name between{nullptr};
   Name like{nullptr};
+  Name random{nullptr};
 
   /// Aggregate functions.
   Name arbitrary{nullptr};

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -4386,24 +4386,45 @@ void ToGraph::applySampling(
   VELOX_USER_CHECK_GE(percentage, 0, "Sampling percentage must be >= 0");
   VELOX_USER_CHECK_LE(percentage, 100, "Sampling percentage must be <= 100");
 
+  // Handle the endpoints here so the sample methods below only deal with a
+  // percentage in the open interval (0, 100).
   if (percentage == 100) {
     makeQueryGraph(*sample.onlyInput(), allowedInDt, orderObservedAbove);
     return;
   }
 
-  // TODO Optimize the case when percentage == 0.
-  // TODO Figure out how to avoid hard-coding "rand" and "lt".
+  if (percentage == 0) {
+    makeEmptyValuesTable(sample);
+    return;
+  }
 
   switch (sample.sampleMethod()) {
-    case lp::SampleNode::SampleMethod::kSystem:
-      VELOX_NYI("SYSTEM sampling is not supported yet");
+    case lp::SampleNode::SampleMethod::kSystem: {
+      // SYSTEM sampling drops whole splits, so it needs a single table scan.
+      // Reject anything else rather than falling back to per-row sampling,
+      // which is the cost SYSTEM exists to avoid.
+      const auto& input = *sample.onlyInput();
+      auto* outerDt = std::exchange(currentDt_, newDt());
+      makeQueryGraph(input, kAllAllowedInDt, orderObservedAbove);
+      VELOX_USER_CHECK(
+          currentDt_->tables.size() == 1 &&
+              currentDt_->tables[0]->is(PlanType::kTableNode),
+          "TABLESAMPLE SYSTEM is only supported directly over a table");
+      const_cast<BaseTable*>(currentDt_->tables[0]->as<BaseTable>())
+          ->sampledPercentage = static_cast<float>(percentage);
+      finalizeDt(sample, outerDt);
       break;
+    }
     case lp::SampleNode::SampleMethod::kBernoulli: {
       // Implement using filter(rand() < percentage / 100.0).
+      VELOX_USER_CHECK_NOT_NULL(
+          functionNames_.random,
+          "BERNOULLI sampling requires a registered 'rand' function");
       auto predicate = std::make_shared<lp::CallExpr>(
           velox::BOOLEAN(),
-          "lt",
-          std::make_shared<lp::CallExpr>(velox::DOUBLE(), "rand"),
+          functionNames_.lt,
+          std::make_shared<lp::CallExpr>(
+              velox::DOUBLE(), functionNames_.random),
           std::make_shared<lp::ConstantExpr>(
               velox::DOUBLE(),
               std::make_shared<velox::Variant>(percentage / 100.0)));

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1427,7 +1427,7 @@ velox::core::TypedExprPtr toAndWithAliases(
 
 velox::core::PlanNodePtr ToVelox::makeScan(
     const TableScan& scan,
-    ExecutableFragment& /*fragment*/,
+    ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& /*stages*/) {
   columnAlteredTypes_.clear();
 
@@ -1482,6 +1482,10 @@ velox::core::PlanNodePtr ToVelox::makeScan(
           scanId, outputType, tableHandle, assignments);
 
   relationOpToNodeId_.insert_or_assign(&scan, scanId);
+
+  if (scan.baseTable->sampledPercentage.has_value()) {
+    fragment.sampledScans.emplace(scanId, *scan.baseTable->sampledPercentage);
+  }
 
   if (filter != nullptr) {
     result =

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -133,6 +133,7 @@ add_executable(
   SubfieldTest.cpp
   SubqueryTest.cpp
   SyntacticJoinOrderTest.cpp
+  TableSampleTest.cpp
   FeatureGen.cpp
   Genies.cpp
   BucketedExecutionPlanTest.cpp

--- a/axiom/optimizer/tests/PlanTest.cpp
+++ b/axiom/optimizer/tests/PlanTest.cpp
@@ -831,31 +831,6 @@ TEST_F(PlanTest, values) {
   }
 }
 
-TEST_F(PlanTest, tablesample) {
-  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
-
-  auto makeLogicalPlan = [&](double percentage) {
-    return lp::PlanBuilder(makeContext())
-        .tableScan("t")
-        .sample(percentage, lp::SampleNode::SampleMethod::kBernoulli)
-        .build();
-  };
-
-  {
-    auto plan = toSingleNodePlan(makeLogicalPlan(10));
-
-    auto matcher = matchScan("t").filter("rand() < 0.1").build();
-    AXIOM_ASSERT_PLAN(plan, matcher);
-  }
-
-  {
-    auto plan = toSingleNodePlan(makeLogicalPlan(100));
-
-    auto matcher = matchScan("t").build();
-    AXIOM_ASSERT_PLAN(plan, matcher);
-  }
-}
-
 TEST_F(PlanTest, limitBeforeProject) {
   testConnector_->addTable("t", ROW({"a", "b"}, {INTEGER(), INTEGER()}));
   {

--- a/axiom/optimizer/tests/TableSampleTest.cpp
+++ b/axiom/optimizer/tests/TableSampleTest.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+
+class TableSampleTest : public test::QueryTestBase {
+ protected:
+  lp::LogicalPlanNodePtr parseSampledScan(const std::string& sample) {
+    return parseSelect(
+        "SELECT * FROM t TABLESAMPLE " + sample, kTestConnectorId);
+  }
+};
+
+TEST_F(TableSampleTest, bernoulli) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  // BERNOULLI samples each row independently, lowered to filter(rand() < p).
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSampledScan("BERNOULLI (10)")),
+      matchScan("t").filter("rand() < 0.1").build());
+
+  // 100% is a no-op passthrough.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSampledScan("BERNOULLI (100)")),
+      matchScan("t").build());
+
+  // 0% produces an empty result.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSampledScan("BERNOULLI (0)")),
+      matchValues().build());
+}
+
+TEST_F(TableSampleTest, system) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  // Returns the single fragment's plan node and its sampled-scan map.
+  auto planSampled = [&](const std::string& sample) {
+    auto result =
+        planVelox(parseSampledScan(sample), {.numWorkers = 1, .numDrivers = 1});
+    EXPECT_EQ(result.plan->fragments().size(), 1);
+    const auto& fragment = result.plan->fragments().at(0);
+    return std::make_pair(fragment.fragment.planNode, fragment.sampledScans);
+  };
+
+  // SYSTEM samples whole splits, so the percentage rides on the scan's split
+  // generation with no per-row filter.
+  {
+    const auto& [plan, sampledScans] = planSampled("SYSTEM (50)");
+    AXIOM_ASSERT_PLAN(plan, matchScan("t").build());
+    ASSERT_EQ(sampledScans.size(), 1);
+    EXPECT_EQ(sampledScans.begin()->second, 50);
+  }
+
+  // 100% is a no-op passthrough: a plain scan with nothing sampled.
+  {
+    const auto& [plan, sampledScans] = planSampled("SYSTEM (100)");
+    AXIOM_ASSERT_PLAN(plan, matchScan("t").build());
+    EXPECT_TRUE(sampledScans.empty());
+  }
+
+  // 0% produces an empty result: no scan, nothing sampled.
+  {
+    const auto& [plan, sampledScans] = planSampled("SYSTEM (0)");
+    AXIOM_ASSERT_PLAN(plan, matchValues().build());
+    EXPECT_TRUE(sampledScans.empty());
+  }
+}
+
+TEST_F(TableSampleTest, explainShowsSampleRate) {
+  testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
+
+  auto explain = [&](const std::string& sample) {
+    return planVelox(
+               parseSampledScan(sample), {.numWorkers = 1, .numDrivers = 1})
+        .plan->toString();
+  };
+
+  EXPECT_EQ(
+      explain("SYSTEM (50)"),
+      "Fragment 0: fragment1 SINGLE:\n"
+      "-- TableScan[0][\"default\".\"t\"] -> a:INTEGER, b:INTEGER\n"
+      "   sample: 50%\n\n");
+
+  // A fractional rate in scientific notation is accepted.
+  EXPECT_EQ(
+      explain("SYSTEM (1E-1)"),
+      "Fragment 0: fragment1 SINGLE:\n"
+      "-- TableScan[0][\"default\".\"t\"] -> a:INTEGER, b:INTEGER\n"
+      "   sample: 0.1%\n\n");
+}
+
+TEST_F(TableSampleTest, sampledCardinality) {
+  testConnector_->addTable("big", ROW({"bk", "bv"}, BIGINT()))
+      ->setStats(100'000, {{"bk", {.numDistinct = 100'000}}});
+  testConnector_->addTable("small", ROW({"sk", "sv"}, BIGINT()))
+      ->setStats(1'000, {{"sk", {.numDistinct = 1'000}}});
+
+  auto planSingleNode = [&](const std::string& big) {
+    return toSingleNodePlan(parseSelect(
+        "SELECT * FROM " + big + " JOIN small ON bk = sk", kTestConnectorId));
+  };
+
+  // Unsampled, 'small' (1K rows) is the smaller side.
+  AXIOM_ASSERT_PLAN(
+      planSingleNode("big"),
+      matchScan("big").hashJoinInner(matchScan("small").build()).build());
+
+  // Sampling 'big' to 0.5% (~500 rows) makes it the smaller side.
+  AXIOM_ASSERT_PLAN(
+      planSingleNode("big TABLESAMPLE SYSTEM (0.5)"),
+      matchScan("small").hashJoinInner(matchScan("big").build()).build());
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/TableSampleTest.cpp
+++ b/axiom/optimizer/tests/TableSampleTest.cpp
@@ -18,6 +18,7 @@
 #include <gtest/gtest.h>
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 
 namespace facebook::axiom::optimizer {
 namespace {
@@ -25,15 +26,21 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class TableSampleTest : public test::QueryTestBase {
+class TableSampleTest : public test::QueryTestBase,
+                        public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+    useV2_ = GetParam();
+  }
+
   lp::LogicalPlanNodePtr parseSampledScan(const std::string& sample) {
     return parseSelect(
         "SELECT * FROM t TABLESAMPLE " + sample, kTestConnectorId);
   }
 };
 
-TEST_F(TableSampleTest, bernoulli) {
+TEST_P(TableSampleTest, bernoulli) {
   testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
 
   // BERNOULLI samples each row independently, lowered to filter(rand() < p).
@@ -52,7 +59,7 @@ TEST_F(TableSampleTest, bernoulli) {
       matchValues().build());
 }
 
-TEST_F(TableSampleTest, system) {
+TEST_P(TableSampleTest, system) {
   testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
 
   // Returns the single fragment's plan node and its sampled-scan map.
@@ -86,9 +93,18 @@ TEST_F(TableSampleTest, system) {
     AXIOM_ASSERT_PLAN(plan, matchValues().build());
     EXPECT_TRUE(sampledScans.empty());
   }
+
+  // SYSTEM needs a single scan to sample; a non-scan source fails.
+  VELOX_ASSERT_THROW(
+      planVelox(
+          parseSelect(
+              "SELECT * FROM (VALUES (1)) AS v (x) TABLESAMPLE SYSTEM (50)",
+              kTestConnectorId),
+          {.numWorkers = 1, .numDrivers = 1}),
+      "TABLESAMPLE SYSTEM is only supported directly over a table");
 }
 
-TEST_F(TableSampleTest, explainShowsSampleRate) {
+TEST_P(TableSampleTest, explainShowsSampleRate) {
   testConnector_->addTable("t", ROW({"a", "b"}, INTEGER()));
 
   auto explain = [&](const std::string& sample) {
@@ -111,7 +127,7 @@ TEST_F(TableSampleTest, explainShowsSampleRate) {
       "   sample: 0.1%\n\n");
 }
 
-TEST_F(TableSampleTest, sampledCardinality) {
+TEST_P(TableSampleTest, sampledCardinality) {
   testConnector_->addTable("big", ROW({"bk", "bv"}, BIGINT()))
       ->setStats(100'000, {{"bk", {.numDistinct = 100'000}}});
   testConnector_->addTable("small", ROW({"sk", "sv"}, BIGINT()))
@@ -119,19 +135,24 @@ TEST_F(TableSampleTest, sampledCardinality) {
 
   auto planSingleNode = [&](const std::string& big) {
     return toSingleNodePlan(parseSelect(
-        "SELECT * FROM " + big + " JOIN small ON bk = sk", kTestConnectorId));
+        "SELECT bk, bv, sv FROM " + big + " JOIN small ON bk = sk",
+        kTestConnectorId));
+  };
+
+  auto matchJoin = [&](const std::string& probe, const std::string& build) {
+    return matchScan(probe).hashJoinInner(matchScan(build).build()).build();
   };
 
   // Unsampled, 'small' (1K rows) is the smaller side.
-  AXIOM_ASSERT_PLAN(
-      planSingleNode("big"),
-      matchScan("big").hashJoinInner(matchScan("small").build()).build());
+  AXIOM_ASSERT_PLAN(planSingleNode("big"), matchJoin("big", "small"));
 
   // Sampling 'big' to 0.5% (~500 rows) makes it the smaller side.
   AXIOM_ASSERT_PLAN(
       planSingleNode("big TABLESAMPLE SYSTEM (0.5)"),
-      matchScan("small").hashJoinInner(matchScan("big").build()).build());
+      matchJoin("small", "big"));
 }
+
+AXIOM_INSTANTIATE_V1_V2(TableSampleTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -411,7 +411,7 @@ class Emitter {
   // A fresh producer/consumer fragment with a unique task prefix.
   ExecutableFragment newFragment() {
     return ExecutableFragment{
-        .taskPrefix = fmt::format("fragment{}", fragmentCounter_++)};
+        .taskPrefix = fmt::format("fragment{}", ++fragmentCounter_)};
   }
 
   const OptimizerSession& session_;
@@ -610,6 +610,13 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
   // under grouped execution, tagging the fragment as bucketed.
   if (const auto* partitionType = tablePartitionType(scan)) {
     groupedLeaves_.push_back({scanNode->id(), partitionType});
+  }
+
+  // TABLESAMPLE SYSTEM: the split source emits each split with this
+  // probability. Recorded per scan so split generation can sample.
+  if (scan.baseTable()->sampledPercentage.has_value()) {
+    currentFragment_->sampledScans.emplace(
+        scanNode->id(), *scan.baseTable()->sampledPercentage);
   }
 
   velox::core::PlanNodePtr result = std::move(scanNode);

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -41,6 +41,33 @@ void mergeConstraints(const ConstraintMap& from, ConstraintMap& into) {
   }
 }
 
+// Scales a scan's estimated row count and per-column NDVs by a TABLESAMPLE
+// SYSTEM rate, if one is set. Modeled as a scan-level selectivity, so it
+// applies whether the row count came from connector stats or the base-table
+// fallback.
+void applySampleRate(
+    const BaseTable& baseTable,
+    const Scan* scan,
+    Estimate& estimate) {
+  if (!baseTable.sampledPercentage.has_value() ||
+      !estimate.cardinality.has_value()) {
+    return;
+  }
+
+  const float fraction = *baseTable.sampledPercentage / 100.0f;
+  estimate.cardinality = std::max(1.0f, *estimate.cardinality * fraction);
+
+  // A column cannot have more distinct values than the sampled row count.
+  for (ColumnCP column : scan->outputColumns()) {
+    Value capped = value(estimate.constraints, column);
+    if (!capped.cardinality.has_value() ||
+        *capped.cardinality > *estimate.cardinality) {
+      capped.cardinality = *estimate.cardinality;
+      estimate.constraints.insert_or_assign(column->id(), capped);
+    }
+  }
+}
+
 } // namespace
 
 const Estimate& EstimateProvider::estimate(NodeCP node) {
@@ -89,6 +116,8 @@ Estimate EstimateProvider::compute(NodeCP node) {
         // No base-table statistics: cardinality is unknown.
         result.cardinality = std::nullopt;
       }
+
+      applySampleRate(*baseTable, scan, result);
       return result;
     }
 

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -99,6 +99,30 @@ ExprCP ExprFactory::makeLessThanOrEqual(ExprCP lhs, ExprCP rhs) {
   return makeBooleanCall(name, {lhs, rhs}, /*specialForm=*/false);
 }
 
+ExprCP ExprFactory::makeSamplePredicate(double fraction) {
+  const Name randName = builder_.functionNames().random;
+  VELOX_USER_CHECK_NOT_NULL(
+      randName,
+      "BERNOULLI sampling requires a 'rand' function registered via "
+      "FunctionRegistry::registerRandom; the active dialect did not register "
+      "it");
+  const Name ltName = builder_.functionNames().lt;
+  VELOX_USER_CHECK_NOT_NULL(
+      ltName,
+      "BERNOULLI sampling requires lessThan registered via "
+      "FunctionRegistry::registerLessThan; the active dialect did not register "
+      "it");
+
+  ExprCP randCall = builder_.makeCall(
+      randName,
+      Value(toType(velox::DOUBLE())),
+      /*args=*/{},
+      functionBits(randName, /*specialForm=*/false));
+  ExprCP threshold =
+      builder_.makeLiteral(velox::Variant(fraction), toType(velox::DOUBLE()));
+  return makeBooleanCall(ltName, {randCall, threshold}, /*specialForm=*/false);
+}
+
 ExprCP ExprFactory::makeIsNull(ExprCP arg) {
   const Name name = builder_.functionNames().isNull;
   VELOX_USER_CHECK_NOT_NULL(

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -73,6 +73,11 @@ class ExprFactory {
   /// Builds `lhs <= rhs`.
   ExprCP makeLessThanOrEqual(ExprCP lhs, ExprCP rhs);
 
+  /// Builds the BERNOULLI sampling predicate `rand() < fraction`, where
+  /// 'fraction' is in [0, 1). The `rand()` call is non-deterministic, so it is
+  /// re-evaluated per row.
+  ExprCP makeSamplePredicate(double fraction);
+
   /// Builds `is_null(arg)`. Result is BOOLEAN and is never NULL —
   /// returns `true` when 'arg' is NULL and `false` otherwise.
   ExprCP makeIsNull(ExprCP arg);

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -100,6 +100,20 @@ void collectUsedNamesInPlan(
   }
 }
 
+// Returns the single Scan leaf reached through single-input nodes (Filter,
+// Project, ...), or nullptr if the subtree branches (join, set) or bottoms out
+// in a non-Scan leaf. SYSTEM sampling requires exactly one scan to sample.
+ScanCP soleScan(NodeCP node) {
+  const auto inputs = node->inputs();
+  if (inputs.empty()) {
+    return node->is(NodeType::kScan) ? node->as<Scan>() : nullptr;
+  }
+  if (inputs.size() != 1) {
+    return nullptr;
+  }
+  return soleScan(inputs[0]);
+}
+
 // Collects every `InputReferenceExpr::name` referenced anywhere in `expr`.
 // Used by translate functions to compute the required-set their input must
 // supply, given the expressions the node itself reads. `WindowExpr`,
@@ -404,6 +418,16 @@ class Translator {
       const lp::LimitNode& limit,
       const LpNameSet& required);
   Translated translateSort(const lp::SortNode& sort, const LpNameSet& required);
+  Translated translateSample(
+      const lp::SampleNode& sample,
+      const LpNameSet& required);
+
+  // Returns the constant sample percentage (in [0, 100]) of a SampleNode.
+  double extractSamplePercentage(const logical_plan::Expr& percentage);
+
+  // Returns a zero-row result with 'outputType''s schema.
+  Translated makeEmptyResult(const velox::RowType& outputType);
+
   Translated translateAggregate(
       const lp::AggregateNode& aggregate,
       const LpNameSet& required);
@@ -632,6 +656,8 @@ Translated Translator::translateNode(
       return translateLimit(*node.as<lp::LimitNode>(), required);
     case lp::NodeKind::kSort:
       return translateSort(*node.as<lp::SortNode>(), required);
+    case lp::NodeKind::kSample:
+      return translateSample(*node.as<lp::SampleNode>(), required);
     case lp::NodeKind::kAggregate:
       return translateAggregate(*node.as<lp::AggregateNode>(), required);
     case lp::NodeKind::kValues:
@@ -1118,12 +1144,7 @@ Translated Translator::translateLimit(
   if (limit.count() == 0) {
     // LIMIT 0 returns no rows. Skip translating the input entirely and
     // replace with an empty `Values` carrying the same schema.
-    Scope scope;
-    ColumnVector outputColumns =
-        makeOutputColumns(*limit.outputType(), /*cardinality=*/0, scope);
-    ValuesCP valuesNode =
-        builder_.make<Values>({nullptr, nullptr, std::move(outputColumns)});
-    return {valuesNode, std::move(scope)};
+    return makeEmptyResult(*limit.outputType());
   }
   // Limit is a pass-through with no expressions of its own.
   Translated input = translateNode(*limit.onlyInput(), required);
@@ -1157,6 +1178,72 @@ Translated Translator::translateSort(
   SortCP sortNode = builder_.make<Sort>(
       {currentInput, std::move(orderKeys), std::move(orderTypes)});
   return {sortNode, std::move(input.scope)};
+}
+
+double Translator::extractSamplePercentage(const lp::Expr& percentage) {
+  Scope emptyScope;
+  ExprCP folded =
+      simplifier_.simplify(translateExpr(percentage, emptyScope, nullptr));
+  VELOX_USER_CHECK(
+      folded->is(PlanType::kLiteralExpr),
+      "Sampling percentage must be constant: {}",
+      percentage.toString());
+  const velox::Variant& value = folded->as<Literal>()->literal();
+  VELOX_USER_CHECK(!value.isNull(), "Sampling percentage must not be null");
+  VELOX_USER_CHECK_EQ(
+      value.kind(),
+      velox::TypeKind::DOUBLE,
+      "Sampling percentage must be a double");
+  const double result = value.value<double>();
+  VELOX_USER_CHECK_GE(result, 0, "Sampling percentage must be >= 0");
+  VELOX_USER_CHECK_LE(result, 100, "Sampling percentage must be <= 100");
+  return result;
+}
+
+Translated Translator::makeEmptyResult(const velox::RowType& outputType) {
+  Scope scope;
+  ColumnVector outputColumns =
+      makeOutputColumns(outputType, /*cardinality=*/0, scope);
+  ValuesCP valuesNode =
+      builder_.make<Values>({nullptr, nullptr, std::move(outputColumns)});
+  return {valuesNode, std::move(scope)};
+}
+
+Translated Translator::translateSample(
+    const lp::SampleNode& sample,
+    const LpNameSet& required) {
+  const double percentage = extractSamplePercentage(*sample.percentage());
+
+  // Handle the endpoints here so the switch below only sees a percentage in
+  // the open interval (0, 100).
+  if (percentage == 100) {
+    return translateNode(*sample.onlyInput(), required);
+  }
+  if (percentage == 0) {
+    return makeEmptyResult(*sample.outputType());
+  }
+
+  Translated input = translateNode(*sample.onlyInput(), required);
+
+  switch (sample.sampleMethod()) {
+    case lp::SampleNode::SampleMethod::kSystem: {
+      // SYSTEM sampling drops whole splits, so it needs a single scan to
+      // sample.
+      ScanCP scan = soleScan(input.node);
+      VELOX_USER_CHECK_NOT_NULL(
+          scan, "TABLESAMPLE SYSTEM is only supported directly over a table");
+      const_cast<BaseTable*>(scan->baseTable())->sampledPercentage =
+          static_cast<float>(percentage);
+      return input;
+    }
+    case lp::SampleNode::SampleMethod::kBernoulli: {
+      ExprCP predicate = exprFactory_.makeSamplePredicate(percentage / 100.0);
+      NodeCP filtered =
+          builder_.make<Filter>({input.node, ExprVector{predicate}});
+      return {filtered, std::move(input.scope)};
+    }
+  }
+  VELOX_UNREACHABLE();
 }
 
 Translated Translator::translateAggregate(

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -64,7 +64,11 @@ std::shared_ptr<connector::SplitSource>
 SimpleSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& /* session */,
     const velox::core::TableScanNode& scan,
-    const std::shared_ptr<connector::PartitionType>& /*partitionType*/) {
+    const std::shared_ptr<connector::PartitionType>& /*partitionType*/,
+    std::optional<double> samplePercentage) {
+  VELOX_USER_CHECK(
+      !samplePercentage.has_value(),
+      "SYSTEM sampling is not supported for pre-materialized splits");
   auto it = nodeSplitMap_.find(scan.id());
   if (it == nodeSplitMap_.end()) {
     VELOX_FAIL("Splits are not provided for scan {}", scan.id());
@@ -76,7 +80,8 @@ std::shared_ptr<connector::SplitSource>
 ConnectorSplitSourceFactory::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
     const velox::core::TableScanNode& scan,
-    const std::shared_ptr<connector::PartitionType>& partitionType) {
+    const std::shared_ptr<connector::PartitionType>& partitionType,
+    std::optional<double> samplePercentage) {
   const auto& handle = scan.tableHandle();
   auto metadata =
       connector::ConnectorMetadataRegistry::get(handle->connectorId());
@@ -99,7 +104,12 @@ ConnectorSplitSourceFactory::splitSourceForScan(
       QueryRuntimeStats::kListPartitionsCount, partitions.size());
 
   return splitManager->getSplitSource(
-      session, handle, partitions, partitionType, runtimeStats_);
+      session,
+      handle,
+      partitions,
+      partitionType,
+      samplePercentage,
+      runtimeStats_);
 }
 
 namespace {
@@ -468,8 +478,10 @@ void LocalRunner::start() {
 std::shared_ptr<connector::SplitSource> LocalRunner::splitSourceForScan(
     const connector::ConnectorSessionPtr& session,
     const velox::core::TableScanNode& scan,
-    const std::shared_ptr<connector::PartitionType>& partitionType) {
-  return splitSourceFactory_->splitSourceForScan(session, scan, partitionType);
+    const std::shared_ptr<connector::PartitionType>& partitionType,
+    std::optional<double> samplePercentage) {
+  return splitSourceFactory_->splitSourceForScan(
+      session, scan, partitionType, samplePercentage);
 }
 
 void LocalRunner::cancelTasks() {
@@ -734,10 +746,16 @@ void LocalRunner::makeStages(
             it != fragment.groupedNodes.end()) {
           partitionType = it->second;
         }
+        std::optional<double> samplePercentage;
+        if (auto it = fragment.sampledScans.find(scan->id());
+            it != fragment.sampledScans.end()) {
+          samplePercentage = it->second;
+        }
         auto source = splitSourceForScan(
             session_->toConnectorSession(scan->tableHandle()->connectorId()),
             *scan,
-            partitionType);
+            partitionType,
+            samplePercentage);
         splitScope_.add(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -40,11 +40,14 @@ class SplitSourceFactory {
   /// Returns a splitSource for one TableScan across all Tasks of
   /// the fragment. The source will be invoked to produce splits for
   /// each individual worker running the scan. When 'partitionType' is
-  /// non-null, emitted Splits are tagged with a groupId.
+  /// non-null, emitted Splits are tagged with a groupId. When
+  /// 'samplePercentage' is set (TABLESAMPLE SYSTEM), the source emits each
+  /// split with that probability.
   virtual std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) = 0;
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) = 0;
 };
 
 class SimpleSplitSourceFactory : public SplitSourceFactory {
@@ -59,7 +62,8 @@ class SimpleSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) override;
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override;
 
  private:
   folly::F14FastMap<
@@ -77,7 +81,8 @@ class ConnectorSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) override;
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override;
 
  protected:
   QueryRuntimeStats& runtimeStats_;
@@ -199,7 +204,8 @@ class LocalRunner : public Runner,
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType);
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage);
 
   // Aggregates the live per-fragment task stats. This is the in-progress
   // snapshot returned by stats() before the run completes. Caller must hold

--- a/axiom/runner/tests/ProgressReporterTest.cpp
+++ b/axiom/runner/tests/ProgressReporterTest.cpp
@@ -72,9 +72,12 @@ class GatedSplitSourceFactory : public SplitSourceFactory {
   std::shared_ptr<connector::SplitSource> splitSourceForScan(
       const connector::ConnectorSessionPtr& session,
       const velox::core::TableScanNode& scan,
-      const std::shared_ptr<connector::PartitionType>& partitionType) override {
+      const std::shared_ptr<connector::PartitionType>& partitionType,
+      std::optional<double> samplePercentage) override {
     return std::make_shared<GatedSplitSource>(
-        inner_.splitSourceForScan(session, scan, partitionType), gate_);
+        inner_.splitSourceForScan(
+            session, scan, partitionType, samplePercentage),
+        gate_);
   }
 
  private:

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2404,6 +2404,15 @@ SqlStatementPtr parseCreateTable(
           names.push_back(schema->nameOf(i));
           types.push_back(schema->childAt(i));
         }
+
+        // For INCLUDING PROPERTIES, copy the source table's properties;
+        // try_emplace keeps any already set by an explicit WITH clause.
+        if (likeClause->propertiesOption() ==
+            LikeClause::PropertiesOption::kIncluding) {
+          for (const auto& [key, value] : table->options()) {
+            properties.try_emplace(key, lp::ConstantExpr::fromVariant(value));
+          }
+        }
         break;
       }
       case NodeType::kConstraintSpecification: {

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -296,6 +296,47 @@ TEST_F(DdlParserTest, createTable) {
       "Duplicate property");
 }
 
+TEST_F(DdlParserTest, createTableLikeProperties) {
+  auto metadata =
+      facebook::axiom::connector::ConnectorMetadataRegistry::get(kConnectorId);
+
+  const auto rowType = ROW({"a", "b"}, INTEGER());
+
+  // Register a source table that carries a table property.
+  metadata->createTable(
+      /*session=*/nullptr,
+      facebook::axiom::SchemaTableName{"default", "src"},
+      rowType,
+      /*options=*/
+      {{std::string(
+            facebook::axiom::connector::TestConnectorMetadata::kExplainIo),
+        Variant::array(std::vector<Variant>{Variant("a")})}},
+      /*ifNotExists=*/false,
+      /*explain=*/false);
+
+  // LIKE ... INCLUDING PROPERTIES carries the source table's properties.
+  testCreateTable(
+      "CREATE TABLE copy (LIKE src INCLUDING PROPERTIES)",
+      "copy",
+      rowType,
+      /*properties=*/{{"explain_io", "[\"a\"]"}});
+
+  // An explicit WITH property overrides the inherited one.
+  testCreateTable(
+      "CREATE TABLE copy_override (LIKE src INCLUDING PROPERTIES) "
+      "WITH (explain_io = ARRAY['b'])",
+      "copy_override",
+      rowType,
+      /*properties=*/{{"explain_io", "array_constructor(b)"}});
+
+  // The default (no option) copies columns only, not properties.
+  testCreateTable("CREATE TABLE copy2 (LIKE src)", "copy2", rowType);
+
+  // EXCLUDING PROPERTIES behaves like the default: columns only.
+  testCreateTable(
+      "CREATE TABLE copy3 (LIKE src EXCLUDING PROPERTIES)", "copy3", rowType);
+}
+
 TEST_F(DdlParserTest, dropTable) {
   {
     auto statement = parseSql("DROP TABLE t");


### PR DESCRIPTION
Summary:
CREATE TABLE ... (LIKE src INCLUDING PROPERTIES) silently dropped the source table's properties. The new table kept the source's columns but none of its partitioned_by, bucketing, or format — so a LIKE of a partitioned table produced a non-partitioned table.

For example:

    CREATE TABLE t (a INTEGER) WITH (partitioned_by = ARRAY['ds'])
    CREATE TABLE u (LIKE t INCLUDING PROPERTIES)

left u with no partitioned_by. Now u inherits it.

The LIKE branch of parseCreateTable copies the source table's properties when INCLUDING PROPERTIES is given, with an explicit WITH (...) taking precedence. EXCLUDING PROPERTIES and the default (no option) copy columns only, unchanged.

Differential Revision: D112067704
