### PR TITLE
feat(exec): Add kRightAnti join type (#1585)

### DIFF
--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -110,6 +110,7 @@ velox::core::JoinType demoteOuterToInner(
     case velox::core::JoinType::kLeftSemiProject:
     case velox::core::JoinType::kRightSemiFilter:
     case velox::core::JoinType::kRightSemiProject:
+    case velox::core::JoinType::kRightAnti:
     case velox::core::JoinType::kAnti:
     case velox::core::JoinType::kCountingAnti:
       return joinType;
@@ -229,6 +230,7 @@ bool canPushLeft(velox::core::JoinType joinType, bool leftOnly) {
     case velox::core::JoinType::kFull:
     case velox::core::JoinType::kRightSemiFilter:
     case velox::core::JoinType::kRightSemiProject:
+    case velox::core::JoinType::kRightAnti:
       return false;
     case velox::core::JoinType::kNumJoinTypes:
       break;
@@ -377,6 +379,7 @@ bool canPushRight(velox::core::JoinType joinType, bool rightOnly) {
     case velox::core::JoinType::kRight:
     case velox::core::JoinType::kRightSemiFilter:
     case velox::core::JoinType::kRightSemiProject:
+    case velox::core::JoinType::kRightAnti:
       return true;
     case velox::core::JoinType::kLeft:
     case velox::core::JoinType::kFull:
@@ -430,9 +433,10 @@ FilterTarget joinFilterTarget(
     case velox::core::JoinType::kAnti:
     case velox::core::JoinType::kCountingAnti:
       return rightOnly ? FilterTarget::kRight : FilterTarget::kKeep;
-    // ...and the left side for right-semi.
+    // ...and the left side for right-semi and right-anti.
     case velox::core::JoinType::kRightSemiFilter:
     case velox::core::JoinType::kRightSemiProject:
+    case velox::core::JoinType::kRightAnti:
       return leftOnly ? FilterTarget::kLeft : FilterTarget::kKeep;
     case velox::core::JoinType::kNumJoinTypes:
       break;


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/velox/pull/18138

Add a `kRightAnti` hash-join type that returns build-side (right) rows with no match on the probe (left) side -- the mirror of `kRightSemiFilter`. This lets an optimizer build the hash table from the smaller input of an anti join: `kAnti(L, R)` (build R) is equivalent to `kRightAnti(R, L)` (build L), a free win when the left side is much smaller than the right.

The implementation reuses the existing unmatched-build-row machinery: `kRightAnti` rides `needRightSideJoin` (probed-flag tracking + spill), HashBuild keeps null keys (a null-keyed build row never matches and so is always returned), and `HashProbe::getBuildSideOutput` emits not-probed rows via `listNotProbedRows` with build-only output (no probe columns). The null-aware (`NOT IN`) variant is rejected by omission from `isNullAwareSupported`, because resolving its three-valued logic for a build row would require materializing the entire streaming probe side.

Implements facebookincubator/velox#17815.

Reviewed By: mbasmanova

Differential Revision: D110210356


