### PR TITLE
feat(optimizer/v2): Add Node::withInputs primitive (#1587)

### DIFF
--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -116,24 +116,24 @@ class Builder {
     return makeLiteral(velox::Variant::null(type->kind()), type);
   }
 
-  /// `Values` that emits every column of its underlying data, i.e. with
-  /// identity channels (see `Values::Key`). Pruning is done only in
-  /// PushdownAndPrunePass, which builds the narrowed channels directly.
+  /// `Values` node carrying zero rows with the given output schema.
+  /// Used to replace subtrees a rewrite proved produce no rows.
+  const Values* makeEmptyValues(ColumnVector outputColumns) {
+    auto channels = identityChannels(outputColumns.size());
+    return make<Values>({/*source=*/nullptr,
+                         /*rows=*/nullptr,
+                         std::move(outputColumns),
+                         std::move(channels)});
+  }
+
+  /// `Values` node carrying arena-folded 'rows' with the given output schema.
   const Values* makeValues(
       const logical_plan::ValuesNode* source,
       const velox::Variant* rows,
       ColumnVector outputColumns) {
-    QGVector<velox::column_index_t> channels(outputColumns.size());
-    std::iota(channels.begin(), channels.end(), 0);
+    auto channels = identityChannels(outputColumns.size());
     return make<Values>(
         {source, rows, std::move(outputColumns), std::move(channels)});
-  }
-
-  /// `Values` node carrying zero rows with the given output schema.
-  /// Used to replace subtrees a rewrite proved produce no rows.
-  const Values* makeEmptyValues(ColumnVector outputColumns) {
-    return makeValues(
-        /*source=*/nullptr, /*rows=*/nullptr, std::move(outputColumns));
   }
 
   /// Interned `Name`s for well-known functions, snapshotted from the
@@ -145,6 +145,14 @@ class Builder {
   }
 
  private:
+  // Builds identity channels `0..numColumns-1` for a `Values::Key` whose output
+  // emits every underlying data column in order.
+  static QGVector<velox::column_index_t> identityChannels(size_t numColumns) {
+    QGVector<velox::column_index_t> channels(numColumns);
+    std::iota(channels.begin(), channels.end(), 0);
+    return channels;
+  }
+
   // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
   // swaps 'args' (and renames to the reverse) when `args[0]` should
   // come second per the canonical order: literal-on-right, lower-id

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -18,6 +18,7 @@
 
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/Builder.h"
 #include "axiom/optimizer/v2/KeyHash.h"
 #include "axiom/optimizer/v2/NodePrinter.h"
 #include "axiom/optimizer/v2/NodeVisitor.h"
@@ -2010,6 +2011,178 @@ bool TableWrite::KeyEq::operator()(const Key& key, const TableWrite* node)
 bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
     const {
   return (*this)(key, node);
+}
+
+NodeCP Scan::withInputs(NodeVector newInputs, Builder& /*builder*/) const {
+  VELOX_CHECK(newInputs.empty(), "Leaf node cannot have inputs: Scan");
+  return this;
+}
+
+NodeCP Values::withInputs(NodeVector newInputs, Builder& /*builder*/) const {
+  VELOX_CHECK(newInputs.empty(), "Leaf node cannot have inputs: Values");
+  return this;
+}
+
+NodeCP Filter::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Filter>({newInputs[0], predicates_});
+}
+
+NodeCP Project::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Project>({newInputs[0], exprs_, outputColumns()});
+}
+
+NodeCP Limit::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Limit>({newInputs[0], offset_, count_});
+}
+
+NodeCP Sort::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Sort>({newInputs[0], orderKeys_, orderTypes_});
+}
+
+NodeCP TopN::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<TopN>(
+      {newInputs[0], orderKeys_, orderTypes_, offset_, count_});
+}
+
+NodeCP Aggregate::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Aggregate>(Aggregate::Key{
+      .input = newInputs[0],
+      .groupingKeys = groupingKeys_,
+      .aggregates = aggregates_,
+      .outputColumns = outputColumns(),
+      .step = step_,
+      .groupId = groupId_,
+      .globalGroupingSets = globalGroupingSets_});
+}
+
+NodeCP GroupId::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<GroupId>(
+      {newInputs[0],
+       groupingKeys_,
+       aggregationInputs_,
+       groupingSets_,
+       groupingKeyColumns_,
+       groupId_,
+       outputColumns()});
+}
+
+NodeCP MarkDistinct::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<MarkDistinct>(
+      {newInputs[0], markers_, distinctKeys_, masks_, outputColumns()});
+}
+
+NodeCP Unnest::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Unnest>(
+      {newInputs[0],
+       unnestExpressions_,
+       replicatedColumns_,
+       unnestColumns_,
+       ordinalityColumn_,
+       outputColumns()});
+}
+
+NodeCP UnionAll::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(
+      newInputs.size(),
+      inputs_.size(),
+      "UnionAll replacement input count must match existing input count");
+  // `legColumns_` reference `Column*`s from the old inputs' output schemas.
+  // Callers replacing an input must preserve every referenced `Column`
+  // identity; the `UnionAll` ctor enforces this.
+  return builder.make<UnionAll>(
+      {std::move(newInputs), legColumns_, outputColumns()});
+}
+
+NodeCP Join::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 2);
+  return builder.make<Join>(
+      {newInputs[0],
+       newInputs[1],
+       joinType_,
+       leftKeys_,
+       rightKeys_,
+       filter_,
+       nullAware_,
+       nullAsValue_,
+       outputColumns()});
+}
+
+NodeCP Window::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Window>(
+      {newInputs[0],
+       functions_,
+       partitionKeys_,
+       orderKeys_,
+       orderTypes_,
+       outputColumns()});
+}
+
+NodeCP TopNRowNumber::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<TopNRowNumber>(
+      {newInputs[0],
+       rankFunction_,
+       partitionKeys_,
+       orderKeys_,
+       orderTypes_,
+       limit_,
+       rankColumn_,
+       outputColumns()});
+}
+
+NodeCP Apply::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 2);
+  return builder.make<Apply>(
+      {newInputs[0],
+       newInputs[1],
+       correlationColumns_,
+       kind_,
+       filter_,
+       enforceSingleRow_,
+       markColumn_,
+       inLhs_,
+       inBodyKey_,
+       includeMarker_,
+       outputColumns()});
+}
+
+NodeCP EnforceSingleRow::withInputs(NodeVector newInputs, Builder& builder)
+    const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<EnforceSingleRow>({newInputs[0]});
+}
+
+NodeCP AssignUniqueId::withInputs(NodeVector newInputs, Builder& builder)
+    const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<AssignUniqueId>({newInputs[0], idColumn_});
+}
+
+NodeCP EnforceDistinct::withInputs(NodeVector newInputs, Builder& builder)
+    const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<EnforceDistinct>(
+      {newInputs[0], distinctKeys_, errorMessage_});
+}
+
+NodeCP Exchange::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Exchange>({newInputs[0], partitioning_});
+}
+
+NodeCP TableWrite::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<TableWrite>({newInputs[0], table_, kind_, columnExprs_});
 }
 
 #define V2_DEFINE_ACCEPT(NodeT)                                               \

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -57,6 +57,7 @@ enum class NodeType : uint8_t {
 
 AXIOM_DECLARE_ENUM_NAME(NodeType);
 
+class Builder;
 class Node;
 class NodeVisitor;
 class NodeVisitorContext;
@@ -126,6 +127,23 @@ class Node : public PlanObject {
   /// node-owned storage; callers must not retain it past the node's
   /// lifetime.
   virtual std::span<const NodeCP> inputs() const = 0;
+
+  /// Returns a canonical node of this kind with `newInputs` replacing the
+  /// current inputs and every other field (output columns, keys, expressions,
+  /// etc.) preserved. Constructed through `builder` so the result participates
+  /// in hash-consing. `newInputs.size()` must equal `inputs().size()`, so a
+  /// leaf must be called with an empty vector and returns `this`.
+  ///
+  /// Preserved fields may reference `Column*` identities from the old inputs
+  /// (predicates, keys, `UnionAll::legColumns`, etc.). The caller is
+  /// responsible for ensuring each `newInputs[i]` still exposes every such
+  /// `Column`. Rewrites that change output-column identity must rebuild the
+  /// parent explicitly rather than going through `withInputs`.
+  ///
+  /// Example:
+  ///
+  ///     NodeCP rebuilt = node->withInputs({newChild}, builder);
+  virtual NodeCP withInputs(NodeVector newInputs, Builder& builder) const = 0;
 
   /// Double-dispatch hook for `NodeVisitor`.
   virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
@@ -199,6 +217,8 @@ class Scan : public Node {
     return {};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -251,6 +271,8 @@ class Filter : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -316,6 +338,8 @@ class Project : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -383,6 +407,8 @@ class Limit : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -440,6 +466,8 @@ class Sort : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -512,6 +540,8 @@ class TopN : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -629,6 +659,8 @@ class Aggregate : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -722,6 +754,8 @@ class GroupId : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -807,6 +841,8 @@ class MarkDistinct : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -881,6 +917,8 @@ class Values : public Node {
   std::span<const NodeCP> inputs() const override {
     return {};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -966,6 +1004,8 @@ class Unnest : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1033,6 +1073,8 @@ class UnionAll : public Node {
   const QGVector<ColumnVector>& legColumns() const {
     return legColumns_;
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1167,6 +1209,8 @@ class Join : public Node {
     return inputs_;
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1262,6 +1306,8 @@ class Window : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1353,6 +1399,8 @@ class TopNRowNumber : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1528,6 +1576,8 @@ class Apply : public Node {
     return inputs_;
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1583,6 +1633,8 @@ class EnforceSingleRow : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1632,6 +1684,8 @@ class AssignUniqueId : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1694,6 +1748,8 @@ class EnforceDistinct : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1750,6 +1806,8 @@ class Exchange : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1815,6 +1873,8 @@ class TableWrite : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
   RelationSetTest.cpp
+  NodeTransformTest.cpp
   TpchPlanTest.cpp
   TpchResultTest.cpp
 )
@@ -36,4 +37,5 @@ target_link_libraries(
   axiom_optimizer_tests_tpch_queries
   velox_exec_test_lib
   GTest::gtest
+  GTest::gmock
 )

--- a/axiom/optimizer/v2/tests/NodeTransformTest.cpp
+++ b/axiom/optimizer/v2/tests/NodeTransformTest.cpp
@@ -1,0 +1,528 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/tests/UnitTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/connectors/Connector.h"
+#include "velox/type/Type.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+struct ReplacementCase {
+  NodeCP original;
+  NodeVector sameInputs;
+  NodeVector replacementInputs;
+};
+
+class NodeTransformTest : public UnitTestBase {
+ protected:
+  void SetUp() override {
+    UnitTestBase::SetUp();
+    testConnector_ =
+        std::make_shared<connector::TestConnector>(kTestConnectorId);
+    velox::connector::registerConnector(testConnector_);
+    connector::ConnectorMetadataRegistry::global().insert(
+        kTestConnectorId, testConnector_->metadata());
+    testConnector_->addTable("t", velox::ROW({"a"}, {velox::BIGINT()}));
+    resolver_ = std::make_unique<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
+    schema_ = std::make_unique<optimizer::Schema>(*resolver_);
+  }
+
+  void TearDown() override {
+    schema_.reset();
+    resolver_.reset();
+    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
+    velox::connector::unregisterConnector(kTestConnectorId);
+    testConnector_.reset();
+    UnitTestBase::TearDown();
+  }
+
+  NodeCP emptyLeaf(std::string_view name) {
+    return builder_->makeEmptyValues(
+        optimizer::ColumnVector{makeColumn(name, velox::BIGINT())});
+  }
+
+  NodeCP replacementLeafWithSameColumns(NodeCP input) {
+    const auto* rows = optimizer::queryCtx()->registerVariant(
+        std::make_unique<velox::Variant>(velox::Variant::array({})));
+    return builder_->makeValues(
+        nullptr, rows, optimizer::ColumnVector{input->outputColumns()});
+  }
+
+  void assertLeafContract(NodeCP leaf, std::string_view error) {
+    EXPECT_THAT(leaf->inputs(), testing::IsEmpty());
+    EXPECT_EQ(leaf->withInputs({}, *builder_), leaf);
+    VELOX_ASSERT_THROW(
+        leaf->withInputs({emptyLeaf("unexpected")}, *builder_), error);
+  }
+
+  void assertNonLeafContract(const ReplacementCase& testCase) {
+    ASSERT_FALSE(testCase.sameInputs.empty());
+    ASSERT_EQ(testCase.sameInputs.size(), testCase.original->inputs().size());
+    ASSERT_EQ(testCase.replacementInputs.size(), testCase.sameInputs.size());
+    EXPECT_EQ(
+        testCase.original->withInputs(testCase.sameInputs, *builder_),
+        testCase.original);
+    NodeCP rebuilt =
+        testCase.original->withInputs(testCase.replacementInputs, *builder_);
+    EXPECT_NE(rebuilt, testCase.original);
+    EXPECT_EQ(rebuilt->nodeType(), testCase.original->nodeType());
+    EXPECT_THAT(
+        rebuilt->inputs(),
+        testing::ElementsAreArray(testCase.replacementInputs));
+    NodeVector wrongArity;
+    if (testCase.sameInputs.size() != 1) {
+      wrongArity.push_back(testCase.sameInputs[0]);
+    }
+    const std::string_view message =
+        testCase.sameInputs.size() == 1 ? "(0 vs. 1)" : "(1 vs. 2)";
+    VELOX_ASSERT_THROW(
+        testCase.original->withInputs(std::move(wrongArity), *builder_),
+        message);
+  }
+
+  optimizer::BaseTable* makeScannableBaseTable() {
+    const auto* schemaTable =
+        schema_->findTable(kTestConnectorId, SchemaTableName{"default", "t"});
+    VELOX_CHECK_NOT_NULL(schemaTable);
+    auto* baseTable = optimizer::make<optimizer::BaseTable>();
+    baseTable->cname = toName("scan_alias");
+    baseTable->schemaTable = schemaTable;
+    baseTable->filteredCardinality = schemaTable->cardinality;
+    return baseTable;
+  }
+
+  static constexpr auto kTestConnectorId = "test";
+  std::shared_ptr<connector::TestConnector> testConnector_;
+  std::unique_ptr<connector::SchemaResolver> resolver_;
+  std::unique_ptr<optimizer::Schema> schema_;
+};
+
+TEST_F(NodeTransformTest, scan) {
+  auto* scan = builder_->make<Scan>(
+      {makeScannableBaseTable(),
+       optimizer::ColumnVector{makeColumn("a", velox::BIGINT())},
+       ExprVector{builder_->makeBoolean(true)}});
+  assertLeafContract(scan, "Leaf node cannot have inputs: Scan");
+}
+
+TEST_F(NodeTransformTest, values) {
+  assertLeafContract(emptyLeaf("a"), "Leaf node cannot have inputs: Values");
+}
+
+TEST_F(NodeTransformTest, filter) {
+  NodeCP input = emptyLeaf("a");
+  auto* original =
+      builder_->make<Filter>({input, ExprVector{builder_->makeBoolean(true)}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, project) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP boolColumn = makeColumn("flag", velox::BOOLEAN());
+  auto* original = builder_->make<Project>(
+      {input,
+       ExprVector{inputColumn, builder_->makeBoolean(true)},
+       optimizer::ColumnVector{inputColumn, boolColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, limit) {
+  NodeCP input = emptyLeaf("a");
+  auto* original = builder_->make<Limit>({input, /*offset=*/17, /*count=*/23});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, sort) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  auto* original = builder_->make<Sort>(
+      {input,
+       ExprVector{inputColumn},
+       optimizer::OrderTypeVector{optimizer::OrderType::kDescNullsLast}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, topN) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  auto* original = builder_->make<TopN>(
+      {input,
+       ExprVector{inputColumn},
+       optimizer::OrderTypeVector{optimizer::OrderType::kDescNullsLast},
+       /*offset=*/11,
+       /*count=*/29});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, aggregate) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP aggregateColumn = makeColumn("sum_a", velox::BIGINT());
+  auto* original = builder_->make<Aggregate>(Aggregate::Key{
+      .input = input,
+      .groupingKeys = ExprVector{inputColumn},
+      .aggregates = AggregateCallVector{builder_->makeAggregate(
+          toName("sum"),
+          optimizer::Value(inputColumn->value().type),
+          ExprVector{inputColumn},
+          optimizer::FunctionSet{},
+          /*isDistinct=*/false,
+          /*condition=*/nullptr,
+          inputColumn->value().type,
+          /*orderKeys=*/{},
+          /*orderTypes=*/{})},
+      .outputColumns = optimizer::ColumnVector{inputColumn, aggregateColumn},
+      .step = AggregateStep::kSingle,
+  });
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, groupId) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP groupColumn = makeColumn("group_a", velox::BIGINT());
+  ColumnCP groupIdColumn = makeColumn("group_id", velox::BIGINT());
+  QGVector<QGVector<int32_t>> groupingSets;
+  groupingSets.push_back(QGVector<int32_t>{0});
+  auto* original = builder_->make<GroupId>(
+      {input,
+       ExprVector{inputColumn},
+       ExprVector{inputColumn},
+       std::move(groupingSets),
+       optimizer::ColumnVector{groupColumn},
+       groupIdColumn,
+       optimizer::ColumnVector{groupColumn, inputColumn, groupIdColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, markDistinct) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP markerColumn = makeColumn("marker", velox::BOOLEAN());
+  auto* original = builder_->make<MarkDistinct>(
+      {input,
+       optimizer::ColumnVector{markerColumn},
+       ExprVector{inputColumn},
+       optimizer::ColumnVector{},
+       optimizer::ColumnVector{inputColumn, markerColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, unnest) {
+  ColumnCP inputColumn = makeColumn("a", velox::BIGINT());
+  ColumnCP boolColumn = makeColumn("flag", velox::BOOLEAN());
+  ColumnCP arrayColumn = makeColumn("items", velox::ARRAY(velox::BIGINT()));
+  NodeCP input = builder_->makeEmptyValues(
+      optimizer::ColumnVector{inputColumn, boolColumn, arrayColumn});
+  ColumnCP unnestColumn = makeColumn("item", velox::BIGINT());
+  ColumnCP ordinalityColumn = makeColumn("ord", velox::BIGINT());
+  QGVector<optimizer::ColumnVector> unnestColumns;
+  unnestColumns.push_back(optimizer::ColumnVector{unnestColumn});
+  auto* original = builder_->make<Unnest>(
+      {input,
+       ExprVector{arrayColumn},
+       optimizer::ColumnVector{inputColumn},
+       std::move(unnestColumns),
+       ordinalityColumn,
+       optimizer::ColumnVector{inputColumn, unnestColumn, ordinalityColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, window) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  WindowFunctions windowFunctions;
+  windowFunctions.push_back(
+      WindowFunction{
+          .call = builder_->makeCall(
+              toName("sum"),
+              optimizer::Value(optimizer::queryCtx()->toType(velox::BIGINT())),
+              ExprVector{inputColumn},
+              optimizer::FunctionSet{}),
+          .frame = optimizer::Frame::wholePartition(),
+          .ignoreNulls = true,
+      });
+  ColumnCP windowColumn = makeColumn("window_sum", velox::BIGINT());
+  auto* original = builder_->make<Window>(
+      {input,
+       std::move(windowFunctions),
+       ExprVector{inputColumn},
+       ExprVector{inputColumn},
+       optimizer::OrderTypeVector{optimizer::OrderType::kAscNullsFirst},
+       optimizer::ColumnVector{inputColumn, windowColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, topNRowNumber) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP rankColumn = makeColumn("rank", velox::BIGINT());
+  auto* original = builder_->make<TopNRowNumber>(
+      {input,
+       TopNRowNumber::RankFunction::kRank,
+       ExprVector{inputColumn},
+       ExprVector{inputColumn},
+       optimizer::OrderTypeVector{optimizer::OrderType::kAscNullsFirst},
+       /*limit=*/7,
+       rankColumn,
+       optimizer::ColumnVector{inputColumn, rankColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, enforceSingleRow) {
+  NodeCP input = emptyLeaf("a");
+  auto* original = builder_->make<EnforceSingleRow>({input});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, assignUniqueId) {
+  NodeCP input = emptyLeaf("a");
+  auto* original = builder_->make<AssignUniqueId>(
+      {input, makeColumn("uid", velox::BIGINT())});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, enforceDistinct) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  auto* original = builder_->make<EnforceDistinct>(
+      {input, ExprVector{inputColumn}, toName("duplicate scalar row")});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, exchange) {
+  NodeCP input = emptyLeaf("a");
+  auto* original = builder_->make<Exchange>(
+      {input,
+       Partitioning{
+           .kind = PartitionKind::kGather,
+           .scope = PropertyScope::kGlobal,
+       }});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, tableWrite) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  auto writeTable =
+      testConnector_->addTable("t_write", velox::ROW({"a"}, {velox::BIGINT()}));
+  auto* original = builder_->make<TableWrite>(
+      {input,
+       writeTable.get(),
+       connector::WriteKind::kInsert,
+       ExprVector{inputColumn}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{input},
+          .replacementInputs =
+              NodeVector{replacementLeafWithSameColumns(input)},
+      });
+}
+
+TEST_F(NodeTransformTest, unionAll) {
+  NodeCP left = emptyLeaf("a");
+  NodeCP right = emptyLeaf("a");
+  NodeCP replacementLeft = replacementLeafWithSameColumns(left);
+  NodeCP replacementRight = replacementLeafWithSameColumns(right);
+  auto* original = builder_->make<UnionAll>(
+      {NodeVector{left, right},
+       QGVector<optimizer::ColumnVector>{
+           optimizer::ColumnVector{left->outputColumns()[0]},
+           optimizer::ColumnVector{right->outputColumns()[0]}},
+       optimizer::ColumnVector{makeColumn("union_out", velox::BIGINT())}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{left, right},
+          .replacementInputs = NodeVector{replacementLeft, replacementRight},
+      });
+}
+
+TEST_F(NodeTransformTest, join) {
+  NodeCP left = emptyLeaf("a");
+  NodeCP right = emptyLeaf("a");
+  NodeCP replacementLeft = replacementLeafWithSameColumns(left);
+  NodeCP replacementRight = replacementLeafWithSameColumns(right);
+  auto* original = builder_->make<Join>(
+      {left,
+       right,
+       velox::core::JoinType::kLeft,
+       ExprVector{left->outputColumns()[0]},
+       ExprVector{right->outputColumns()[0]},
+       ExprVector{builder_->makeBoolean(true)},
+       /*nullAware=*/false,
+       /*nullAsValue=*/false,
+       optimizer::ColumnVector{
+           left->outputColumns()[0], right->outputColumns()[0]}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{left, right},
+          .replacementInputs = NodeVector{replacementLeft, replacementRight},
+      });
+}
+
+TEST_F(NodeTransformTest, apply) {
+  NodeCP left = emptyLeaf("a");
+  NodeCP right = emptyLeaf("a");
+  NodeCP replacementLeft = replacementLeafWithSameColumns(left);
+  NodeCP replacementRight = replacementLeafWithSameColumns(right);
+  ColumnCP includeMarker = makeColumn("include", velox::BOOLEAN());
+  auto* original = builder_->make<Apply>(
+      {left,
+       right,
+       optimizer::ColumnVector{left->outputColumns()[0]},
+       velox::core::JoinType::kLeft,
+       ExprVector{builder_->makeBoolean(true)},
+       /*enforceSingleRow=*/true,
+       /*markColumn=*/nullptr,
+       /*inLhs=*/nullptr,
+       /*inBodyKey=*/nullptr,
+       includeMarker,
+       optimizer::ColumnVector{
+           left->outputColumns()[0],
+           right->outputColumns()[0],
+           includeMarker}});
+  assertNonLeafContract(
+      ReplacementCase{
+          .original = original,
+          .sameInputs = NodeVector{left, right},
+          .replacementInputs = NodeVector{replacementLeft, replacementRight},
+      });
+}
+
+TEST_F(NodeTransformTest, unionAllWrongArity) {
+  NodeCP left = emptyLeaf("a");
+  NodeCP right = emptyLeaf("a");
+  auto* unionAll = builder_->make<UnionAll>(
+      {NodeVector{left, right},
+       QGVector<optimizer::ColumnVector>{
+           optimizer::ColumnVector{left->outputColumns()[0]},
+           optimizer::ColumnVector{right->outputColumns()[0]}},
+       optimizer::ColumnVector{makeColumn("union_out", velox::BIGINT())}});
+
+  VELOX_ASSERT_THROW(
+      unionAll->withInputs(NodeVector{left}, *builder_),
+      "(1 vs. 2) UnionAll replacement input count must match existing input count");
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test


### PR DESCRIPTION
Summary:


Adds a virtual `Node::withInputs(NodeVector, Builder&)` on every v2 IR node — a canonical "clone this node with these children". A caller rewriting a subtree previously had to subclass `NodeRewriter` and override a per-kind hook for every one of the 20+ node kinds, even when the substitution logic was uniform.

Each override forwards its non-input fields to `Builder::make<T>`, so results participate in hash-consing: `node->withInputs(node->inputs(), builder)` returns the same interned pointer. Leaves reject non-empty inputs and return `this` unchanged.

The `rewriteTree(root, builder, callback)` helper this primitive is designed for follows in a separate diff.

Differential Revision: D111926921


