### PR TITLE
refactor(v2): Route NodeRewriter defaults via withInputs (#1588)

### DIFF
--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -116,24 +116,25 @@ class Builder {
     return makeLiteral(velox::Variant::null(type->kind()), type);
   }
 
-  /// `Values` that emits every column of its underlying data, i.e. with
-  /// identity channels (see `Values::Key`). Pruning is done only in
-  /// PushdownAndPrunePass, which builds the narrowed channels directly.
+  /// `Values` node carrying zero rows with the given output schema.
+  /// Used to replace subtrees a rewrite proved produce no rows.
+  const Values* makeEmptyValues(ColumnVector outputColumns) {
+    auto channels = identityChannels(outputColumns.size());
+    return make<Values>({/*source=*/nullptr,
+                         /*rows=*/nullptr,
+                         std::move(outputColumns),
+                         std::move(channels)});
+  }
+
+  /// `Values` node carrying arena-folded 'rows' with the given output schema.
+  /// Fills identity channels (`0..n-1`), i.e. every data column is emitted.
   const Values* makeValues(
       const logical_plan::ValuesNode* source,
       const velox::Variant* rows,
       ColumnVector outputColumns) {
-    QGVector<velox::column_index_t> channels(outputColumns.size());
-    std::iota(channels.begin(), channels.end(), 0);
+    auto channels = identityChannels(outputColumns.size());
     return make<Values>(
         {source, rows, std::move(outputColumns), std::move(channels)});
-  }
-
-  /// `Values` node carrying zero rows with the given output schema.
-  /// Used to replace subtrees a rewrite proved produce no rows.
-  const Values* makeEmptyValues(ColumnVector outputColumns) {
-    return makeValues(
-        /*source=*/nullptr, /*rows=*/nullptr, std::move(outputColumns));
   }
 
   /// Interned `Name`s for well-known functions, snapshotted from the
@@ -145,6 +146,17 @@ class Builder {
   }
 
  private:
+  // Builds identity channels `0..numColumns-1` for a `Values::Key` whose output
+  // emits every underlying data column in order.
+  static QGVector<velox::column_index_t> identityChannels(size_t numColumns) {
+    QGVector<velox::column_index_t> channels;
+    channels.reserve(numColumns);
+    for (velox::column_index_t i = 0; i < numColumns; ++i) {
+      channels.push_back(i);
+    }
+    return channels;
+  }
+
   // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
   // swaps 'args' (and renames to the reverse) when `args[0]` should
   // come second per the canonical order: literal-on-right, lower-id

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -18,6 +18,7 @@
 
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/Builder.h"
 #include "axiom/optimizer/v2/KeyHash.h"
 #include "axiom/optimizer/v2/NodePrinter.h"
 #include "axiom/optimizer/v2/NodeVisitor.h"
@@ -2010,6 +2011,178 @@ bool TableWrite::KeyEq::operator()(const Key& key, const TableWrite* node)
 bool TableWrite::KeyEq::operator()(const TableWrite* node, const Key& key)
     const {
   return (*this)(key, node);
+}
+
+NodeCP Scan::withInputs(NodeVector newInputs, Builder& /*builder*/) const {
+  VELOX_CHECK(newInputs.empty(), "Leaf node cannot have inputs: Scan");
+  return this;
+}
+
+NodeCP Values::withInputs(NodeVector newInputs, Builder& /*builder*/) const {
+  VELOX_CHECK(newInputs.empty(), "Leaf node cannot have inputs: Values");
+  return this;
+}
+
+NodeCP Filter::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Filter>({newInputs[0], predicates_});
+}
+
+NodeCP Project::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Project>({newInputs[0], exprs_, outputColumns()});
+}
+
+NodeCP Limit::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Limit>({newInputs[0], offset_, count_});
+}
+
+NodeCP Sort::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Sort>({newInputs[0], orderKeys_, orderTypes_});
+}
+
+NodeCP TopN::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<TopN>(
+      {newInputs[0], orderKeys_, orderTypes_, offset_, count_});
+}
+
+NodeCP Aggregate::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Aggregate>(Aggregate::Key{
+      .input = newInputs[0],
+      .groupingKeys = groupingKeys_,
+      .aggregates = aggregates_,
+      .outputColumns = outputColumns(),
+      .step = step_,
+      .groupId = groupId_,
+      .globalGroupingSets = globalGroupingSets_});
+}
+
+NodeCP GroupId::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<GroupId>(
+      {newInputs[0],
+       groupingKeys_,
+       aggregationInputs_,
+       groupingSets_,
+       groupingKeyColumns_,
+       groupId_,
+       outputColumns()});
+}
+
+NodeCP MarkDistinct::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<MarkDistinct>(
+      {newInputs[0], markers_, distinctKeys_, masks_, outputColumns()});
+}
+
+NodeCP Unnest::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Unnest>(
+      {newInputs[0],
+       unnestExpressions_,
+       replicatedColumns_,
+       unnestColumns_,
+       ordinalityColumn_,
+       outputColumns()});
+}
+
+NodeCP UnionAll::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(
+      newInputs.size(),
+      inputs_.size(),
+      "UnionAll replacement input count must match existing input count");
+  // `legColumns_` reference `Column*`s from the old inputs' output schemas.
+  // Callers replacing an input must preserve every referenced `Column`
+  // identity; the `UnionAll` ctor enforces this.
+  return builder.make<UnionAll>(
+      {std::move(newInputs), legColumns_, outputColumns()});
+}
+
+NodeCP Join::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 2);
+  return builder.make<Join>(
+      {newInputs[0],
+       newInputs[1],
+       joinType_,
+       leftKeys_,
+       rightKeys_,
+       filter_,
+       nullAware_,
+       nullAsValue_,
+       outputColumns()});
+}
+
+NodeCP Window::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Window>(
+      {newInputs[0],
+       functions_,
+       partitionKeys_,
+       orderKeys_,
+       orderTypes_,
+       outputColumns()});
+}
+
+NodeCP TopNRowNumber::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<TopNRowNumber>(
+      {newInputs[0],
+       rankFunction_,
+       partitionKeys_,
+       orderKeys_,
+       orderTypes_,
+       limit_,
+       rankColumn_,
+       outputColumns()});
+}
+
+NodeCP Apply::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 2);
+  return builder.make<Apply>(
+      {newInputs[0],
+       newInputs[1],
+       correlationColumns_,
+       kind_,
+       filter_,
+       enforceSingleRow_,
+       markColumn_,
+       inLhs_,
+       inBodyKey_,
+       includeMarker_,
+       outputColumns()});
+}
+
+NodeCP EnforceSingleRow::withInputs(NodeVector newInputs, Builder& builder)
+    const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<EnforceSingleRow>({newInputs[0]});
+}
+
+NodeCP AssignUniqueId::withInputs(NodeVector newInputs, Builder& builder)
+    const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<AssignUniqueId>({newInputs[0], idColumn_});
+}
+
+NodeCP EnforceDistinct::withInputs(NodeVector newInputs, Builder& builder)
+    const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<EnforceDistinct>(
+      {newInputs[0], distinctKeys_, errorMessage_});
+}
+
+NodeCP Exchange::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<Exchange>({newInputs[0], partitioning_});
+}
+
+NodeCP TableWrite::withInputs(NodeVector newInputs, Builder& builder) const {
+  VELOX_CHECK_EQ(newInputs.size(), 1);
+  return builder.make<TableWrite>({newInputs[0], table_, kind_, columnExprs_});
 }
 
 #define V2_DEFINE_ACCEPT(NodeT)                                               \

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -57,6 +57,7 @@ enum class NodeType : uint8_t {
 
 AXIOM_DECLARE_ENUM_NAME(NodeType);
 
+class Builder;
 class Node;
 class NodeVisitor;
 class NodeVisitorContext;
@@ -126,6 +127,24 @@ class Node : public PlanObject {
   /// node-owned storage; callers must not retain it past the node's
   /// lifetime.
   virtual std::span<const NodeCP> inputs() const = 0;
+
+  /// Returns a canonical node of this kind with `newInputs` replacing the
+  /// current inputs and every other field (output columns, keys, expressions,
+  /// etc.) preserved. Constructed through `builder` so the result participates
+  /// in hash-consing. `newInputs.size()` must equal `inputs().size()`, so a
+  /// leaf must be called with an empty vector and returns `this`.
+  ///
+  /// Preserved fields may reference `Column*` identities from the old inputs
+  /// (predicates, keys, `UnionAll::legColumns`, etc.). The caller is
+  /// responsible for ensuring each `newInputs[i]` still exposes every such
+  /// `Column`; ctors detect a mismatch on a best-effort basis only. Rewrites
+  /// that change output-column identity must rebuild the parent explicitly
+  /// rather than going through `withInputs`.
+  ///
+  /// Example:
+  ///
+  ///     NodeCP rebuilt = node->withInputs({newChild}, builder);
+  virtual NodeCP withInputs(NodeVector newInputs, Builder& builder) const = 0;
 
   /// Double-dispatch hook for `NodeVisitor`.
   virtual void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
@@ -199,6 +218,8 @@ class Scan : public Node {
     return {};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -251,6 +272,8 @@ class Filter : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -316,6 +339,8 @@ class Project : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -383,6 +408,8 @@ class Limit : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -440,6 +467,8 @@ class Sort : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -512,6 +541,8 @@ class TopN : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -629,6 +660,8 @@ class Aggregate : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -722,6 +755,8 @@ class GroupId : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -807,6 +842,8 @@ class MarkDistinct : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -881,6 +918,8 @@ class Values : public Node {
   std::span<const NodeCP> inputs() const override {
     return {};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -966,6 +1005,8 @@ class Unnest : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1033,6 +1074,8 @@ class UnionAll : public Node {
   const QGVector<ColumnVector>& legColumns() const {
     return legColumns_;
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1167,6 +1210,8 @@ class Join : public Node {
     return inputs_;
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1262,6 +1307,8 @@ class Window : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1353,6 +1400,8 @@ class TopNRowNumber : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1528,6 +1577,8 @@ class Apply : public Node {
     return inputs_;
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1583,6 +1634,8 @@ class EnforceSingleRow : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1632,6 +1685,8 @@ class AssignUniqueId : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1694,6 +1749,8 @@ class EnforceDistinct : public Node {
     return {&input_, 1};
   }
 
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
+
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
 
@@ -1750,6 +1807,8 @@ class Exchange : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;
@@ -1815,6 +1874,8 @@ class TableWrite : public Node {
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
+
+  NodeCP withInputs(NodeVector newInputs, Builder& builder) const override;
 
   void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
       const override;

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -25,22 +25,54 @@ namespace facebook::axiom::optimizer::v2 {
 /// Empty context type for stateless rewriters.
 struct NoContext {};
 
-/// Visitor base for tree-IR rewrite passes. Default implementations
-/// recursively rewrite children and rebuild a node only when a child
-/// changed (identity-equal pointer comparison). Subclasses override the
-/// per-kind hooks they transform.
+/// Visitor base for tree-IR rewrite passes. The default per-kind hooks
+/// rewrite children and rebuild via `Node::withInputs` only when a child
+/// changed. Subclasses override a per-kind `rewriteX` hook to transform that
+/// node kind, or `rewriteNode` to intercept any node before its subtree.
 ///
 /// Stateless passes inherit `NodeRewriter<>`. State-bearing passes
 /// parameterize on a `TContext` that is threaded by reference through
 /// dispatch.
+///
+/// Example — a terminal substitution pass:
+///
+///     class Substituter : public NodeRewriter<> {
+///      protected:
+///       NodeCP rewriteNode(NodeCP node, NoContext& context) override {
+///         return node == target_ ? replacement_
+///                                : NodeRewriter::rewriteNode(node, context);
+///       }
+///     };
+///
+///     Substituter pass{builder, target, replacement};
+///     NodeCP rewritten = pass.rewrite(root);
 template <typename TContext = NoContext>
 class NodeRewriter {
  public:
   explicit NodeRewriter(Builder& builder) : builder_(builder) {}
   virtual ~NodeRewriter() = default;
 
-  /// Dispatches by `node->nodeType()` to the matching `rewriteX` hook.
+  /// Entry point. Rewrites 'node' and its subtree, returning the rewritten
+  /// root (the same pointer when nothing changed). Not virtual; customize
+  /// behavior by overriding `rewriteNode`.
   NodeCP rewrite(NodeCP node, TContext& context) {
+    return rewriteNode(node, context);
+  }
+
+  /// Overload for stateless passes — rewrites without constructing a context.
+  NodeCP rewrite(NodeCP node)
+    requires std::is_same_v<TContext, NoContext>
+  {
+    NoContext empty{};
+    return rewrite(node, empty);
+  }
+
+ protected:
+  // Interception hook, run once per node before its subtree. Override to
+  // replace a node up front; call `NodeRewriter::rewriteNode` for the default
+  // per-kind dispatch. A replacement must keep the node's output `Column`
+  // identities, or ancestor `withInputs` rebuilds break.
+  virtual NodeCP rewriteNode(NodeCP node, TContext& context) {
     switch (node->nodeType()) {
       case NodeType::kScan:
         return rewriteScan(node->as<Scan>(), context);
@@ -88,266 +120,123 @@ class NodeRewriter {
     VELOX_UNREACHABLE();
   }
 
-  /// Convenience overload available when `TContext` is `NoContext`.
-  NodeCP rewrite(NodeCP node)
-    requires std::is_same_v<TContext, NoContext>
-  {
-    NoContext empty{};
-    return rewrite(node, empty);
+  // Rebuilds via `Node::withInputs` only when a child changed, allocating
+  // `newInputs` lazily so a passthrough returns the same `node` alloc-free.
+  NodeCP rewriteChildren(NodeCP node, TContext& context) {
+    const auto inputs = node->inputs();
+    NodeVector newInputs;
+    for (size_t i = 0; i < inputs.size(); ++i) {
+      NodeCP child = inputs[i];
+      NodeCP rewritten = rewriteNode(child, context);
+      if (newInputs.empty() && rewritten == child) {
+        continue;
+      }
+      if (newInputs.empty()) {
+        newInputs.reserve(inputs.size());
+        for (size_t j = 0; j < i; ++j) {
+          newInputs.push_back(inputs[j]);
+        }
+      }
+      newInputs.push_back(rewritten);
+    }
+    if (newInputs.empty()) {
+      return node;
+    }
+    return node->withInputs(std::move(newInputs), builder_);
   }
 
- protected:
-  virtual NodeCP rewriteScan(const Scan* node, TContext& /*context*/) {
-    return node;
+  virtual NodeCP rewriteScan(const Scan* node, TContext& context) {
+    return rewriteChildren(node, context);
   }
 
-  virtual NodeCP rewriteValues(const Values* node, TContext& /*context*/) {
-    return node;
+  virtual NodeCP rewriteValues(const Values* node, TContext& context) {
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteFilter(const Filter* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Filter>({newInput, node->predicates()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteProject(const Project* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Project>(
-        {newInput, node->exprs(), node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteLimit(const Limit* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Limit>(
-        {newInput, node->offset(), node->count()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteSort(const Sort* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Sort>(
-        {newInput, node->orderKeys(), node->orderTypes()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteTopN(const TopN* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<TopN>(
-        {newInput,
-         node->orderKeys(),
-         node->orderTypes(),
-         node->offset(),
-         node->count()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteAggregate(const Aggregate* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Aggregate>(Aggregate::Key{
-        .input = newInput,
-        .groupingKeys = node->groupingKeys(),
-        .aggregates = node->aggregates(),
-        .outputColumns = node->outputColumns(),
-        .step = node->step(),
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteGroupId(const GroupId* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<GroupId>(
-        {newInput,
-         node->groupingKeys(),
-         node->aggregationInputs(),
-         node->groupingSets(),
-         node->groupingKeyColumns(),
-         node->groupId(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteMarkDistinct(
       const MarkDistinct* node,
       TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<MarkDistinct>(
-        {newInput,
-         node->markers(),
-         node->distinctKeys(),
-         node->masks(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteUnnest(const Unnest* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Unnest>(
-        {newInput,
-         node->unnestExpressions(),
-         node->replicatedColumns(),
-         node->unnestColumns(),
-         node->ordinalityColumn(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteUnionAll(const UnionAll* node, TContext& context) {
-    NodeVector newInputs;
-    newInputs.reserve(node->inputs().size());
-    bool changed = false;
-    for (NodeCP input : node->inputs()) {
-      NodeCP newInput = rewrite(input, context);
-      changed |= (newInput != input);
-      newInputs.push_back(newInput);
-    }
-    if (!changed) {
-      return node;
-    }
-    // legColumns are by Column*: valid as long as leg rewrites preserve
-    // identity of every referenced column. Rewrites that drop or replace a
-    // referenced column must remap legColumns explicitly; the UnionAll ctor
-    // enforces this.
-    return builder_.template make<UnionAll>(
-        {std::move(newInputs), node->legColumns(), node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteJoin(const Join* node, TContext& context) {
-    NodeCP newLeft = rewrite(node->left(), context);
-    NodeCP newRight = rewrite(node->right(), context);
-    if (newLeft == node->left() && newRight == node->right()) {
-      return node;
-    }
-    return builder_.template make<Join>(
-        {newLeft,
-         newRight,
-         node->joinType(),
-         node->leftKeys(),
-         node->rightKeys(),
-         node->filter(),
-         node->nullAware(),
-         node->nullAsValue(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteWindow(const Window* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Window>(
-        {newInput,
-         node->functions(),
-         node->partitionKeys(),
-         node->orderKeys(),
-         node->orderTypes(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteTopNRowNumber(
       const TopNRowNumber* node,
       TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<TopNRowNumber>(
-        {newInput,
-         node->rankFunction(),
-         node->partitionKeys(),
-         node->orderKeys(),
-         node->orderTypes(),
-         node->limit(),
-         node->rankColumn(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteApply(const Apply* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    NodeCP newBody = rewrite(node->body(), context);
-    if (newInput == node->input() && newBody == node->body()) {
-      return node;
-    }
-    return builder_.template make<Apply>(
-        {newInput,
-         newBody,
-         node->correlationColumns(),
-         node->kind(),
-         node->filter(),
-         node->enforceSingleRow(),
-         node->markColumn(),
-         node->inLhs(),
-         node->inBodyKey(),
-         node->includeMarker(),
-         node->outputColumns()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteEnforceSingleRow(
       const EnforceSingleRow* node,
       TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<EnforceSingleRow>({newInput});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteAssignUniqueId(
       const AssignUniqueId* node,
       TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<AssignUniqueId>({newInput, node->idColumn()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteEnforceDistinct(
       const EnforceDistinct* node,
       TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<EnforceDistinct>(
-        {newInput, node->distinctKeys(), node->errorMessage()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteExchange(const Exchange* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<Exchange>({newInput, node->partitioning()});
+    return rewriteChildren(node, context);
   }
 
   virtual NodeCP rewriteTableWrite(const TableWrite* node, TContext& context) {
-    NodeCP newInput = rewrite(node->input(), context);
-    if (newInput == node->input()) {
-      return node;
-    }
-    return builder_.template make<TableWrite>(
-        {newInput, node->table(), node->kind(), node->columnExprs()});
+    return rewriteChildren(node, context);
   }
 
   Builder& builder() {

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   axiom_optimizer_v2_test
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
+  NodeRewriterTest.cpp
   NodeTransformTest.cpp
   TpchPlanTest.cpp
   TpchResultTest.cpp

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(
   axiom_optimizer_v2_test
   AlgebraicPropertiesTest.cpp
   JoinHypergraphTest.cpp
-  RelationSetTest.cpp
+  NodeTransformTest.cpp
   TpchPlanTest.cpp
   TpchResultTest.cpp
 )
@@ -36,4 +36,5 @@ target_link_libraries(
   axiom_optimizer_tests_tpch_queries
   velox_exec_test_lib
   GTest::gtest
+  GTest::gmock
 )

--- a/axiom/optimizer/v2/tests/NodeRewriterTest.cpp
+++ b/axiom/optimizer/v2/tests/NodeRewriterTest.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+#include "axiom/optimizer/v2/tests/UnitTestBase.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+class NodeRewriterTest : public UnitTestBase {
+ protected:
+  // `makeEmptyValues` hash-conses on columns, so distinct leaves need
+  // disjoint columns.
+  NodeCP leaf(std::string_view name) {
+    optimizer::ColumnVector cols{makeColumn(name, velox::BIGINT())};
+    return builder_->makeEmptyValues(std::move(cols));
+  }
+
+  ExprCP truePredicate() {
+    return builder_->makeBoolean(true);
+  }
+};
+
+class NodeSubstituter : public NodeRewriter<> {
+ public:
+  NodeSubstituter(Builder& builder, NodeCP from, NodeCP to)
+      : NodeRewriter<>{builder}, from_{from}, to_{to} {}
+
+  const std::vector<NodeCP>& visited() const {
+    return visited_;
+  }
+
+ protected:
+  NodeCP rewriteNode(NodeCP node, NoContext& context) override {
+    visited_.push_back(node);
+    return node == from_ ? to_ : NodeRewriter::rewriteNode(node, context);
+  }
+
+ private:
+  const NodeCP from_;
+  const NodeCP to_;
+  std::vector<NodeCP> visited_;
+};
+
+struct NodeVisitCount {
+  int count{0};
+};
+
+class CountingRewriter : public NodeRewriter<NodeVisitCount> {
+ public:
+  using NodeRewriter<NodeVisitCount>::NodeRewriter;
+
+ protected:
+  NodeCP rewriteNode(NodeCP node, NodeVisitCount& context) override {
+    ++context.count;
+    return NodeRewriter::rewriteNode(node, context);
+  }
+};
+
+TEST_F(NodeRewriterTest, passthroughReturnsSamePointer) {
+  NodeCP values = leaf("a");
+  NodeCP filter = builder_->make<Filter>({values, ExprVector{truePredicate()}});
+  NodeCP outer = builder_->make<Filter>({filter, ExprVector{truePredicate()}});
+
+  NodeRewriter<> rewriter{*builder_};
+  EXPECT_EQ(rewriter.rewrite(outer), outer);
+}
+
+TEST_F(NodeRewriterTest, multiInputPassthroughReturnsSamePointer) {
+  NodeCP legA = leaf("m_a");
+  NodeCP legB = leaf("m_b");
+  QGVector<optimizer::ColumnVector> legColumns;
+  legColumns.push_back(optimizer::ColumnVector{legA->outputColumns()[0]});
+  legColumns.push_back(optimizer::ColumnVector{legB->outputColumns()[0]});
+  NodeCP unionAll = builder_->make<UnionAll>(
+      {NodeVector{legA, legB},
+       std::move(legColumns),
+       optimizer::ColumnVector{makeColumn("m_out", velox::BIGINT())}});
+
+  NodeRewriter<> rewriter{*builder_};
+  EXPECT_EQ(rewriter.rewrite(unionAll), unionAll);
+}
+
+TEST_F(NodeRewriterTest, contextThreadsThroughSubtree) {
+  NodeCP values = leaf("a");
+  NodeCP filter = builder_->make<Filter>({values, ExprVector{truePredicate()}});
+  NodeCP outer = builder_->make<Filter>({filter, ExprVector{truePredicate()}});
+
+  CountingRewriter rewriter{*builder_};
+  NodeVisitCount context;
+  EXPECT_EQ(rewriter.rewrite(outer, context), outer);
+  EXPECT_EQ(context.count, 3);
+}
+
+TEST_F(NodeRewriterTest, substitutionRebuildsParentChain) {
+  NodeCP leafA = leaf("a");
+  // `replacement` reuses leafA's Column so the ancestor Filters can rebuild
+  // through `withInputs`.
+  NodeCP replacement =
+      builder_->make<Filter>({leafA, ExprVector{truePredicate()}});
+  NodeCP innerFilter =
+      builder_->make<Filter>({leafA, ExprVector{truePredicate()}});
+  NodeCP outerFilter =
+      builder_->make<Filter>({innerFilter, ExprVector{truePredicate()}});
+
+  NodeSubstituter rewriter{*builder_, leafA, replacement};
+  NodeCP result = rewriter.rewrite(outerFilter);
+
+  ASSERT_NE(result, outerFilter);
+  const auto* rewrittenOuter = result->as<Filter>();
+  const auto* rewrittenInner = rewrittenOuter->input()->as<Filter>();
+  EXPECT_EQ(rewrittenInner->input(), replacement);
+  EXPECT_EQ(
+      rewrittenOuter->predicates(), outerFilter->as<Filter>()->predicates());
+  EXPECT_EQ(
+      rewrittenInner->predicates(), innerFilter->as<Filter>()->predicates());
+}
+
+TEST_F(NodeRewriterTest, substitutionIsTerminal) {
+  NodeCP leafA = leaf("a");
+  NodeCP intercepted =
+      builder_->make<Filter>({leafA, ExprVector{truePredicate()}});
+  NodeCP outer =
+      builder_->make<Filter>({intercepted, ExprVector{truePredicate()}});
+  NodeCP substitute = builder_->makeEmptyValues(
+      optimizer::ColumnVector{intercepted->outputColumns()[0]});
+
+  NodeSubstituter rewriter{*builder_, intercepted, substitute};
+  NodeCP result = rewriter.rewrite(outer);
+
+  ASSERT_NE(result, outer);
+  EXPECT_EQ(result->as<Filter>()->input(), substitute);
+  EXPECT_THAT(rewriter.visited(), testing::Not(testing::Contains(leafA)));
+}
+
+TEST_F(NodeRewriterTest, uninvolvedSiblingKeepsIdentity) {
+  NodeCP leftA = leaf("l_a");
+  NodeCP leftReplacement =
+      builder_->make<Filter>({leftA, ExprVector{truePredicate()}});
+  NodeCP right = leaf("r");
+
+  NodeCP join = builder_->make<Join>(
+      {leftA,
+       right,
+       velox::core::JoinType::kInner,
+       ExprVector{},
+       ExprVector{},
+       ExprVector{},
+       /*nullAware=*/false,
+       /*nullAsValue=*/false,
+       optimizer::ColumnVector{
+           leftA->outputColumns()[0], right->outputColumns()[0]}});
+
+  NodeSubstituter rewriter{*builder_, leftA, leftReplacement};
+  NodeCP result = rewriter.rewrite(join);
+
+  ASSERT_NE(result, join);
+  const auto* rewrittenJoin = result->as<Join>();
+  EXPECT_EQ(rewrittenJoin->left(), leftReplacement);
+  EXPECT_EQ(rewrittenJoin->right(), right);
+}
+
+TEST_F(NodeRewriterTest, midInputChangeBackFillsPrefixAndKeepsSuffix) {
+  NodeCP legA = leaf("u_a");
+  NodeCP legB = leaf("u_b");
+  NodeCP legBReplacement =
+      builder_->make<Filter>({legB, ExprVector{truePredicate()}});
+  NodeCP legC = leaf("u_c");
+
+  QGVector<optimizer::ColumnVector> legColumns;
+  legColumns.push_back(optimizer::ColumnVector{legA->outputColumns()[0]});
+  legColumns.push_back(optimizer::ColumnVector{legB->outputColumns()[0]});
+  legColumns.push_back(optimizer::ColumnVector{legC->outputColumns()[0]});
+
+  NodeCP unionAll = builder_->make<UnionAll>(
+      {NodeVector{legA, legB, legC},
+       std::move(legColumns),
+       optimizer::ColumnVector{makeColumn("u_out", velox::BIGINT())}});
+
+  NodeSubstituter rewriter{*builder_, legB, legBReplacement};
+  NodeCP result = rewriter.rewrite(unionAll);
+
+  ASSERT_NE(result, unionAll);
+  EXPECT_THAT(
+      result->inputs(), testing::ElementsAre(legA, legBReplacement, legC));
+  EXPECT_EQ(
+      result->as<UnionAll>()->legColumns(),
+      unionAll->as<UnionAll>()->legColumns());
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test

--- a/axiom/optimizer/v2/tests/NodeTransformTest.cpp
+++ b/axiom/optimizer/v2/tests/NodeTransformTest.cpp
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/SchemaResolver.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/Node.h"
+#include "velox/common/base/tests/GTestUtils.h"
+#include "velox/common/memory/HashStringAllocator.h"
+#include "velox/common/memory/Memory.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+struct ReplacementCase {
+  NodeCP original;
+  NodeVector sameInputs;
+  NodeVector replacementInputs;
+};
+
+class NodeTransformTest : public optimizer::test::QueryTestBase {
+ protected:
+  void SetUp() override {
+    QueryTestBase::SetUp();
+    pool_ = velox::memory::memoryManager()->addLeafPool("node_transform");
+    allocator_ = std::make_unique<velox::HashStringAllocator>(pool_.get());
+    context_ = std::make_unique<optimizer::QueryGraphContext>(*allocator_);
+    optimizer::queryCtx() = context_.get();
+    builder_ = std::make_unique<Builder>();
+    resolver_ = std::make_unique<connector::SchemaResolver>(
+        connector::ConnectorMetadataRegistry::global());
+    schema_ = std::make_unique<optimizer::Schema>(*resolver_);
+  }
+
+  void TearDown() override {
+    schema_.reset();
+    resolver_.reset();
+    builder_.reset();
+    optimizer::queryCtx() = nullptr;
+    context_.reset();
+    allocator_.reset();
+    pool_.reset();
+    QueryTestBase::TearDown();
+  }
+
+  // Registers a single scannable table 't(a BIGINT)' through the test
+  // connector, used by the scan and tableWrite cases (default is TPC-H).
+  void configureTestConnector() override {
+    writeTargetTable_ =
+        testConnector_->addTable("t", velox::ROW({"a"}, {velox::BIGINT()}));
+  }
+
+  optimizer::ColumnCP makeColumn(
+      std::string_view name,
+      const velox::TypePtr& type) {
+    return optimizer::Column::create(
+        name, optimizer::Value(optimizer::queryCtx()->toType(type)));
+  }
+
+  NodeCP emptyLeaf(std::string_view name) {
+    return builder_->makeEmptyValues(makeColumns(name));
+  }
+
+  // Builds a Values leaf with the same output columns as 'input' but a single
+  // opaque row, so it interns to a different node than the empty-rows leaves
+  // used as originals. Only node identity matters to withInputs, not contents.
+  NodeCP replacementLeafWithSameColumns(NodeCP input) {
+    std::vector<velox::Variant> row(
+        input->outputColumns().size(), velox::Variant{static_cast<int64_t>(1)});
+    const auto* rows = optimizer::queryCtx()->registerVariant(
+        std::make_unique<velox::Variant>(velox::Variant::array(
+            std::vector<velox::Variant>{velox::Variant::row(std::move(row))})));
+    return builder_->makeValues(
+        /*source=*/nullptr,
+        rows,
+        optimizer::ColumnVector{input->outputColumns()});
+  }
+
+  void assertLeafContract(NodeCP leaf, std::string_view error) {
+    EXPECT_THAT(leaf->inputs(), testing::IsEmpty());
+    EXPECT_EQ(leaf->withInputs({}, *builder_), leaf);
+    VELOX_ASSERT_THROW(
+        leaf->withInputs({emptyLeaf("unexpected")}, *builder_), error);
+  }
+
+  void assertNonLeafContract(const ReplacementCase& testCase) {
+    ASSERT_FALSE(testCase.sameInputs.empty());
+    ASSERT_EQ(testCase.sameInputs.size(), testCase.original->inputs().size());
+    ASSERT_EQ(testCase.replacementInputs.size(), testCase.sameInputs.size());
+
+    EXPECT_EQ(
+        testCase.original->withInputs(testCase.sameInputs, *builder_),
+        testCase.original);
+
+    NodeCP rebuilt =
+        testCase.original->withInputs(testCase.replacementInputs, *builder_);
+    EXPECT_NE(rebuilt, testCase.original);
+    EXPECT_EQ(rebuilt->nodeType(), testCase.original->nodeType());
+    EXPECT_THAT(
+        rebuilt->inputs(),
+        testing::ElementsAreArray(testCase.replacementInputs));
+
+    NodeVector wrongArity;
+    if (testCase.sameInputs.size() != 1) {
+      wrongArity.push_back(testCase.sameInputs[0]);
+    }
+    const std::string_view message =
+        testCase.sameInputs.size() == 1 ? "(0 vs. 1)" : "(1 vs. 2)";
+    VELOX_ASSERT_THROW(
+        testCase.original->withInputs(std::move(wrongArity), *builder_),
+        message);
+  }
+
+  ReplacementCase unaryCase(NodeCP node, NodeCP input) {
+    return ReplacementCase{
+        .original = node,
+        .sameInputs = NodeVector{input},
+        .replacementInputs = NodeVector{replacementLeafWithSameColumns(input)},
+    };
+  }
+
+  optimizer::ColumnVector makeColumns(std::string_view name) {
+    return optimizer::ColumnVector{makeColumn(name, velox::BIGINT())};
+  }
+
+  ExprCP truePredicate() {
+    return builder_->makeBoolean(true);
+  }
+
+  // BaseTable backed by the connector-registered 't', with a real layout so
+  // Scan's partitioning inference (which reads BaseTable::layout()) succeeds.
+  optimizer::BaseTable* makeScannableBaseTable() {
+    const auto* schemaTable = schema_->findTable(
+        kTestConnectorId, SchemaTableName{kDefaultSchema, "t"});
+    VELOX_CHECK_NOT_NULL(schemaTable);
+    auto* baseTable = optimizer::make<optimizer::BaseTable>();
+    baseTable->cname = toName("scan_alias");
+    baseTable->schemaTable = schemaTable;
+    baseTable->filteredCardinality = schemaTable->cardinality;
+    return baseTable;
+  }
+
+  const connector::Table* makeConnectorTable() {
+    return writeTargetTable_.get();
+  }
+
+  std::shared_ptr<velox::memory::MemoryPool> pool_;
+  std::unique_ptr<velox::HashStringAllocator> allocator_;
+  std::unique_ptr<optimizer::QueryGraphContext> context_;
+  std::unique_ptr<Builder> builder_;
+  std::unique_ptr<connector::SchemaResolver> resolver_;
+  std::unique_ptr<optimizer::Schema> schema_;
+  std::shared_ptr<connector::Table> writeTargetTable_;
+};
+
+TEST_F(NodeTransformTest, scan) {
+  auto* scan = builder_->make<Scan>(
+      {makeScannableBaseTable(),
+       makeColumns("scan_col"),
+       ExprVector{truePredicate()}});
+  assertLeafContract(scan, "Leaf node cannot have inputs: Scan");
+}
+
+TEST_F(NodeTransformTest, values) {
+  assertLeafContract(
+      emptyLeaf("values_col"), "Leaf node cannot have inputs: Values");
+}
+
+TEST_F(NodeTransformTest, filter) {
+  NodeCP input = emptyLeaf("a");
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Filter>({input, ExprVector{truePredicate()}}), input));
+}
+
+TEST_F(NodeTransformTest, project) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP boolColumn = makeColumn("flag", velox::BOOLEAN());
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Project>(
+          {input,
+           ExprVector{inputColumn, truePredicate()},
+           optimizer::ColumnVector{inputColumn, boolColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, limit) {
+  NodeCP input = emptyLeaf("a");
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Limit>({input, /*offset=*/17, /*count=*/23}), input));
+}
+
+TEST_F(NodeTransformTest, sort) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Sort>(
+          {input,
+           ExprVector{inputColumn},
+           optimizer::OrderTypeVector{optimizer::OrderType::kDescNullsLast}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, topN) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<TopN>(
+          {input,
+           ExprVector{inputColumn},
+           optimizer::OrderTypeVector{optimizer::OrderType::kDescNullsLast},
+           /*offset=*/11,
+           /*count=*/29}),
+      input));
+}
+
+TEST_F(NodeTransformTest, aggregate) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP aggregateColumn = makeColumn("sum_a", velox::BIGINT());
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Aggregate>(Aggregate::Key{
+          .input = input,
+          .groupingKeys = ExprVector{inputColumn},
+          .aggregates = AggregateCallVector{builder_->makeAggregate(
+              toName("sum"),
+              optimizer::Value(inputColumn->value().type),
+              ExprVector{inputColumn},
+              optimizer::FunctionSet{},
+              /*isDistinct=*/false,
+              /*condition=*/nullptr,
+              inputColumn->value().type,
+              /*orderKeys=*/{},
+              /*orderTypes=*/{})},
+          .outputColumns =
+              optimizer::ColumnVector{inputColumn, aggregateColumn},
+          .step = AggregateStep::kSingle,
+      }),
+      input));
+}
+
+TEST_F(NodeTransformTest, groupId) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP groupColumn = makeColumn("group_a", velox::BIGINT());
+  ColumnCP groupIdColumn = makeColumn("group_id", velox::BIGINT());
+  QGVector<QGVector<int32_t>> groupingSets;
+  groupingSets.push_back(QGVector<int32_t>{0});
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<GroupId>(
+          {input,
+           ExprVector{inputColumn},
+           ExprVector{inputColumn},
+           std::move(groupingSets),
+           optimizer::ColumnVector{groupColumn},
+           groupIdColumn,
+           optimizer::ColumnVector{groupColumn, inputColumn, groupIdColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, markDistinct) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP markerColumn = makeColumn("marker", velox::BOOLEAN());
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<MarkDistinct>(
+          {input,
+           optimizer::ColumnVector{markerColumn},
+           ExprVector{inputColumn},
+           optimizer::ColumnVector{},
+           optimizer::ColumnVector{inputColumn, markerColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, unnest) {
+  ColumnCP inputColumn = makeColumn("a", velox::BIGINT());
+  ColumnCP boolColumn = makeColumn("flag", velox::BOOLEAN());
+  ColumnCP arrayColumn = makeColumn("items", velox::ARRAY(velox::BIGINT()));
+  NodeCP input = builder_->makeEmptyValues(
+      optimizer::ColumnVector{inputColumn, boolColumn, arrayColumn});
+  ColumnCP unnestColumn = makeColumn("item", velox::BIGINT());
+  ColumnCP ordinalityColumn = makeColumn("ord", velox::BIGINT());
+  QGVector<optimizer::ColumnVector> unnestColumns;
+  unnestColumns.push_back(optimizer::ColumnVector{unnestColumn});
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Unnest>(
+          {input,
+           ExprVector{arrayColumn},
+           optimizer::ColumnVector{inputColumn},
+           std::move(unnestColumns),
+           ordinalityColumn,
+           optimizer::ColumnVector{
+               inputColumn, unnestColumn, ordinalityColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, window) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  WindowFunctions windowFunctions;
+  windowFunctions.push_back(
+      WindowFunction{
+          .call = builder_->makeCall(
+              toName("sum"),
+              optimizer::Value(optimizer::queryCtx()->toType(velox::BIGINT())),
+              ExprVector{inputColumn},
+              optimizer::FunctionSet{}),
+          .frame = optimizer::Frame::wholePartition(),
+          .ignoreNulls = true,
+      });
+  ColumnCP windowColumn = makeColumn("window_sum", velox::BIGINT());
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Window>(
+          {input,
+           std::move(windowFunctions),
+           ExprVector{inputColumn},
+           ExprVector{inputColumn},
+           optimizer::OrderTypeVector{optimizer::OrderType::kAscNullsFirst},
+           optimizer::ColumnVector{inputColumn, windowColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, topNRowNumber) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+  ColumnCP rankColumn = makeColumn("rank", velox::BIGINT());
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<TopNRowNumber>(
+          {input,
+           TopNRowNumber::RankFunction::kRank,
+           ExprVector{inputColumn},
+           ExprVector{inputColumn},
+           optimizer::OrderTypeVector{optimizer::OrderType::kAscNullsFirst},
+           /*limit=*/7,
+           rankColumn,
+           optimizer::ColumnVector{inputColumn, rankColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, enforceSingleRow) {
+  NodeCP input = emptyLeaf("a");
+
+  assertNonLeafContract(
+      unaryCase(builder_->make<EnforceSingleRow>({input}), input));
+}
+
+TEST_F(NodeTransformTest, assignUniqueId) {
+  NodeCP input = emptyLeaf("a");
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<AssignUniqueId>(
+          {input, makeColumn("uid", velox::BIGINT())}),
+      input));
+}
+
+TEST_F(NodeTransformTest, enforceDistinct) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<EnforceDistinct>(
+          {input, ExprVector{inputColumn}, toName("duplicate scalar row")}),
+      input));
+}
+
+TEST_F(NodeTransformTest, exchange) {
+  NodeCP input = emptyLeaf("a");
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<Exchange>(
+          {input,
+           Partitioning{
+               .kind = PartitionKind::kGather,
+               .scope = PropertyScope::kGlobal,
+           }}),
+      input));
+}
+
+TEST_F(NodeTransformTest, tableWrite) {
+  NodeCP input = emptyLeaf("a");
+  ColumnCP inputColumn = input->outputColumns()[0];
+
+  assertNonLeafContract(unaryCase(
+      builder_->make<TableWrite>(
+          {input,
+           makeConnectorTable(),
+           connector::WriteKind::kInsert,
+           ExprVector{inputColumn}}),
+      input));
+}
+
+TEST_F(NodeTransformTest, multiInput) {
+  NodeCP left = emptyLeaf("left");
+  NodeCP right = emptyLeaf("right");
+  NodeCP replacementLeft = replacementLeafWithSameColumns(left);
+  NodeCP replacementRight = replacementLeafWithSameColumns(right);
+
+  auto* unionAll = builder_->make<UnionAll>(
+      {NodeVector{left, right},
+       QGVector<optimizer::ColumnVector>{
+           optimizer::ColumnVector{left->outputColumns()[0]},
+           optimizer::ColumnVector{right->outputColumns()[0]}},
+       optimizer::ColumnVector{makeColumn("union_out", velox::BIGINT())}});
+  assertNonLeafContract({
+      .original = unionAll,
+      .sameInputs = NodeVector{left, right},
+      .replacementInputs = NodeVector{replacementLeft, replacementRight},
+  });
+
+  auto* join = builder_->make<Join>(
+      {left,
+       right,
+       velox::core::JoinType::kLeft,
+       ExprVector{left->outputColumns()[0]},
+       ExprVector{right->outputColumns()[0]},
+       ExprVector{truePredicate()},
+       /*nullAware=*/false,
+       /*nullAsValue=*/false,
+       optimizer::ColumnVector{
+           left->outputColumns()[0], right->outputColumns()[0]}});
+  assertNonLeafContract({
+      .original = join,
+      .sameInputs = NodeVector{left, right},
+      .replacementInputs = NodeVector{replacementLeft, replacementRight},
+  });
+
+  ColumnCP includeMarker = makeColumn("include", velox::BOOLEAN());
+  auto* apply = builder_->make<Apply>(
+      {left,
+       right,
+       optimizer::ColumnVector{left->outputColumns()[0]},
+       velox::core::JoinType::kLeft,
+       ExprVector{truePredicate()},
+       /*enforceSingleRow=*/true,
+       /*markColumn=*/nullptr,
+       /*inLhs=*/nullptr,
+       /*inBodyKey=*/nullptr,
+       includeMarker,
+       optimizer::ColumnVector{
+           left->outputColumns()[0],
+           right->outputColumns()[0],
+           includeMarker}});
+  assertNonLeafContract({
+      .original = apply,
+      .sameInputs = NodeVector{left, right},
+      .replacementInputs = NodeVector{replacementLeft, replacementRight},
+  });
+}
+
+TEST_F(NodeTransformTest, unionAllWrongArity) {
+  NodeCP left = emptyLeaf("left");
+  NodeCP right = emptyLeaf("right");
+  auto* unionAll = builder_->make<UnionAll>(
+      {NodeVector{left, right},
+       QGVector<optimizer::ColumnVector>{
+           optimizer::ColumnVector{left->outputColumns()[0]},
+           optimizer::ColumnVector{right->outputColumns()[0]}},
+       optimizer::ColumnVector{makeColumn("union_out", velox::BIGINT())}});
+
+  VELOX_ASSERT_THROW(
+      unionAll->withInputs(NodeVector{left}, *builder_),
+      "(1 vs. 2) UnionAll replacement input count must match existing input count");
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test


### PR DESCRIPTION
Summary:

Every per-kind default in `NodeRewriter` hand-rolled its own rebuild — the same field list already expressed by `Node::withInputs`. Adding a field to `Window` required three synchronized edits (ctor, `withInputs`, `rewriteWindow`); a caller who missed the third silently rebuilt with stale fields.

Replaces the per-kind default bodies with a shared `rewriteChildren` helper that recurses on every input and, if any child changed, delegates to `node->withInputs`. `newInputs` is only allocated when a child actually changes, so the passthrough path stays alloc-free. Per-kind virtuals keep their names and signatures, so existing subclass overrides compile and behave unchanged.

Adds a virtual `rewriteNode` interception hook. `rewrite` is a non-virtual entry point that calls `rewriteNode`, whose default dispatches by node kind to the per-kind hooks. A subclass overrides `rewriteNode` to replace a node before its subtree is traversed — the hook for terminal-substitution passes.

Differential Revision: D112176018


