### PR TITLE
fix(optimizer): Prune filter-only columns from query output (#1586)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -551,7 +551,15 @@ PlanAndStats ToVelox::toVeloxPlan(
   }
 
   std::vector<ExecutableFragment> stages;
-  top.fragment.planNode = makeFragment(plan, top, stages);
+  auto rootNode = makeFragment(plan, top, stages);
+
+  // The root fragment passes its input columns through unchanged, so trim it to
+  // the plan's output columns here. Writes are exempt: their root emits write
+  // statistics, not the plan's columns.
+  if (!finishWrite_) {
+    rootNode = maybeTrimColumns(std::move(rootNode), plan);
+  }
+  top.fragment.planNode = std::move(rootNode);
 
   // For the root fragment when no addGather was inserted, apply the
   // optimizer's root groupedLeaves directly to top.groupedNodes so the
@@ -1806,6 +1814,8 @@ velox::core::PlanNodePtr ToVelox::makeWindowInput(
     const ExprVector& partitionKeys,
     ExecutableFragment& fragment,
     std::vector<ExecutableFragment>& stages) {
+  // Trim any rejected-filter columns before the Window so they are not carried
+  // through its sort/partition.
   auto input =
       maybeTrimColumns(makeFragment(op.input(), fragment, stages), op.input());
   if (options_.numDrivers > 1) {

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -281,9 +281,10 @@ class ToVelox {
       std::vector<ExecutableFragment>& stages);
 
   // Adds a ProjectNode to trim extra columns from 'input' if it has more
-  // columns than 'inputOp' expects. This handles Velox operators that pass
-  // through all input columns (e.g., WindowNode) when the input has extra
-  // columns from rejected scan filters.
+  // columns than 'inputOp' expects. A scan with a rejected filter emits the
+  // filter's columns so the FilterNode can evaluate them; consumers that pass
+  // all input columns through (e.g. the root fragment or a WindowNode) would
+  // otherwise leak those columns into the output.
   velox::core::PlanNodePtr maybeTrimColumns(
       velox::core::PlanNodePtr input,
       const RelationOpPtr& inputOp);

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -27,8 +27,14 @@ namespace {
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class TestConnectorQueryTest : public QueryTestBase {
+class TestConnectorQueryTest : public QueryTestBase,
+                               public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    useV2_ = GetParam();
+  }
+
   MultiFragmentPlanPtr appendTableWrite(
       const MultiFragmentPlanPtr& plan,
       const RowTypePtr& schema,
@@ -67,23 +73,39 @@ class TestConnectorQueryTest : public QueryTestBase {
   const MultiFragmentPlan::Options options_{.numWorkers = 1, .numDrivers = 16};
 };
 
-TEST_F(TestConnectorQueryTest, selectFiltered) {
-  auto vector = makeRowVector({"a"}, {makeFlatVector<int64_t>({0, 1, 2})});
-  auto schema = vector->rowType();
+TEST_P(TestConnectorQueryTest, selectFiltered) {
+  auto data = makeRowVector(
+      {"a", "b"},
+      {
+          makeFlatVector<int64_t>({0, 1, 2}),
+          makeFlatVector<int64_t>({0, 10, 20}),
+      });
+  testConnector_->addTable("t", data->rowType())->addData(data);
 
-  testConnector_->addTable("t", schema);
-  testConnector_->appendData("t", vector);
-
-  lp::PlanBuilder::Context context(kTestConnectorId, kDefaultSchema);
-  auto logicalPlan =
-      lp::PlanBuilder(context).tableScan("t").filter("a > 0").build();
   auto expected = makeRowVector({makeFlatVector<int64_t>({1, 2})});
 
-  auto results = runVelox(logicalPlan, options_);
-  exec::test::assertEqualResults(results.results, {expected});
+  // Filter on a selected column.
+  lp::PlanBuilder::Context context(kTestConnectorId, kDefaultSchema);
+  {
+    auto logicalPlan =
+        lp::PlanBuilder(context).tableScan("t", {"a"}).filter("a > 0").build();
+    auto results = runVelox(logicalPlan, options_);
+    exec::test::assertEqualResults(results.results, {expected});
+  }
+
+  // Filter on a column that is not selected: it must not appear in the output.
+  {
+    auto logicalPlan = lp::PlanBuilder(context)
+                           .tableScan("t", {"a", "b"})
+                           .filter("b > 0")
+                           .project({"a"})
+                           .build();
+    auto results = runVelox(logicalPlan, options_);
+    exec::test::assertEqualResults(results.results, {expected});
+  }
 }
 
-TEST_F(TestConnectorQueryTest, writeFiltered) {
+TEST_P(TestConnectorQueryTest, writeFiltered) {
   auto vector = makeRowVector(
       {"b", "c"},
       {makeFlatVector<int64_t>({0, 1, 2}),
@@ -109,6 +131,8 @@ TEST_F(TestConnectorQueryTest, writeFiltered) {
   auto actual = table->data().front();
   velox::test::assertEqualVectors(actual, expected);
 }
+
+AXIOM_INSTANTIATE_V1_V2(TestConnectorQueryTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -754,7 +754,13 @@ velox::core::PlanNodePtr Emitter::emitRoot(
     const ColumnVector& outputColumns,
     const std::vector<std::string>& outputNames) {
   if (isIdentityLayout(*node, outputColumns, outputNames)) {
-    return emit(node);
+    auto result = emit(node);
+    // A scan with a rejected filter emits the filter's columns for the
+    // FilterNode; trim them so they do not leak into the query output.
+    if (result->outputType()->size() > outputColumns.size()) {
+      result = projectToColumns(outputColumns, std::move(result));
+    }
+    return result;
   }
   if (node->is(NodeType::kProject)) {
     return emitRootProject(*node->as<Project>(), outputColumns, outputNames);


### PR DESCRIPTION
Summary:

When a connector rejects a filter, the scan emits the filter's columns so a Filter node can evaluate the predicate. If no operator above the filter selects those columns, they reached the root fragment's output — so `SELECT a FROM t WHERE b = 1`, with `b` not selected and the filter rejected, produced an output that still contained `b`.

Trims the root fragment to the plan's output columns. Writes are exempt: their root fragment emits write statistics, not the plan's columns.

Reviewed By: amitkdutta

Differential Revision: D112149301


