### PR TITLE
fix(cli): Commit CREATE TABLE via the write path (#1584)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -321,14 +321,46 @@ connector::TablePtr SqlQueryRunner::createTable(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
   }
 
+  auto session = makeConnectorSession(queryId, statement.connectorId());
   auto table = metadata->createTable(
-      makeConnectorSession(queryId, statement.connectorId()),
+      session,
       statement.tableName(),
       statement.tableSchema(),
       options,
       statement.ifNotExists(),
       explain);
   VELOX_CHECK(table != nullptr || statement.ifNotExists());
+
+  // Some connectors only stage the table in createTable and commit it in
+  // finishWrite. Run an empty create-write so the table is persisted.
+  if (table != nullptr && !explain) {
+    auto handle = metadata->beginWrite(
+        session, table, connector::WriteKind::kCreate, /*explain=*/false);
+    // TODO: Make the commit timeout configurable (e.g. via a DdlOptions).
+    constexpr std::chrono::seconds kCommitTimeout{60};
+    try {
+      // Await the write so the table is committed, and any failure surfaced,
+      // before returning. The row count is unused for an empty create-write.
+      metadata
+          ->finishWrite(
+              session,
+              handle,
+              /*writeResults=*/{},
+              /*groupingKeys=*/nullptr,
+              /*groupStats=*/{})
+          .get(kCommitTimeout);
+    } catch (...) {
+      // Best-effort abort so a failed commit does not leak connector-side
+      // state; await it so an async connector actually runs the abort. The
+      // original error still propagates.
+      try {
+        metadata->abortWrite(session, handle).get(kCommitTimeout);
+      } catch (...) {
+        // Ignore abort failures; the original error is the useful one.
+      }
+      throw;
+    }
+  }
   return table;
 }
 

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -321,6 +321,19 @@ TEST_F(SqlQueryRunnerTest, explainCreateTable) {
   EXPECT_EQ(result.message, R"(CREATE TABLE IF NOT EXISTS test."default"."t")");
 }
 
+TEST_F(SqlQueryRunnerTest, createTableRunsWritePath) {
+  // Connectors that commit a new table in finishWrite (not createTable) rely on
+  // CREATE TABLE running the write path. Inject a finishWrite error to confirm
+  // it runs.
+  run("SET SESSION test.finish_write_error = 'boom from finishWrite'");
+
+  // EXPLAIN does not run the write path, so it does not hit the error.
+  run("EXPLAIN CREATE TABLE t(x int)");
+
+  // A real CREATE runs the write path, surfacing the commit error.
+  VELOX_ASSERT_THROW(run("CREATE TABLE t(x int)"), "boom from finishWrite");
+}
+
 TEST_F(SqlQueryRunnerTest, explainDropTable) {
   // Fails if the table doesn't exist.
   VELOX_ASSERT_THROW(run("EXPLAIN DROP TABLE t"), "Table does not exist");

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -823,11 +823,17 @@ ConnectorWriteHandlePtr TestConnectorMetadata::beginWrite(
 }
 
 RowsFuture TestConnectorMetadata::finishWrite(
-    const ConnectorSessionPtr& /*session*/,
+    const ConnectorSessionPtr& session,
     const ConnectorWriteHandlePtr& /*handle*/,
     const std::vector<velox::RowVectorPtr>& writeResults,
     velox::RowVectorPtr /*groupingKeys*/,
     std::vector<std::vector<ColumnStatistics>> /*groupStats*/) {
+  VELOX_CHECK_NOT_NULL(session);
+  if (auto error = session->property(TestConfigProvider::kFinishWriteError);
+      error.has_value() && !error->empty()) {
+    VELOX_USER_FAIL("{}", *error);
+  }
+
   int64_t rows = 0;
   velox::DecodedVector decoded;
   for (const auto& result : writeResults) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -727,6 +727,11 @@ class TestConfigProvider : public velox::config::ConfigProvider {
   /// verify a session property reaches connector split-generation.
   static constexpr const char* kListPartitionsError = "list_partitions_error";
 
+  /// When non-empty, TestConnectorMetadata::finishWrite throws a user error
+  /// with this value as the message. Used by tests that verify a write reaches
+  /// connector commit.
+  static constexpr const char* kFinishWriteError = "finish_write_error";
+
   /// Seed for the TABLESAMPLE SYSTEM split coin flip. Defaults to a fixed
   /// value so sampled split sets are reproducible across test runs.
   static constexpr const char* kSampleSeed = "sample_seed";
@@ -741,6 +746,10 @@ class TestConfigProvider : public velox::config::ConfigProvider {
          velox::config::ConfigPropertyType::kString,
          "",
          "Test-only: if non-empty, co_listPartitions throws this message."},
+        {kFinishWriteError,
+         velox::config::ConfigPropertyType::kString,
+         "",
+         "Test-only: if non-empty, finishWrite throws this message."},
         {kSampleSeed,
          velox::config::ConfigPropertyType::kString,
          "42",


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/139


CREATE TABLE in the CLI only staged the new table (metadata->createTable) and never committed it. For a connector that persists a newly created table in finishWrite rather than in createTable, the table was silently never created — a following SHOW CREATE TABLE reported it missing.

After staging, the CLI now runs an empty create-write — beginWrite(kCreate) then finishWrite with no data rows — following the connector write contract. EXPLAIN and the IF NOT EXISTS no-op skip it. Connectors that persist in createTable are unaffected: their beginWrite/finishWrite do not re-register the table.

Reviewed By: amitkdutta

Differential Revision: D112068885


