### PR TITLE
feat(cli): Enforce query execution timeout in SqlQueryRunner (#1589)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -15,8 +15,11 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <folly/CancellationToken.h>
 #include <folly/container/F14Map.h>
 #include <folly/coro/BlockingWait.h>
+#include <folly/coro/Coroutine.h>
+#include <folly/coro/Timeout.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <algorithm>
 #include <cmath>
@@ -1209,7 +1212,7 @@ std::string SqlQueryRunner::runExplainAnalyze(
         startProgressReporter(*runner, queryCtx->queryId(), options);
     // Executed for its runtime stats (printed below); the result batches are
     // not used, so discard them instead of accumulating the whole result set.
-    runner->drain([](velox::RowVectorPtr) {});
+    runner->drain([](velox::RowVectorPtr) {}, options.timeoutMicros);
   }
 
   std::stringstream out;
@@ -1460,9 +1463,11 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         QueryRuntimeStats::kExecuteCpuNanos);
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
-    runner->drain([&](velox::RowVectorPtr batch) {
-      result.results.push_back(std::move(batch));
-    });
+    runner->drain(
+        [&](velox::RowVectorPtr batch) {
+          result.results.push_back(std::move(batch));
+        },
+        options.timeoutMicros);
   }
 
   return result;

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -207,9 +207,13 @@ class SqlQueryRunner {
     int32_t numDrivers{4};
     uint64_t splitTargetBytes{16 << 20};
 
-    /// Microseconds to wait for query to complete. 0 means check for completion
-    /// then timeout immediately if not complete.
-    int32_t timeoutMicros{500'000};
+    /// Cooperative execution deadline in microseconds; 0 means no limit. Bounds
+    /// the execution phase only -- not parsing, permission checks, or
+    /// optimization -- and is cooperative rather than a hard wall-clock cap: a
+    /// non-yielding operator can overrun it, and winding the cancelled query
+    /// down adds teardown latency. When exceeded, run() fails with a user
+    /// error.
+    int64_t timeoutMicros{0};
 
     std::optional<std::string> defaultConnectorId;
     std::optional<std::string> defaultSchema;

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -168,6 +168,22 @@ TEST_F(SqlQueryRunnerTest, runSingleStatement) {
       makeRowVector({makeFlatVector<int32_t>({1})}));
 }
 
+TEST_F(SqlQueryRunnerTest, executionTimeout) {
+  // A multi-way cross product over the small nation table (25 rows) produces
+  // ~244M rows, far more than can complete within the 10ms deadline, so the
+  // execution timeout fires deterministically during execution and the query
+  // fails with a user error.
+  testConnector_->addTpchTables();
+  SqlQueryRunner::RunOptions options;
+  options.timeoutMicros = 10'000; // 10ms
+  VELOX_ASSERT_THROW(
+      runner_->run(
+          "SELECT count(*) FROM nation a, nation b, nation c, "
+          "nation d, nation e, nation f",
+          options),
+      "exceeded maximum time limit");
+}
+
 TEST_F(SqlQueryRunnerTest, currentUser) {
   // CURRENT_USER returns the user passed to the SqlQueryRunner constructor.
   test::assertEqualVectors(


### PR DESCRIPTION
Summary:

Revives `RunOptions::timeoutMicros` as a cooperative execution deadline. The field has been unused since #1527 (coroutine-based result iteration), which replaced the`waitForCompletion(..., timeoutMicros)` cleanup wait with `drain()` and left it an orphan; even before that it bounded only the post-execution cleanup wait, never execution -- so a query with a 1s timeout could run to completion (e.g. 72s).

Both result-collecting call sites in `SqlQueryRunner` now pass `options.timeoutMicros` to `Runner::drain`, where the deadline is enforced via `folly::coro::timeout` over the pull loop, on expiry the query fails with a user error. The limit is cooperative and covers execution only -- not parsing, permission checks, or optimization -- so a non-yielding operator can overrun it. `RunOptions::timeoutMicros` is widened to `int64` to avoid the ~35 min `int32` cap.

Reviewed By: mbasmanova

Differential Revision: D112190981


