### PR TITLE
feat(optimizer): Answer approx_count_star from metadata (#1591)

### DIFF
--- a/axiom/cli/Connectors.cpp
+++ b/axiom/cli/Connectors.cpp
@@ -145,7 +145,8 @@ std::shared_ptr<velox::connector::Connector>
 Connectors::registerLocalHiveConnector(
     const std::string& dataPath,
     const std::string& dataFormat,
-    const std::string& connectorId) {
+    const std::string& connectorId,
+    std::shared_ptr<velox::memory::MemoryPool> rootPool) {
   std::unordered_map<std::string, std::string> connectorConfig = {
       {connector::hive::HiveMetadataConfig::kLocalDataPath, dataPath},
       {connector::hive::HiveMetadataConfig::kLocalFileFormat, dataFormat},
@@ -164,7 +165,9 @@ Connectors::registerLocalHiveConnector(
   connector::ConnectorMetadataRegistry::global().insert(
       connector->connectorId(),
       std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
-          hiveConnector));
+          hiveConnector,
+          rootPool ? std::move(rootPool)
+                   : velox::memory::memoryManager()->addRootPool()));
 
   return connector;
 }

--- a/axiom/cli/Connectors.h
+++ b/axiom/cli/Connectors.h
@@ -69,10 +69,14 @@ class Connectors {
   /// The connector is registered under `connectorId`, so queries can access
   /// local tables like "INSERT INTO ${connectorId}.write_table SELECT * FROM
   /// ${connectorId}.read_table".
+  /// 'rootPool' backs the connector's LocalHiveConnectorMetadata; defaults to a
+  /// root pool from the global MemoryManager. Tests with a standalone
+  /// MemoryManager pass one from it.
   std::shared_ptr<velox::connector::Connector> registerLocalHiveConnector(
       const std::string& dataPath,
       const std::string& dataFormat,
-      const std::string& connectorId = kLocalHiveConnectorId);
+      const std::string& connectorId = kLocalHiveConnectorId,
+      std::shared_ptr<velox::memory::MemoryPool> rootPool = nullptr);
 
   /// Registers a connector from configuration properties.
   ///

--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -35,6 +35,14 @@ const auto& writeKindNames() {
 
 AXIOM_DEFINE_ENUM_NAME(WriteKind, writeKindNames);
 
+void MetadataCountGroup::checkConsistency() const {
+  VELOX_CHECK_GE(numRows, 0, "Row count must be non-negative");
+  for (const auto nulls : numNulls) {
+    VELOX_CHECK_GE(nulls, 0, "Null count must be non-negative");
+    VELOX_CHECK_LE(nulls, numRows, "Null count must not exceed row count");
+  }
+}
+
 namespace {
 
 // @return RowType that represents a subset of 'columns' which are not hidden.

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -384,6 +384,30 @@ struct FilteredTableStats {
   std::vector<int32_t> rejectedFilterIndices;
 };
 
+/// One group of a metadata-derived count produced by co_metadataCounts. One
+/// entry per distinct tuple of the grouping columns; a single entry with empty
+/// 'key' for a global (ungrouped) count. Counts may be estimates; see
+/// co_metadataCounts.
+struct MetadataCountGroup {
+  /// Grouping-column values for this group, in the order of the
+  /// 'groupingColumns' argument of co_metadataCounts. Empty for a global count.
+  std::vector<velox::Variant> key;
+
+  /// Number of rows in this group, derived from table metadata.
+  int64_t numRows{0};
+
+  /// Null count per requested column, 1:1 with the 'columns' argument of
+  /// co_metadataCounts and in the same order. Empty when no columns were
+  /// requested. Each entry must be in [0, numRows] -- even for an estimate, a
+  /// column cannot have fewer than zero or more nulls than there are rows.
+  std::vector<int64_t> numNulls;
+
+  /// Verifies the group's invariants: numRows is non-negative and every
+  /// numNulls entry is in [0, numRows]. The connector must guarantee this,
+  /// including after rescaling an estimate.
+  void checkConsistency() const;
+};
+
 /// Represents a physical manifestation of a table. There is at least
 /// one layout but for tables that have multiple sort orders, partitionings,
 /// indices, column groups, etc. there is a separate layout for each. The layout
@@ -537,6 +561,43 @@ class TableLayout {
   virtual folly::coro::Task<std::optional<FilteredTableStats>> co_estimateStats(
       ConnectorSessionPtr /*session*/,
       velox::connector::ConnectorTableHandlePtr /*tableHandle*/,
+      std::vector<std::string> /*columns*/,
+      std::vector<velox::core::TypedExprPtr> /*filterConjuncts*/) const {
+    co_return std::nullopt;
+  }
+
+  /// Returns per-group row counts, and per-column null counts, derived from
+  /// table metadata, computed WITHOUT reading data. Backs aggregates whose
+  /// result is a metadata-derived count rather than a live scan (see
+  /// SpecialAggregateKind).
+  ///
+  /// The connector is free to return an estimate rather than exact counts --
+  /// for example, derived from a sampled subset of partitions and rescaled --
+  /// so the caller must treat the result as approximate. Filter and grouping
+  /// accounting remain all-or-nothing: a connector that cannot resolve every
+  /// conjunct, or group by the requested columns, from metadata declines by
+  /// returning std::nullopt. There is no rejectedFilterIndices equivalent.
+  ///
+  /// @param session Connector session for the current query.
+  /// @param tableHandle Table handle for the table.
+  /// @param groupingColumns Names of columns to group the counts by, in
+  /// output-key order. Empty requests a single global count. The connector
+  /// returns std::nullopt if it cannot group by these columns from metadata
+  /// (e.g. a grouping column is not a partition column).
+  /// @param columns Names of columns for which per-group null counts are
+  /// requested. Empty when only a row count is needed.
+  /// @param filterConjuncts Filter conjuncts applied to the table, in the same
+  /// canonical form as the 'filters' argument of createTableHandle. The
+  /// connector must account for every conjunct or return std::nullopt.
+  ///
+  /// @return One MetadataCountGroup per group, or std::nullopt if the connector
+  /// cannot answer from metadata. The default implementation returns
+  /// std::nullopt.
+  virtual folly::coro::Task<std::optional<std::vector<MetadataCountGroup>>>
+  co_metadataCounts(
+      ConnectorSessionPtr /*session*/,
+      velox::connector::ConnectorTableHandlePtr /*tableHandle*/,
+      std::vector<std::string> /*groupingColumns*/,
       std::vector<std::string> /*columns*/,
       std::vector<velox::core::TypedExprPtr> /*filterConjuncts*/) const {
     co_return std::nullopt;

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
+#include <folly/Conv.h>
 #include <algorithm>
 #include <utility>
 #include "velox/connectors/hive/HiveConnector.h"
@@ -196,6 +197,29 @@ HiveTableLayout::HiveTableLayout(
                     extractPartitionKeyTypes(partitionedByColumns))
               : nullptr} {
   VELOX_CHECK_EQ(sortedByColumns.size(), sortOrder.size());
+}
+
+// static
+velox::Variant HiveTableLayout::partitionValueToVariant(
+    std::string_view value,
+    const velox::Type& type) {
+  switch (type.kind()) {
+    case velox::TypeKind::BOOLEAN:
+      return velox::Variant(folly::to<bool>(value));
+    case velox::TypeKind::TINYINT:
+      return velox::Variant(folly::to<int8_t>(value));
+    case velox::TypeKind::SMALLINT:
+      return velox::Variant(folly::to<int16_t>(value));
+    case velox::TypeKind::INTEGER:
+      return velox::Variant(folly::to<int32_t>(value));
+    case velox::TypeKind::BIGINT:
+      return velox::Variant(folly::to<int64_t>(value));
+    case velox::TypeKind::VARCHAR:
+      return velox::Variant(std::string(value));
+    default:
+      VELOX_UNREACHABLE(
+          "Unsupported partition column type: {}", type.toString());
+  }
 }
 
 namespace {

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -152,6 +152,12 @@ class HiveTableLayout : public TableLayout {
     return hivePartitionColumns_;
   }
 
+  /// Converts a Hive partition-key string to a Variant of 'type'. Fails for a
+  /// type that cannot appear as a partition key.
+  static velox::Variant partitionValueToVariant(
+      std::string_view value,
+      const velox::Type& type);
+
   std::optional<int32_t> numBuckets() const {
     return numBuckets_;
   }

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -411,12 +411,16 @@ folly::coro::Task<SplitBatch> LocalHiveSplitSource::co_getSplits(
 }
 
 LocalHiveConnectorMetadata::LocalHiveConnectorMetadata(
-    velox::connector::hive::HiveConnector* hiveConnector)
+    velox::connector::hive::HiveConnector* hiveConnector,
+    std::shared_ptr<velox::memory::MemoryPool> rootPool)
     : HiveConnectorMetadata(hiveConnector),
+      rootPool_(std::move(rootPool)),
       splitManager_(this),
       hiveMetadataConfig_(
           std::make_shared<HiveMetadataConfig>(
-              hiveConnector->connectorConfig())) {}
+              hiveConnector->connectorConfig())) {
+  VELOX_CHECK_NOT_NULL(rootPool_, "LocalHiveConnectorMetadata requires a pool");
+}
 
 void LocalHiveConnectorMetadata::reinitialize() {
   std::lock_guard<std::mutex> l(mutex_);
@@ -614,6 +618,8 @@ LocalHiveTableLayout::co_estimateStats(
       ConnectorMetadataRegistry::get(connector()->connectorId());
   auto* localHiveMetadata =
       dynamic_cast<const LocalHiveConnectorMetadata*>(connectorMetadata.get());
+  VELOX_CHECK_NOT_NULL(
+      localHiveMetadata, "Expected LocalHiveConnectorMetadata for connector");
   auto& evaluator =
       *localHiveMetadata->connectorQueryCtx()->expressionEvaluator();
 
@@ -631,6 +637,139 @@ LocalHiveTableLayout::co_estimateStats(
       evaluator,
       partitionColumnsByName,
       requestedColumns);
+}
+
+folly::coro::Task<std::optional<std::vector<MetadataCountGroup>>>
+LocalHiveTableLayout::co_metadataCounts(
+    ConnectorSessionPtr /*session*/,
+    velox::connector::ConnectorTableHandlePtr /*tableHandle*/,
+    std::vector<std::string> groupingColumns,
+    std::vector<std::string> columns,
+    std::vector<velox::core::TypedExprPtr> filterConjuncts) const {
+  folly::F14FastMap<std::string, const Column*> partitionColumnsByName;
+  for (const auto* column : hivePartitionColumns()) {
+    partitionColumnsByName[column->name()] = column;
+  }
+
+  // Every grouping column must be a partition column.
+  std::vector<const Column*> groupingKeyColumns;
+  groupingKeyColumns.reserve(groupingColumns.size());
+  for (const auto& name : groupingColumns) {
+    auto it = partitionColumnsByName.find(name);
+    if (it == partitionColumnsByName.end()) {
+      co_return std::nullopt;
+    }
+    groupingKeyColumns.push_back(it->second);
+  }
+
+  auto connectorMetadata =
+      ConnectorMetadataRegistry::get(connector()->connectorId());
+  auto* localHiveMetadata =
+      dynamic_cast<const LocalHiveConnectorMetadata*>(connectorMetadata.get());
+  VELOX_CHECK_NOT_NULL(
+      localHiveMetadata, "Expected LocalHiveConnectorMetadata for connector");
+  auto& evaluator =
+      *localHiveMetadata->connectorQueryCtx()->expressionEvaluator();
+
+  // The counts are exact, so every conjunct must be resolvable from partition
+  // metadata; decline if any is not.
+  std::vector<MetadataFilter> metadataFilters;
+  std::vector<int32_t> rejectedFilterIndices;
+  classifyFilterConjuncts(
+      filterConjuncts,
+      evaluator,
+      partitionColumnsByName,
+      /*allowPathAndBucket=*/false,
+      metadataFilters,
+      rejectedFilterIndices);
+  if (!rejectedFilterIndices.empty()) {
+    co_return std::nullopt;
+  }
+
+  std::vector<const Column*> nullCountColumns;
+  nullCountColumns.reserve(columns.size());
+  for (const auto& name : columns) {
+    const auto* column = table().findColumn(name);
+    VELOX_CHECK_NOT_NULL(column, "Column not found: {}", name);
+    nullCountColumns.push_back(column);
+  }
+  // Index the requested columns by name once so each partition's stats can be
+  // accumulated in a single pass below.
+  folly::F14FastMap<std::string_view, size_t> nullCountColumnIndex;
+  nullCountColumnIndex.reserve(nullCountColumns.size());
+  for (size_t c = 0; c < nullCountColumns.size(); ++c) {
+    nullCountColumnIndex.emplace(nullCountColumns[c]->name(), c);
+  }
+
+  // One group per distinct grouping-key tuple, accumulating rows and per-column
+  // non-null counts across the matching partitions.
+  std::vector<MetadataCountGroup> groups;
+  std::vector<std::vector<int64_t>> nonNullCounts;
+  folly::F14FastMap<std::string, size_t> groupIndex;
+  for (const auto& partition : partitionStats_) {
+    bool matched = true;
+    for (const auto& metadataFilter : metadataFilters) {
+      auto it = partition.partitionKeys.find(metadataFilter.columnName);
+      if (it == partition.partitionKeys.end() ||
+          !testPartitionValue(
+              *metadataFilter.filter,
+              it->second,
+              *metadataFilter.column->type())) {
+        matched = false;
+        break;
+      }
+    }
+    if (!matched) {
+      continue;
+    }
+
+    // Group key: partition values joined with a NUL separator. Hive partition
+    // values are path components and cannot contain NUL, so the join is
+    // unambiguous.
+    std::string groupKey;
+    std::vector<velox::Variant> keyValues;
+    keyValues.reserve(groupingKeyColumns.size());
+    for (const auto* column : groupingKeyColumns) {
+      auto it = partition.partitionKeys.find(column->name());
+      if (it == partition.partitionKeys.end()) {
+        // The value is not available (e.g. a partition column beyond the first
+        // level, which is not parsed today).
+        co_return std::nullopt;
+      }
+      groupKey += it->second;
+      groupKey += '\0';
+      keyValues.push_back(
+          HiveTableLayout::partitionValueToVariant(
+              it->second, *column->type()));
+    }
+
+    auto [it, inserted] = groupIndex.try_emplace(groupKey, groups.size());
+    if (inserted) {
+      MetadataCountGroup group;
+      group.key = std::move(keyValues);
+      groups.push_back(std::move(group));
+      nonNullCounts.emplace_back(nullCountColumns.size(), 0);
+    }
+    const size_t index = it->second;
+    groups[index].numRows += partition.numRows;
+    for (const auto& stats : partition.columnStats) {
+      auto columnIt = nullCountColumnIndex.find(stats.name);
+      if (columnIt != nullCountColumnIndex.end()) {
+        nonNullCounts[index][columnIt->second] += stats.numValues;
+      }
+    }
+  }
+
+  // A column missing from a partition's stats contributes no non-nulls, i.e. it
+  // is all-null for that partition, so nulls = rows - non-nulls.
+  for (size_t index = 0; index < groups.size(); ++index) {
+    groups[index].numNulls.reserve(nullCountColumns.size());
+    for (int64_t nonNull : nonNullCounts[index]) {
+      groups[index].numNulls.push_back(groups[index].numRows - nonNull);
+    }
+  }
+
+  co_return groups;
 }
 
 LocalHiveTableLayout* LocalTable::makeDefaultLayout(

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -171,6 +171,19 @@ class LocalHiveTableLayout : public HiveTableLayout {
       std::vector<std::string> columns,
       std::vector<velox::core::TypedExprPtr> filterConjuncts) const override;
 
+  /// Returns exact per-group row counts and per-column null counts from
+  /// persisted partition stats, one group per distinct tuple of
+  /// 'groupingColumns' values. Declines (nullopt) if a grouping column is not a
+  /// partition column, if any conjunct is not partition-only, or if a grouping
+  /// column's value is not available in the partition metadata.
+  folly::coro::Task<std::optional<std::vector<MetadataCountGroup>>>
+  co_metadataCounts(
+      ConnectorSessionPtr session,
+      velox::connector::ConnectorTableHandlePtr tableHandle,
+      std::vector<std::string> groupingColumns,
+      std::vector<std::string> columns,
+      std::vector<velox::core::TypedExprPtr> filterConjuncts) const override;
+
  private:
   // Configuration for local Hive metadata.
   std::shared_ptr<HiveMetadataConfig> hiveMetadataConfig_;
@@ -232,8 +245,13 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
  public:
   static constexpr std::string_view kDefaultSchema = "default";
 
-  explicit LocalHiveConnectorMetadata(
-      velox::connector::hive::HiveConnector* hiveConnector);
+  /// 'rootPool' backs the metadata's schema-reader query context. Pass a root
+  /// pool from a MemoryManager whose lifetime covers this metadata; tests with
+  /// a standalone MemoryManager pass one from it so the pool is not orphaned
+  /// when the global manager is reset.
+  LocalHiveConnectorMetadata(
+      velox::connector::hive::HiveConnector* hiveConnector,
+      std::shared_ptr<velox::memory::MemoryPool> rootPool);
 
   TablePtr findTable(const SchemaTableName& tableName) override;
 
@@ -369,8 +387,7 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
 
   mutable std::mutex mutex_;
   mutable bool initialized_{false};
-  std::shared_ptr<velox::memory::MemoryPool> rootPool_{
-      velox::memory::memoryManager()->addRootPool()};
+  std::shared_ptr<velox::memory::MemoryPool> rootPool_;
   std::shared_ptr<velox::memory::MemoryPool> schemaPool_;
   std::shared_ptr<velox::core::QueryCtx> queryCtx_;
   std::shared_ptr<velox::connector::ConnectorQueryCtx> connectorQueryCtx_;

--- a/axiom/graphviz/LogicalPlanDotPrinter.cpp
+++ b/axiom/graphviz/LogicalPlanDotPrinter.cpp
@@ -76,6 +76,14 @@ class SubqueryCollector : public ExprVisitor {
     }
   }
 
+  void visit(const SpecialFormAggExpr& expr, ExprVisitorContext& ctx)
+      const override {
+    visitInputs(expr, ctx);
+    if (expr.fallback() != nullptr) {
+      expr.fallback()->accept(*this, ctx);
+    }
+  }
+
   void visit(const WindowExpr& expr, ExprVisitorContext& ctx) const override {
     visitInputs(expr, ctx);
   }

--- a/axiom/logical_plan/Expr.cpp
+++ b/axiom/logical_plan/Expr.cpp
@@ -35,6 +35,7 @@ const auto& exprKindNames() {
       {ExprKind::kWindow, "Window"},
       {ExprKind::kLambda, "Lambda"},
       {ExprKind::kSubquery, "Subquery"},
+      {ExprKind::kSpecialFormAgg, "SpecialFormAgg"},
   };
   return kNames;
 }
@@ -117,6 +118,12 @@ bool AggregateExpr::equalTo(const Expr& other) const {
   const auto* rhs = other.as<AggregateExpr>();
   return name_ == rhs->name_ && distinct_ == rhs->distinct_ &&
       equalNullableExprs(filter_, rhs->filter_) && ordering_ == rhs->ordering_;
+}
+
+bool SpecialFormAggExpr::equalTo(const Expr& other) const {
+  const auto* rhs = other.as<SpecialFormAggExpr>();
+  return AggregateExpr::equalTo(other) && kind_ == rhs->kind_ &&
+      equalNullableExprs(fallback_, rhs->fallback_);
 }
 
 bool WindowExpr::Frame::operator==(const Frame& other) const {
@@ -266,6 +273,7 @@ void Expr::registerSerDe() {
   registry.Register("CallExpr", CallExpr::create);
   registry.Register("SpecialFormExpr", SpecialFormExpr::create);
   registry.Register("AggregateExpr", AggregateExpr::create);
+  registry.Register("SpecialFormAggExpr", SpecialFormAggExpr::create);
   registry.Register("WindowExpr", WindowExpr::create);
   registry.Register("LambdaExpr", LambdaExpr::create);
   registry.Register("SubqueryExpr", SubqueryExpr::create);
@@ -394,6 +402,31 @@ ExprPtr AggregateExpr::create(const folly::dynamic& obj, void* context) {
       obj["distinct"].asBool());
 }
 
+folly::dynamic SpecialFormAggExpr::serialize() const {
+  auto obj = serializeBase("SpecialFormAggExpr");
+  obj["specialAggregateKind"] = SpecialAggregateKindName::toName(kind_);
+  if (fallback_) {
+    obj["fallback"] = fallback_->serialize();
+  }
+  return obj;
+}
+
+// static
+ExprPtr SpecialFormAggExpr::create(const folly::dynamic& obj, void* context) {
+  auto inputs = deserializeInputs(obj, context);
+  auto kind = SpecialAggregateKindName::toSpecialAggregateKind(
+      obj["specialAggregateKind"].asString());
+  AggregateExprPtr fallback = nullptr;
+  if (obj.count("fallback")) {
+    fallback = std::dynamic_pointer_cast<const AggregateExpr>(
+        velox::ISerializable::deserialize<Expr>(obj["fallback"], context));
+    VELOX_CHECK_NOT_NULL(
+        fallback, "SpecialFormAggExpr fallback must be an AggregateExpr");
+  }
+  return std::make_shared<SpecialFormAggExpr>(
+      kind, std::move(inputs), std::move(fallback));
+}
+
 folly::dynamic WindowExpr::Frame::serialize() const {
   folly::dynamic obj = folly::dynamic::object;
   obj["type"] = WindowExpr::toName(type);
@@ -518,6 +551,12 @@ void AggregateExpr::accept(
   visitor.visit(*this, context);
 }
 
+void SpecialFormAggExpr::accept(
+    const ExprVisitor& visitor,
+    ExprVisitorContext& context) const {
+  visitor.visit(*this, context);
+}
+
 void WindowExpr::accept(const ExprVisitor& visitor, ExprVisitorContext& context)
     const {
   visitor.visit(*this, context);
@@ -581,6 +620,54 @@ const auto& specialFormNames() {
 } // namespace
 
 AXIOM_DEFINE_ENUM_NAME(SpecialForm, specialFormNames)
+
+namespace {
+const auto& specialAggregateKindNames() {
+  static const folly::F14FastMap<SpecialAggregateKind, std::string_view>
+      kNames = {
+          {SpecialAggregateKind::kMetadataRowCount, "METADATA_ROW_COUNT"},
+          {SpecialAggregateKind::kMetadataNullCount, "METADATA_NULL_COUNT"},
+          {SpecialAggregateKind::kMetadataNonNullCount,
+           "METADATA_NON_NULL_COUNT"},
+      };
+  return kNames;
+}
+} // namespace
+
+AXIOM_DEFINE_ENUM_NAME(SpecialAggregateKind, specialAggregateKindNames)
+
+SpecialFormAggExpr::SpecialFormAggExpr(
+    SpecialAggregateKind kind,
+    std::vector<ExprPtr> inputs,
+    AggregateExprPtr fallback)
+    : AggregateExpr{ExprKind::kSpecialFormAgg, velox::BIGINT(), std::string(SpecialAggregateKindName::toName(kind)), std::move(inputs)},
+      kind_{kind},
+      fallback_{std::move(fallback)} {
+  switch (kind_) {
+    case SpecialAggregateKind::kMetadataRowCount:
+      VELOX_USER_CHECK_EQ(
+          inputs_.size(),
+          0,
+          "Metadata aggregate takes no inputs: {}",
+          SpecialAggregateKindName::toName(kind_));
+      break;
+    case SpecialAggregateKind::kMetadataNullCount:
+    case SpecialAggregateKind::kMetadataNonNullCount:
+      VELOX_USER_CHECK_EQ(
+          inputs_.size(),
+          1,
+          "Metadata aggregate takes exactly one input: {}",
+          SpecialAggregateKindName::toName(kind_));
+      break;
+  }
+
+  if (fallback_ != nullptr) {
+    VELOX_USER_CHECK_EQ(
+        fallback_->typeKind(),
+        velox::TypeKind::BIGINT,
+        "Metadata aggregate fallback must return BIGINT");
+  }
+}
 
 namespace {
 void validateDereferenceInputs(

--- a/axiom/logical_plan/Expr.h
+++ b/axiom/logical_plan/Expr.h
@@ -32,6 +32,7 @@ enum class ExprKind {
   kWindow = 5,
   kLambda = 6,
   kSubquery = 7,
+  kSpecialFormAgg = 8,
 };
 
 AXIOM_DECLARE_ENUM_NAME(ExprKind);
@@ -114,6 +115,10 @@ class Expr : public velox::ISerializable {
 
   bool isSubquery() const {
     return kind_ == ExprKind::kSubquery;
+  }
+
+  bool isSpecialFormAgg() const {
+    return kind_ == ExprKind::kSpecialFormAgg;
   }
 
   /// Returns true if the expression appears constant such that it can be
@@ -600,7 +605,49 @@ class AggregateExpr : public Expr {
       ExprPtr filter = nullptr,
       std::vector<SortingField> ordering = {},
       bool distinct = false)
-      : Expr{ExprKind::kAggregate, std::move(type), std::move(inputs)},
+      : AggregateExpr{
+            ExprKind::kAggregate,
+            std::move(type),
+            std::move(name),
+            std::move(inputs),
+            std::move(filter),
+            std::move(ordering),
+            distinct} {}
+
+  const std::string& name() const {
+    return name_;
+  }
+
+  const ExprPtr& filter() const {
+    return filter_;
+  }
+
+  const std::vector<SortingField>& ordering() const {
+    return ordering_;
+  }
+
+  bool isDistinct() const {
+    return distinct_;
+  }
+
+  void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
+      const override;
+
+  folly::dynamic serialize() const override;
+
+  static ExprPtr create(const folly::dynamic& obj, void* context);
+
+ protected:
+  // Constructor for subclasses that use a distinct ExprKind.
+  AggregateExpr(
+      ExprKind kind,
+      velox::TypePtr type,
+      std::string name,
+      std::vector<ExprPtr> inputs,
+      ExprPtr filter = nullptr,
+      std::vector<SortingField> ordering = {},
+      bool distinct = false)
+      : Expr{kind, std::move(type), std::move(inputs)},
         name_{std::move(name)},
         filter_{std::move(filter)},
         ordering_{std::move(ordering)},
@@ -632,20 +679,73 @@ class AggregateExpr : public Expr {
     }
   }
 
-  const std::string& name() const {
-    return name_;
+  bool equalTo(const Expr& other) const override;
+
+ private:
+  void rejectLambdaCaptures() const;
+
+  const std::string name_;
+  const ExprPtr filter_;
+  const std::vector<SortingField> ordering_;
+  const bool distinct_;
+};
+
+using AggregateExprPtr = std::shared_ptr<const AggregateExpr>;
+
+/// A closed set of aggregates whose result is derivable from table metadata
+/// (row counts and per-column null counts) rather than from reading the data.
+/// The optimizer folds them from metadata when it is available and otherwise
+/// replaces them with an ordinary aggregate. The set is a closed, hard-written
+/// contract. See SpecialFormAggExpr.
+///
+/// These aggregates are order-insensitive, so ORDER BY is accepted and ignored
+/// (as for count). The FILTER and DISTINCT modifiers are not supported, and
+/// they cannot be used as window functions.
+enum class SpecialAggregateKind {
+  /// Number of rows in the group. Takes no inputs. Result type: BIGINT.
+  kMetadataRowCount = 0,
+
+  /// Number of null values of the input column in the group. Takes one input
+  /// of any type. Result type: BIGINT.
+  kMetadataNullCount = 1,
+
+  /// Number of non-null values of the input column in the group. Takes one
+  /// input of any type. Result type: BIGINT.
+  kMetadataNonNullCount = 2,
+};
+
+AXIOM_DECLARE_ENUM_NAME(SpecialAggregateKind)
+
+/// An AggregateExpr identified by a SpecialAggregateKind instead of a function
+/// name. Represents an aggregate whose result is derivable from table metadata
+/// rather than from reading the data (see SpecialAggregateKind). It never
+/// executes in Velox: the optimizer either folds it into constants from
+/// metadata or replaces it with 'fallback'.
+///
+/// Subclasses AggregateExpr so it fits anywhere an aggregate does
+/// (AggregateNode and expression resolution), but carries its own ExprKind
+/// (kSpecialFormAgg) and a SpecialAggregateKind. Its function name is the
+/// canonical name of the kind. The kind fully determines the return type
+/// (always BIGINT) and input arity, so no function registry lookup is involved.
+class SpecialFormAggExpr : public AggregateExpr {
+ public:
+  /// @param kind Which metadata aggregate this is.
+  /// @param inputs Arguments, validated per kind (0 inputs for
+  /// kMetadataRowCount, 1 for kMetadataNullCount / kMetadataNonNullCount).
+  /// @param fallback Optional ordinary aggregate to use when the aggregate
+  /// cannot be answered from metadata. If null, the aggregate is plannable only
+  /// where metadata can answer it.
+  SpecialFormAggExpr(
+      SpecialAggregateKind kind,
+      std::vector<ExprPtr> inputs,
+      AggregateExprPtr fallback = nullptr);
+
+  SpecialAggregateKind kind() const {
+    return kind_;
   }
 
-  const ExprPtr& filter() const {
-    return filter_;
-  }
-
-  const std::vector<SortingField>& ordering() const {
-    return ordering_;
-  }
-
-  bool isDistinct() const {
-    return distinct_;
+  const AggregateExprPtr& fallback() const {
+    return fallback_;
   }
 
   void accept(const ExprVisitor& visitor, ExprVisitorContext& context)
@@ -658,15 +758,11 @@ class AggregateExpr : public Expr {
  private:
   bool equalTo(const Expr& other) const override;
 
-  void rejectLambdaCaptures() const;
-
-  const std::string name_;
-  const ExprPtr filter_;
-  const std::vector<SortingField> ordering_;
-  const bool distinct_;
+  const SpecialAggregateKind kind_;
+  const AggregateExprPtr fallback_;
 };
 
-using AggregateExprPtr = std::shared_ptr<const AggregateExpr>;
+using SpecialFormAggExprPtr = std::shared_ptr<const SpecialFormAggExpr>;
 
 /// Represents a window function call. Can be used in ProjectNode.
 /// See https://prestodb.io/docs/current/functions/window.html for SQL-level

--- a/axiom/logical_plan/ExprApi.cpp
+++ b/axiom/logical_plan/ExprApi.cpp
@@ -171,6 +171,24 @@ ExprApi Exists(const ExprApi& input) {
       "exists", std::vector<velox::core::ExprPtr>{input.expr()}, kNoAlias)};
 }
 
+ExprApi MetadataRowCount() {
+  return ExprApi{std::make_shared<velox::core::SpecialFormAggCallExpr>(
+      SpecialAggregateKind::kMetadataRowCount,
+      std::vector<velox::core::ExprPtr>{})};
+}
+
+ExprApi MetadataNullCount(const ExprApi& input) {
+  return ExprApi{std::make_shared<velox::core::SpecialFormAggCallExpr>(
+      SpecialAggregateKind::kMetadataNullCount,
+      std::vector<velox::core::ExprPtr>{input.expr()})};
+}
+
+ExprApi MetadataNonNullCount(const ExprApi& input) {
+  return ExprApi{std::make_shared<velox::core::SpecialFormAggCallExpr>(
+      SpecialAggregateKind::kMetadataNonNullCount,
+      std::vector<velox::core::ExprPtr>{input.expr()})};
+}
+
 ExprApi Sql(const std::string& sql) {
   return ExprApi{velox::parse::DuckSqlExpressionsParser().parseExpr(sql)};
 }

--- a/axiom/logical_plan/ExprApi.h
+++ b/axiom/logical_plan/ExprApi.h
@@ -93,6 +93,94 @@ class SubqueryExpr : public core::IExpr {
   const axiom::logical_plan::LogicalPlanNodePtr subquery_;
 };
 
+/// Untyped carrier for a metadata-answerable aggregate. Subclasses
+/// AggregateCallExpr so it flows through aggregate detection and type
+/// resolution as an ordinary aggregate; ExprResolver recognizes it by type and
+/// produces an axiom::logical_plan::SpecialFormAggExpr. Carries the optional
+/// fallback aggregate (e.g. count(*)) the dialect supplies.
+class SpecialFormAggCallExpr : public AggregateCallExpr {
+ public:
+  /// 'name' is the dialect-supplied name for the aggregate; defaults to the
+  /// kind name when the caller has no better name.
+  SpecialFormAggCallExpr(
+      axiom::logical_plan::SpecialAggregateKind kind,
+      std::vector<ExprPtr> inputs,
+      ExprPtr fallback = nullptr,
+      std::optional<std::string> alias = std::nullopt,
+      std::optional<std::string> name = std::nullopt)
+      : AggregateCallExpr(
+            name.has_value()
+                ? std::move(*name)
+                : std::string(
+                      axiom::logical_plan::SpecialAggregateKindName::toName(
+                          kind)),
+            std::move(inputs),
+            /*distinct=*/false,
+            /*filter=*/nullptr,
+            /*orderBy=*/{},
+            std::move(alias)),
+        specialAggregateKind_{kind},
+        fallback_{std::move(fallback)} {}
+
+  axiom::logical_plan::SpecialAggregateKind specialAggregateKind() const {
+    return specialAggregateKind_;
+  }
+
+  const ExprPtr& fallback() const {
+    return fallback_;
+  }
+
+  ExprPtr replaceInputs(std::vector<ExprPtr> newInputs) const override {
+    return std::make_shared<SpecialFormAggCallExpr>(
+        specialAggregateKind_,
+        std::move(newInputs),
+        fallback_,
+        alias(),
+        name());
+  }
+
+  ExprPtr withAlias(const std::string& alias) const override {
+    return std::make_shared<SpecialFormAggCallExpr>(
+        specialAggregateKind_, inputs(), fallback_, alias, name());
+  }
+
+  ExprPtr dropAlias() const override {
+    return std::make_shared<SpecialFormAggCallExpr>(
+        specialAggregateKind_, inputs(), fallback_, std::nullopt, name());
+  }
+
+  bool operator==(const IExpr& other) const override {
+    const auto* casted = dynamic_cast<const SpecialFormAggCallExpr*>(&other);
+    if (casted == nullptr) {
+      return false;
+    }
+    if (specialAggregateKind_ != casted->specialAggregateKind_) {
+      return false;
+    }
+    if ((fallback_ == nullptr) != (casted->fallback_ == nullptr)) {
+      return false;
+    }
+    if (fallback_ != nullptr && !(*fallback_ == *casted->fallback_)) {
+      return false;
+    }
+    return compareAliasAndInputs(other);
+  }
+
+ protected:
+  size_t localHash() const override {
+    size_t hash =
+        std::hash<int8_t>{}(static_cast<int8_t>(specialAggregateKind_));
+    if (fallback_ != nullptr) {
+      hash = bits::hashMix(hash, fallback_->hash());
+    }
+    return hash;
+  }
+
+ private:
+  const axiom::logical_plan::SpecialAggregateKind specialAggregateKind_;
+  const ExprPtr fallback_;
+};
+
 } // namespace facebook::velox::core
 namespace facebook::axiom::logical_plan {
 namespace detail {
@@ -315,6 +403,18 @@ ExprApi Lambda(std::vector<std::string> names, const ExprApi& body);
 ExprApi Subquery(std::shared_ptr<const LogicalPlanNode> subquery);
 
 ExprApi Exists(const ExprApi& input);
+
+/// Builds a metadata row-count aggregate
+/// (SpecialAggregateKind::kMetadataRowCount). Takes no arguments.
+ExprApi MetadataRowCount();
+
+/// Builds a metadata null-count aggregate
+/// (SpecialAggregateKind::kMetadataNullCount) over 'input'.
+ExprApi MetadataNullCount(const ExprApi& input);
+
+/// Builds a metadata non-null-count aggregate
+/// (SpecialAggregateKind::kMetadataNonNullCount) over 'input'.
+ExprApi MetadataNonNullCount(const ExprApi& input);
 
 ExprApi Sql(const std::string& sql);
 

--- a/axiom/logical_plan/ExprPrinter.cpp
+++ b/axiom/logical_plan/ExprPrinter.cpp
@@ -90,6 +90,20 @@ class ToTextVisitor : public ExprVisitor {
     }
   }
 
+  void visit(const SpecialFormAggExpr& expr, ExprVisitorContext& context)
+      const override {
+    auto& out = toOut(context);
+
+    out << SpecialAggregateKindName::toName(expr.kind());
+    appendInputs(expr, out, context);
+
+    if (expr.fallback() != nullptr) {
+      out << " [fallback: ";
+      expr.fallback()->accept(*this, context);
+      out << "]";
+    }
+  }
+
   void visit(const WindowExpr& expr, ExprVisitorContext& context)
       const override {
     auto& out = toOut(context);

--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -911,10 +911,7 @@ ExprResolver::ResolvedCall ExprResolver::resolveCallTypes(
   const auto numArgs = call->inputs().size();
   std::vector<ExprPtr> inputs;
   if (lambdaSignature == nullptr) {
-    inputs.reserve(numArgs);
-    for (const auto& input : call->inputs()) {
-      inputs.push_back(resolveScalarTypes(input, inputNameResolver));
-    }
+    inputs = resolveScalarInputs(call->inputs(), inputNameResolver);
   } else {
     // Resolve non-lambda arguments first, then infer lambda parameter types
     // from the function signature.
@@ -968,10 +965,65 @@ ExprResolver::ResolvedCall ExprResolver::resolveCallTypes(
 
 AggregateExprPtr ExprResolver::resolveAggregateTypes(
     const velox::core::ExprPtr& expr,
+    const InputNameResolver& inputNameResolver) const {
+  velox::core::ExprPtr filter;
+  std::vector<SortKey> ordering;
+  bool distinct = false;
+  if (const auto* agg = expr->as<velox::core::AggregateCallExpr>()) {
+    filter = agg->filter();
+    for (const auto& key : agg->orderBy()) {
+      ordering.emplace_back(ExprApi(key.expr), key.ascending, key.nullsFirst);
+    }
+    distinct = agg->isDistinct();
+  }
+  return resolveAggregateTypes(
+      expr, inputNameResolver, filter, ordering, distinct);
+}
+
+std::vector<ExprPtr> ExprResolver::resolveScalarInputs(
+    const std::vector<velox::core::ExprPtr>& inputs,
+    const InputNameResolver& inputNameResolver) const {
+  std::vector<ExprPtr> result;
+  result.reserve(inputs.size());
+  for (const auto& input : inputs) {
+    result.push_back(resolveScalarTypes(input, inputNameResolver));
+  }
+  return result;
+}
+
+AggregateExprPtr ExprResolver::resolveSpecialFormAgg(
+    const velox::core::SpecialFormAggCallExpr& expr,
+    const InputNameResolver& inputNameResolver,
+    const velox::core::ExprPtr& filter,
+    bool distinct) const {
+  VELOX_USER_CHECK(
+      !distinct,
+      "DISTINCT is not supported for metadata aggregate {}",
+      expr.name());
+  VELOX_USER_CHECK_NULL(
+      filter, "FILTER is not supported for metadata aggregate {}", expr.name());
+
+  auto inputs = resolveScalarInputs(expr.inputs(), inputNameResolver);
+
+  AggregateExprPtr fallback;
+  if (expr.fallback() != nullptr) {
+    fallback = resolveAggregateTypes(expr.fallback(), inputNameResolver);
+  }
+
+  return std::make_shared<SpecialFormAggExpr>(
+      expr.specialAggregateKind(), std::move(inputs), std::move(fallback));
+}
+
+AggregateExprPtr ExprResolver::resolveAggregateTypes(
+    const velox::core::ExprPtr& expr,
     const InputNameResolver& inputNameResolver,
     const velox::core::ExprPtr& filter,
     const std::vector<SortKey>& ordering,
     bool distinct) const {
+  if (const auto* special = expr->as<velox::core::SpecialFormAggCallExpr>()) {
+    return resolveSpecialFormAgg(*special, inputNameResolver, filter, distinct);
+  }
+
   auto resolved = resolveCallTypes(
       expr,
       inputNameResolver,

--- a/axiom/logical_plan/ExprResolver.h
+++ b/axiom/logical_plan/ExprResolver.h
@@ -84,6 +84,13 @@ class ExprResolver {
       const std::vector<SortKey>& ordering,
       bool distinct) const;
 
+  /// Resolves an aggregate call, extracting DISTINCT / FILTER / ORDER BY from
+  /// 'expr' itself (an AggregateCallExpr or SpecialFormAggCallExpr). Used for
+  /// nested aggregates such as a special aggregate's fallback.
+  AggregateExprPtr resolveAggregateTypes(
+      const velox::core::ExprPtr& expr,
+      const InputNameResolver& inputNameResolver) const;
+
   /// Resolves a window function call. Resolves argument types, partition keys,
   /// ordering, and frame bounds, then looks up the window function signature
   /// and produces a WindowExpr.
@@ -107,6 +114,20 @@ class ExprResolver {
     std::vector<ExprPtr> inputs;
     velox::TypePtr type;
   };
+
+  // Resolves a list of untyped scalar arguments to typed expressions.
+  std::vector<ExprPtr> resolveScalarInputs(
+      const std::vector<velox::core::ExprPtr>& inputs,
+      const InputNameResolver& inputNameResolver) const;
+
+  // Resolves a SpecialFormAggCallExpr into a SpecialFormAggExpr. These
+  // aggregates reject the DISTINCT and FILTER modifiers ('filter' / 'distinct'
+  // here) and ignore ORDER BY (order-insensitive).
+  AggregateExprPtr resolveSpecialFormAgg(
+      const velox::core::SpecialFormAggCallExpr& expr,
+      const InputNameResolver& inputNameResolver,
+      const velox::core::ExprPtr& filter,
+      bool distinct) const;
 
   // Resolves function call arguments (including lambdas) and determines the
   // return type using the provided resolve functions. Used by both

--- a/axiom/logical_plan/ExprVisitor.h
+++ b/axiom/logical_plan/ExprVisitor.h
@@ -41,6 +41,10 @@ class ExprVisitor {
   virtual void visit(const AggregateExpr& expr, ExprVisitorContext& context)
       const = 0;
 
+  virtual void visit(
+      const SpecialFormAggExpr& expr,
+      ExprVisitorContext& context) const = 0;
+
   virtual void visit(const WindowExpr& expr, ExprVisitorContext& context)
       const = 0;
 

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -20,6 +20,7 @@
 #include "axiom/connectors/ConnectorMetadata.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/NameMappings.h"
+#include "velox/expression/FunctionSignature.h"
 #include "velox/type/TypeCoercer.h"
 
 namespace facebook::axiom::logical_plan {
@@ -921,28 +922,19 @@ void PlanBuilder::resolveAggregates(
   for (size_t i = 0; i < aggregates.size(); ++i) {
     const auto& aggregate = aggregates[i];
 
-    velox::core::ExprPtr filter;
-    std::vector<SortKey> sortKeys;
-    bool distinct = false;
-
-    if (aggregate.expr()->is(velox::core::IExpr::Kind::kAggregate)) {
-      auto* agg = aggregate.expr()->as<velox::core::AggregateCallExpr>();
-      filter = agg->filter();
-      for (const auto& key : agg->orderBy()) {
-        sortKeys.emplace_back(ExprApi(key.expr), key.ascending, key.nullsFirst);
-      }
-      distinct = agg->isDistinct();
-    }
-
-    auto expr =
-        resolveAggregateTypes(aggregate.expr(), filter, sortKeys, distinct);
+    auto expr = resolveAggregateTypes(aggregate.expr());
 
     if (aggregate.name().has_value()) {
       const auto& alias = aggregate.name().value();
       outputNames.push_back(newName(alias));
       tracker.add(alias, outputNames.back());
     } else {
-      outputNames.push_back(newName(expr->name()));
+      // Derive the output name from the parse-time call name, canonicalized so
+      // it reflects the source function rather than any internal name the
+      // resolved expr may carry.
+      const auto* call = aggregate.expr()->as<velox::core::CallExpr>();
+      VELOX_CHECK_NOT_NULL(call, "Aggregate expression must be a call");
+      outputNames.push_back(newName(velox::exec::sanitizeName(call->name())));
     }
 
     exprs.emplace_back(std::move(expr));
@@ -1847,18 +1839,11 @@ ExprPtr PlanBuilder::resolveScalarTypes(
 }
 
 AggregateExprPtr PlanBuilder::resolveAggregateTypes(
-    const velox::core::ExprPtr& expr,
-    const velox::core::ExprPtr& filter,
-    const std::vector<SortKey>& ordering,
-    bool distinct) const {
+    const velox::core::ExprPtr& expr) const {
   return resolver_.resolveAggregateTypes(
-      expr,
-      [&](const auto& alias, const auto& name) {
+      expr, [&](const auto& alias, const auto& name) {
         return resolveInputName(alias, name);
-      },
-      filter,
-      ordering,
-      distinct);
+      });
 }
 
 WindowExprPtr PlanBuilder::resolveWindowTypes(

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -875,10 +875,7 @@ class PlanBuilder {
   ExprPtr resolveScalarTypes(const velox::core::ExprPtr& expr) const;
 
   AggregateExprPtr resolveAggregateTypes(
-      const velox::core::ExprPtr& expr,
-      const velox::core::ExprPtr& filter,
-      const std::vector<SortKey>& ordering,
-      bool distinct) const;
+      const velox::core::ExprPtr& expr) const;
 
   WindowExprPtr resolveWindowTypes(
       const velox::core::WindowCallExpr& windowCallExpr) const;

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -527,6 +527,15 @@ class SummarizeExprVisitor : public ExprVisitor {
     visitInputs(expr, ctx);
   }
 
+  void visit(const SpecialFormAggExpr& expr, ExprVisitorContext& ctx)
+      const override {
+    auto& myCtx = static_cast<Context&>(ctx);
+    myCtx.expressionCounts()["aggregate"]++;
+    myCtx.functionCounts()[std::string(
+        SpecialAggregateKindName::toName(expr.kind()))]++;
+    visitInputs(expr, ctx);
+  }
+
   void visit(const WindowExpr& expr, ExprVisitorContext& ctx) const override {
     auto& myCtx = static_cast<Context&>(ctx);
     myCtx.expressionCounts()["window"]++;

--- a/axiom/optimizer/ConstantExprEvaluator.cpp
+++ b/axiom/optimizer/ConstantExprEvaluator.cpp
@@ -65,6 +65,12 @@ class ExprTranslator : public lp::ExprVisitor {
     VELOX_NYI();
   }
 
+  void visit(
+      const lp::SpecialFormAggExpr& expr,
+      lp::ExprVisitorContext& context) const {
+    VELOX_NYI();
+  }
+
   void visit(const lp::WindowExpr& expr, lp::ExprVisitorContext& context)
       const {
     VELOX_NYI();

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1267,7 +1267,10 @@ class Aggregate : public Call {
       ExprCP condition,
       const velox::Type* intermediateType,
       ExprVector orderKeys,
-      OrderTypeVector orderTypes)
+      OrderTypeVector orderTypes,
+      std::optional<logical_plan::SpecialAggregateKind> specialKind =
+          std::nullopt,
+      const Aggregate* fallback = nullptr)
       : Call(
             PlanType::kAggregateExpr,
             name,
@@ -1278,7 +1281,9 @@ class Aggregate : public Call {
         condition_(condition),
         intermediateType_(intermediateType),
         orderKeys_(std::move(orderKeys)),
-        orderTypes_(std::move(orderTypes)) {
+        orderTypes_(std::move(orderTypes)),
+        specialKind_(specialKind),
+        fallback_(fallback) {
     VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
 
     for (auto& arg : this->args()) {
@@ -1314,6 +1319,21 @@ class Aggregate : public Call {
 
   const OrderTypeVector& orderTypes() const {
     return orderTypes_;
+  }
+
+  /// The metadata-aggregate kind if this is a special-form metadata aggregate,
+  /// or std::nullopt for an ordinary aggregate. A metadata aggregate is folded
+  /// into constants from table metadata or replaced by 'fallback' before
+  /// lowering; its 'name' is the canonical kind name and is never lowered to a
+  /// Velox aggregate.
+  const std::optional<logical_plan::SpecialAggregateKind>& specialKind() const {
+    return specialKind_;
+  }
+
+  /// For a metadata aggregate, the ordinary aggregate (e.g. count) to use when
+  /// no connector can answer it from metadata, or nullptr if none was supplied.
+  const Aggregate* fallback() const {
+    return fallback_;
   }
 
   /// Returns a copy with isDistinct set to false.
@@ -1361,6 +1381,8 @@ class Aggregate : public Call {
   TypeVector rawInputType_;
   ExprVector orderKeys_;
   OrderTypeVector orderTypes_;
+  const std::optional<logical_plan::SpecialAggregateKind> specialKind_;
+  const Aggregate* fallback_;
 };
 
 using AggregateCP = const Aggregate*;

--- a/axiom/optimizer/docs/Testing.md
+++ b/axiom/optimizer/docs/Testing.md
@@ -299,16 +299,19 @@ Test tables are declared at the top of the `.sql` file via setup directives. Sta
 
 | Directive | Behavior |
 |---|---|
+| `-- connector: <test\|hive>` | Selects the connector the file's setup DDL and queries run against. Defaults to `test`. |
 | `-- setup_file: relative.sql` | Splice in the contents of another `.sql` file as setup statements. Path is relative to the directory of the file containing the directive. |
 | `-- setup` … `-- end_setup` | Inline block of setup statements. |
 
 Both forms can appear any number of times, in any order, before the first query. Setup directives appearing after a query has started are rejected — install all tables first, then write queries.
 
+**Choosing a connector.** By default a file runs against the in-memory `TestConnector`. Add `-- connector: hive` to run against a LocalHive connector instead: setup DDL then executes as real `CREATE TABLE` / `INSERT` / `CTAS` writing DWRF files, partition metadata, and write-time stats to a temp directory — so features that read from partition metadata (e.g. the metadata-count fold) are actually exercised. Use `CREATE TABLE ... WITH (partitioned_by = ARRAY['k'])` for partitioned tables (partition columns come last in the schema).
+
 Setup statements run via Axiom's PrestoParser:
 
-- `CREATE TABLE name(col TYPE, ...)` registers an empty table.
-- `INSERT INTO name VALUES (...), ...`, `INSERT INTO name SELECT ...`, and `CREATE TABLE name AS SELECT ...` install rows. Each `INSERT` produces one TestConnector split — use multiple `INSERT`s when you want a multi-split table.
-- All statements are also mirrored into DuckDB so result comparison works against the same data. There is no `-- duckdb:` override for setup statements; setup SQL must be valid in both Presto and DuckDB. Stick to portable types (`BIGINT`, `DOUBLE`, `VARCHAR`, `BOOLEAN`, `DATE`, …) and literal `VALUES`.
+- `CREATE TABLE name(col TYPE, ...)` registers a table (with any table properties).
+- `INSERT INTO name VALUES (...), ...`, `INSERT INTO name SELECT ...`, and `CREATE TABLE name AS SELECT ...` install rows.
+- All statements are also mirrored into DuckDB so result comparison works against the same data — with Presto table properties (`WITH (...)`) stripped, since DuckDB doesn't understand them. There is no `-- duckdb:` override for setup statements; setup SQL must otherwise be valid in both Presto and DuckDB. Stick to portable types (`BIGINT`, `DOUBLE`, `VARCHAR`, `BOOLEAN`, `DATE`, …) and literal `VALUES`.
 
 Most files share the standard table `t` via the project-wide setup file:
 

--- a/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
+++ b/axiom/optimizer/tests/AxiomSqlBenchmark.cpp
@@ -278,7 +278,8 @@ class VeloxRunner : public velox::QueryBenchmarkBase {
         kHiveConnectorId,
         std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
             dynamic_cast<velox::connector::hive::HiveConnector*>(
-                connector.get())));
+                connector.get()),
+            velox::memory::memoryManager()->addRootPool()));
 
     return connector;
   }

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ target_link_libraries(
   axiom_optimizer_tests_plan_matcher
   velox_hive_connector
   velox_parse_parser
+  velox_exec_test_lib
   GTest::gmock
   glog::glog
   GTest::gtest
@@ -121,6 +122,7 @@ add_executable(
   HiveLimitQueriesTest.cpp
   HiveQueriesTest.cpp
   JoinTest.cpp
+  MetadataCountsTest.cpp
   MultiFragmentPlanTest.cpp
   NonDeterministicFlagTest.cpp
   TpchDataGenerator.cpp

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -133,7 +133,7 @@ void HiveQueriesTestBase::setupHiveConnector() {
           .get());
 
   auto metadata = std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
-      hiveConnector);
+      hiveConnector, velox::memory::memoryManager()->addRootPool());
   hiveMetadata_ = metadata.get();
 
   connector::ConnectorMetadataRegistry::global().insert(

--- a/axiom/optimizer/tests/MetadataCountsTest.cpp
+++ b/axiom/optimizer/tests/MetadataCountsTest.cpp
@@ -1,0 +1,188 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gmock/gmock.h>
+
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+
+using namespace facebook::velox;
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+// Tests the metadata aggregates (approx_count_star, approx_null_count,
+// approx_non_null_count) in the v2 optimizer. A query whose grouping and
+// filters are answerable from partition metadata folds to a Values node holding
+// the exact counts, so no data is read; anything else falls back to reading the
+// data. Result correctness under execution is covered by
+// sql/metadataAggregate.sql.
+//
+// Table t: column a is null exactly in partition k=0; partitions k = 0/1/2 have
+// 9/8/8 rows (25 total), so a has 9 nulls and 16 non-nulls.
+class MetadataCountsTest : public test::HiveQueriesTestBase {
+ protected:
+  MetadataCountsTest() {
+    useV2_ = true;
+  }
+
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_NATION});
+  }
+
+  void SetUp() override {
+    test::HiveQueriesTestBase::SetUp();
+
+    runCtas(
+        "CREATE TABLE t WITH (partitioned_by = ARRAY['k']) AS "
+        "SELECT IF(n_nationkey % 3 > 0, n_nationkey) AS a, n_nationkey % 3 AS k "
+        "FROM nation");
+  }
+
+  void TearDown() override {
+    hiveMetadata().dropTableIfExists("t");
+    test::HiveQueriesTestBase::TearDown();
+  }
+};
+
+// --- Answered from partition metadata: folds to a constant, reads no data. ---
+
+TEST_F(MetadataCountsTest, rowCount) {
+  auto makeExpected = [&](int64_t count) {
+    return makeRowVector({makeFlatVector<int64_t>({count})});
+  };
+
+  {
+    auto plan = toSingleNodePlan("SELECT approx_count_star() FROM t");
+    AXIOM_ASSERT_PLAN(plan, matchValues(makeExpected(25)).build());
+    EXPECT_THAT(
+        plan->outputType()->names(),
+        ::testing::ElementsAre("approx_count_star"));
+  }
+
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT k, approx_count_star() as x FROM t GROUP BY 1");
+    AXIOM_ASSERT_PLAN(
+        plan,
+        matchValues(makeRowVector({
+                        makeFlatVector<int64_t>({0, 1, 2}),
+                        makeFlatVector<int64_t>({9, 8, 8}),
+                    }))
+            .build());
+    EXPECT_THAT(plan->outputType()->names(), ::testing::ElementsAre("k", "x"));
+  }
+
+  // Unpartitioned table: a single whole-table count.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT approx_count_star() FROM nation"),
+      matchValues(makeExpected(25)).build());
+
+  // A filter on a partition column is pushed into the scan and answered from
+  // metadata; only the matching partition is counted.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT approx_count_star() FROM t WHERE k = 1"),
+      matchValues(makeExpected(8)).build());
+
+  // A filter matching no partition yields one row: 0.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT approx_count_star() FROM t WHERE k = 9"),
+      matchValues(makeExpected(0)).build());
+}
+
+TEST_F(MetadataCountsTest, nullCounts) {
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT k, approx_null_count(a) FROM t GROUP BY 1"),
+      matchValues(makeRowVector({
+                      makeFlatVector<int64_t>({0, 1, 2}),
+                      makeFlatVector<int64_t>({9, 0, 0}),
+                  }))
+          .build());
+
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT k, approx_non_null_count(a) FROM t GROUP BY 1"),
+      matchValues(makeRowVector({
+                      makeFlatVector<int64_t>({0, 1, 2}),
+                      makeFlatVector<int64_t>({0, 8, 8}),
+                  }))
+          .build());
+}
+
+TEST_F(MetadataCountsTest, multipleAndDerivedAggregates) {
+  // Several metadata aggregates fold together into a single row.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(
+          "SELECT approx_count_star(), approx_null_count(a), "
+          "approx_non_null_count(a) FROM t"),
+      matchValues(makeRowVector({
+                      makeFlatVector<int64_t>({25}),
+                      makeFlatVector<int64_t>({9}),
+                      makeFlatVector<int64_t>({16}),
+                  }))
+          .build());
+
+  // An expression over metadata aggregates folds, with the arithmetic left as a
+  // projection over the folded counts.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(
+          "SELECT approx_count_star() - approx_null_count(a) FROM t"),
+      matchValues(makeRowVector({
+                      makeFlatVector<int64_t>({25}),
+                      makeFlatVector<int64_t>({9}),
+                  }))
+          .project({"c0 - c1"})
+          .build());
+}
+
+// --- Not answerable from metadata: falls back to reading the data. ---
+
+TEST_F(MetadataCountsTest, fallsBack) {
+  // Grouping by a data column.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT a, approx_count_star() FROM t GROUP BY a"),
+      matchHiveScan("t").singleAggregation({"a"}, {"count(*)"}).build());
+
+  // Filter on a data column.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT approx_count_star() FROM t WHERE a > 5"),
+      matchHiveScan("t").singleAggregation({}, {"count(*)"}).build());
+
+  // A regular aggregate alongside a metadata aggregate.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan("SELECT approx_count_star(), sum(a) FROM t"),
+      matchHiveScan("t").singleAggregation({}, {"count(*)", "sum(a)"}).build());
+}
+
+TEST_F(MetadataCountsTest, unionAll) {
+  // One leg is answered from metadata (folds to a constant), the other reads
+  // the data.
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(
+          "SELECT approx_count_star() as x FROM t UNION ALL SELECT sum(a) FROM t"),
+      matchValues(makeRowVector({makeFlatVector<int64_t>({25})}))
+          .project()
+          .localPartition({
+              matchHiveScan("t")
+                  .aliases({"a"})
+                  .singleAggregation({}, {"sum(a)"})
+                  .project()
+                  .build(),
+          })
+          .build());
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -22,6 +22,7 @@
 #include "velox/connectors/hive/TableHandle.h"
 #include "velox/duckdb/conversion/DuckParser.h"
 #include "velox/exec/HashPartitionFunction.h"
+#include "velox/exec/tests/utils/QueryAssertions.h"
 #include "velox/parse/ExprRewriter.h"
 #include "velox/parse/Expressions.h"
 #include "velox/parse/ExpressionsParser.h"
@@ -62,7 +63,7 @@ class PlanMatcherImpl : public PlanMatcher {
       const PlanNodePtr& plan,
       const std::unordered_map<std::string, std::string>& symbols,
       const DistributedMatchContext* context) const override {
-    const auto* specificNode = dynamic_cast<const T*>(plan.get());
+    const auto* specificNode = plan->as<T>();
     EXPECT_TRUE(specificNode != nullptr)
         << "Expected " << folly::demangle(typeid(T).name()) << ", but got "
         << plan->toString(false, false);
@@ -98,9 +99,19 @@ class PlanMatcherImpl : public PlanMatcher {
     }
 
     auto result = matchDetails(*specificNode, newSymbols);
-    if (!result.match || aliases_.empty()) {
+    if (!result.match) {
       return result;
     }
+
+    if (onMatch_) {
+      onMatch_(plan);
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
+    if (aliases_.empty()) {
+      return result;
+    }
+
     const auto& names = plan->outputType()->names();
     VELOX_USER_CHECK_LE(aliases_.size(), names.size());
     auto resultSymbols = result.symbols;
@@ -1062,11 +1073,11 @@ void verifyShuffleConsumer(
     const PlanNodePtr& plan,
     std::optional<ShuffleType> type) {
   if (type == ShuffleType::kOrdered) {
-    EXPECT_TRUE(dynamic_cast<const MergeExchangeNode*>(plan.get()) != nullptr)
+    EXPECT_TRUE(plan->is<MergeExchangeNode>())
         << "Expected MergeExchange at shuffle boundary, but got "
         << plan->toString(false, false);
   } else {
-    EXPECT_TRUE(dynamic_cast<const ExchangeNode*>(plan.get()) != nullptr)
+    EXPECT_TRUE(plan->is<ExchangeNode>())
         << "Expected Exchange at shuffle boundary, but got "
         << plan->toString(false, false);
   }
@@ -1186,8 +1197,7 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
   AXIOM_TEST_RETURN_IF_FAILURE
 
   const auto& fragmentPlan = producerFragment->fragment.planNode;
-  const auto* partitionedOutput =
-      dynamic_cast<const PartitionedOutputNode*>(fragmentPlan.get());
+  const auto* partitionedOutput = fragmentPlan->as<PartitionedOutputNode>();
   EXPECT_TRUE(partitionedOutput != nullptr)
       << "Expected PartitionedOutput at fragment root, but got "
       << fragmentPlan->toString(false, false);
@@ -1894,15 +1904,49 @@ PlanMatcherBuilder& PlanMatcherBuilder::hiveScan(
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::values() {
+PlanMatcherBuilder& PlanMatcherBuilder::values(OnMatchCallback onMatch) {
   VELOX_USER_CHECK_NULL(matcher_);
   matcher_ = std::make_shared<ValuesMatcher>();
+  if (onMatch) {
+    matcher_->setOnMatch(std::move(onMatch));
+  }
   return *this;
 }
+
+namespace {
+// Returns a row type's column names as aliases (by position) so downstream
+// matchers can reference the columns by name rather than the
+// optimizer-generated internal names.
+std::vector<std::optional<std::string>> toAliases(const RowTypePtr& rowType) {
+  std::vector<std::optional<std::string>> aliases;
+  aliases.reserve(rowType->size());
+  for (const auto& name : rowType->names()) {
+    aliases.emplace_back(name);
+  }
+  return aliases;
+}
+} // namespace
 
 PlanMatcherBuilder& PlanMatcherBuilder::values(const RowTypePtr& outputType) {
   VELOX_USER_CHECK_NULL(matcher_);
   matcher_ = std::make_shared<ValuesMatcher>(outputType);
+  matcher_->setAliases(toAliases(outputType));
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::values(
+    const std::vector<RowVectorPtr>& expected) {
+  VELOX_USER_CHECK_NULL(matcher_);
+  VELOX_USER_CHECK(
+      !expected.empty(), "values() expects at least one RowVector");
+  matcher_ = std::make_shared<ValuesMatcher>();
+
+  matcher_->setOnMatch([expected](const PlanNodePtr& node) {
+    velox::exec::test::assertEqualResults(
+        expected, node->as<ValuesNode>()->values());
+  });
+
+  matcher_->setAliases(toAliases(expected.front()->rowType()));
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <functional>
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/core/PlanNode.h"
 #include "velox/type/Filter.h"
@@ -131,10 +132,18 @@ class PlanMatcher {
     aliases_ = std::move(aliases);
   }
 
+  /// Registers a callback invoked with the matched node on a successful match.
+  void setOnMatch(std::function<void(const PlanNodePtr&)> onMatch) {
+    onMatch_ = std::move(onMatch);
+  }
+
  protected:
   // Aliases bound to the matched node's output columns by position.
   // Applied on successful match by PlanMatcherImpl::match().
   std::vector<std::optional<std::string>> aliases_;
+
+  // Invoked with the matched node on a successful match, if set.
+  std::function<void(const PlanNodePtr&)> onMatch_;
 };
 
 /// Match details for a HashJoin node beyond join type. Each field is
@@ -161,6 +170,9 @@ struct HashJoinDetails {
 
 class PlanMatcherBuilder {
  public:
+  /// Callback invoked with the matched node on a successful match.
+  using OnMatchCallback = std::function<void(const PlanNodePtr&)>;
+
   /// Matches any TableScan node regardless of table name or output type.
   PlanMatcherBuilder& tableScan();
 
@@ -191,12 +203,22 @@ class PlanMatcherBuilder {
       const std::string& remainingFilter = "",
       std::optional<double> sampleRate = std::nullopt);
 
-  /// Matches any Values node regardless of type.
-  PlanMatcherBuilder& values();
+  /// Matches any Values node regardless of type. 'onMatch', if set, is invoked
+  /// with the matched Values node.
+  PlanMatcherBuilder& values(OnMatchCallback onMatch = nullptr);
 
-  /// Matches a Values node with the specified output type.
+  /// Matches a Values node with the specified output type. Only the number of
+  /// columns and their types are asserted, not the column names. The names in
+  /// 'outputType' are registered as aliases (by position) so downstream
+  /// matchers can reference the columns by those names.
   /// @param outputType The expected output type of the Values node.
   PlanMatcherBuilder& values(const RowTypePtr& outputType);
+
+  /// Matches a Values node whose rows equal 'expected' (order-insensitive).
+  /// Only the number of columns and their types are asserted, not the column
+  /// names. The names in 'expected's row type are registered as aliases (by
+  /// position) so downstream matchers can reference the columns by those names.
+  PlanMatcherBuilder& values(const std::vector<RowVectorPtr>& expected);
 
   /// Matches any Filter node regardless of predicate.
   PlanMatcherBuilder& filter();

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -255,6 +255,13 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
     return velox::core::PlanMatcherBuilder().values(outputType);
   }
 
+  /// Matches a Values node whose rows equal 'expected' (order-insensitive).
+  static velox::core::PlanMatcherBuilder matchValues(
+      const velox::RowVectorPtr& expected) {
+    return velox::core::PlanMatcherBuilder().values(
+        std::vector<velox::RowVectorPtr>{expected});
+  }
+
   /// Creates a QueryCtx with the specified query ID.
   std::shared_ptr<velox::core::QueryCtx> makeQueryCtx(
       const std::string& queryId);

--- a/axiom/optimizer/tests/SqlFile.cpp
+++ b/axiom/optimizer/tests/SqlFile.cpp
@@ -259,6 +259,22 @@ SqlFile SqlFile::parse(std::string_view content, std::string_view baseDir) {
       continue;
     }
 
+    if (trimmed.starts_with("-- connector:")) {
+      auto name = std::string(ltrim(trimmed.substr(13)));
+      rtrim(name);
+      if (name == "test") {
+        result.connector = TestConnectorKind::kTest;
+      } else if (name == "hive") {
+        result.connector = TestConnectorKind::kLocalHive;
+      } else {
+        VELOX_USER_FAIL(
+            "Unknown connector directive '{}' (expected 'test' or 'hive')",
+            name);
+      }
+      bytesConsumed = lineEnd;
+      continue;
+    }
+
     if (trimmed.starts_with("-- setup_file:")) {
       auto refPath = std::string(ltrim(trimmed.substr(15)));
       VELOX_USER_CHECK(!refPath.empty(), "setup_file directive missing path");

--- a/axiom/optimizer/tests/SqlFile.h
+++ b/axiom/optimizer/tests/SqlFile.h
@@ -26,6 +26,16 @@
 
 namespace facebook::axiom::optimizer::test {
 
+/// Selects the connector a .sql test file's setup DDL and queries run against.
+enum class TestConnectorKind {
+  /// In-memory TestConnector (default).
+  kTest,
+  /// LocalHive connector: setup DDL runs as real CREATE TABLE / INSERT / CTAS,
+  /// so on-disk data, partition metadata, and write-time stats are available
+  /// (e.g. for metadata-count folds).
+  kLocalHive,
+};
+
 /// Represents a single SQL query parsed from a test file, along with its
 /// assertion type and any annotation parameters.
 struct QueryEntry {
@@ -69,10 +79,16 @@ struct SqlFile {
   /// Query entries parsed from the body of the file.
   std::vector<QueryEntry> entries;
 
+  /// Connector the file's setup DDL and queries run against, from a top-of-file
+  /// '-- connector: <test|hive>' directive. Defaults to kTest.
+  TestConnectorKind connector{TestConnectorKind::kTest};
+
   /// Parses 'content' into setup statements and queries.
   ///
   /// Setup directives recognized at the top of 'content' (before the first
   /// query):
+  ///   -- connector: <test|hive>
+  ///       Selects the connector for the whole file. Defaults to 'test'.
   ///   -- setup_file: relative/path.sql
   ///       Splices in the contents of another .sql file, parsed as a
   ///       sequence of setup statements separated by '----'. Path is

--- a/axiom/optimizer/tests/SqlFileTest.cpp
+++ b/axiom/optimizer/tests/SqlFileTest.cpp
@@ -356,5 +356,48 @@ TEST_F(SqlFileTest, lineNumbersUnaffectedBySetup) {
   EXPECT_EQ(file.entries[1].lineNumber, 7);
 }
 
+TEST_F(SqlFileTest, connectorDefaultsToTest) {
+  EXPECT_EQ(SqlFile::parse("SELECT 1", "").connector, TestConnectorKind::kTest);
+}
+
+TEST_F(SqlFileTest, connectorDirective) {
+  {
+    auto file = SqlFile::parse(
+        "-- connector: hive\n"
+        "SELECT 1",
+        "");
+    EXPECT_EQ(file.connector, TestConnectorKind::kLocalHive);
+    ASSERT_EQ(file.entries.size(), 1);
+    EXPECT_EQ(file.entries[0].sql, "SELECT 1");
+    // The directive line is consumed, so query line numbers are unaffected.
+    EXPECT_EQ(file.entries[0].lineNumber, 2);
+  }
+  {
+    auto file = SqlFile::parse("-- connector: test\nSELECT 1", "");
+    EXPECT_EQ(file.connector, TestConnectorKind::kTest);
+  }
+}
+
+TEST_F(SqlFileTest, connectorDirectiveWithSetup) {
+  auto file = SqlFile::parse(
+      "-- connector: hive\n"
+      "-- setup\n"
+      "CREATE TABLE t(a BIGINT)\n"
+      "-- end_setup\n"
+      "SELECT a FROM t",
+      "");
+  EXPECT_EQ(file.connector, TestConnectorKind::kLocalHive);
+  ASSERT_EQ(file.setupStatements.size(), 1);
+  EXPECT_EQ(file.setupStatements[0], "CREATE TABLE t(a BIGINT)");
+  ASSERT_EQ(file.entries.size(), 1);
+  EXPECT_EQ(file.entries[0].sql, "SELECT a FROM t");
+}
+
+TEST_F(SqlFileTest, connectorUnknownRejected) {
+  VELOX_ASSERT_THROW(
+      SqlFile::parse("-- connector: postgres\nSELECT 1", ""),
+      "Unknown connector directive 'postgres'");
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -20,11 +20,22 @@
 #include <algorithm>
 #include <filesystem>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/hive/LocalHiveConnectorMetadata.h"
+#include "axiom/optimizer/ConstantExprEvaluator.h"
 #include "axiom/optimizer/tests/SqlFile.h"
 #include "axiom/optimizer/tests/SqlTestBase.h"
 #include "axiom/optimizer/tests/TestDataPath.h"
+#include "axiom/runner/LocalRunner.h"
+#include "axiom/sql/presto/PrestoParser.h"
+#include "velox/common/file/FileSystems.h"
 #include "velox/common/memory/Memory.h"
+#include "velox/common/testutil/TempDirectoryPath.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/connectors/hive/HiveConnector.h"
+#include "velox/dwio/common/FileSink.h"
+#include "velox/dwio/dwrf/RegisterDwrfReader.h"
+#include "velox/dwio/dwrf/RegisterDwrfWriter.h"
+#include "velox/exec/tests/utils/HiveConnectorTestBase.h"
 
 namespace facebook::axiom::optimizer::test {
 namespace {
@@ -59,6 +70,102 @@ struct FileName {
   char value[N]{};
 };
 
+// Removes a Presto table-property clause ("WITH ( ... )") so the same setup DDL
+// can run in DuckDB, which doesn't understand properties like partitioned_by.
+// Matches only a "WITH (" table-property clause, not a "WITH cte" CTE.
+std::string stripTablePropertiesForDuckDb(const std::string& sql) {
+  static constexpr std::string_view kWith = " with (";
+  const auto match = std::search(
+      sql.begin(), sql.end(), kWith.begin(), kWith.end(), [](char a, char b) {
+        return std::tolower(static_cast<unsigned char>(a)) == b;
+      });
+  if (match == sql.end()) {
+    return sql;
+  }
+  // Position of the space before "WITH" and of the clause's opening '('.
+  const size_t pos = static_cast<size_t>(match - sql.begin());
+  const size_t open = pos + kWith.size() - 1;
+  int depth = 0;
+  size_t i = open;
+  for (; i < sql.size(); ++i) {
+    if (sql[i] == '(') {
+      ++depth;
+    } else if (sql[i] == ')' && --depth == 0) {
+      break;
+    }
+  }
+  return sql.substr(0, pos) + sql.substr(i + 1);
+}
+
+// Runs one setup DDL statement against 'metadata's connector: CREATE TABLE
+// registers the (possibly partitioned) table with any table properties; INSERT
+// / CTAS write data through the connector's write path. Works for any connector
+// whose metadata implements createTable (TestConnector, LocalHive). DuckDB
+// installation is done by the caller.
+void runSetupStatement(
+    const std::string& sql,
+    const std::string& connectorId,
+    const std::string& defaultSchema,
+    connector::ConnectorMetadata& metadata,
+    const std::function<std::shared_ptr<runner::LocalRunner>(
+        const logical_plan::LogicalPlanNodePtr&)>& runnerFactory) {
+  ::axiom::sql::presto::PrestoParser parser(
+      connectorId,
+      defaultSchema,
+      std::make_shared<::axiom::sql::presto::ParserSession>(
+          /*queryId=*/"test",
+          /*user=*/"test",
+          ::axiom::sql::presto::ParserOptions{},
+          connector::ConnectorProperties{}));
+  auto stmt = parser.parse(sql);
+
+  auto session = std::make_shared<connector::ConnectorSession>(
+      /*queryId=*/"test", /*user=*/"test", connector::Properties{});
+
+  auto evalOptions = [](const auto& properties) {
+    folly::F14FastMap<std::string, velox::Variant> options;
+    for (const auto& [key, value] : properties) {
+      options[key] =
+          optimizer::ConstantExprEvaluator::evaluateConstantExpr(*value);
+    }
+    return options;
+  };
+
+  if (stmt->isCreateTable()) {
+    const auto& create =
+        *stmt->as<::axiom::sql::presto::CreateTableStatement>();
+    metadata.createTable(
+        session,
+        create.tableName(),
+        create.tableSchema(),
+        evalOptions(create.properties()),
+        /*ifNotExists=*/false,
+        /*explain=*/false);
+    return;
+  }
+
+  logical_plan::LogicalPlanNodePtr plan;
+  if (stmt->isInsert()) {
+    plan = stmt->as<::axiom::sql::presto::InsertStatement>()->plan();
+  } else if (stmt->isCreateTableAsSelect()) {
+    const auto& ctas =
+        *stmt->as<::axiom::sql::presto::CreateTableAsSelectStatement>();
+    metadata.createTable(
+        session,
+        ctas.tableName(),
+        ctas.tableSchema(),
+        evalOptions(ctas.properties()),
+        /*ifNotExists=*/false,
+        /*explain=*/false);
+    plan = ctas.plan();
+  } else {
+    VELOX_USER_FAIL("Unsupported setup statement: {}", sql);
+  }
+
+  auto runner = runnerFactory(plan);
+  runner->drain([](velox::RowVectorPtr) {});
+}
+
 // Per-.sql-file, per-optimizer gtest fixture. Each (file, optimizer) pair is a
 // distinct instantiation with its own SetUpTestCase/TearDownTestCase scope and
 // its own suite-scoped state: a standalone MemoryManager (separate from the
@@ -91,44 +198,105 @@ class SqlTest : public SqlTestBase {
         memory::kMaxMemory,
         memory::MemoryReclaimer::create());
     suiteOptimizerPool_ = suiteRootPool_->addLeafChild("optimizer");
-
-    suiteConnector_ = std::make_shared<connector::TestConnector>(
-        kTestConnectorId,
-        /*config=*/nullptr,
-        suiteRootPool_);
-    velox::connector::ConnectorRegistry::global().insert(
-        kTestConnectorId, suiteConnector_);
-    connector::ConnectorMetadataRegistry::global().insert(
-        kTestConnectorId, suiteConnector_->metadata());
-
     suiteDuckDbRunner_ = std::make_unique<exec::test::DuckDbQueryRunner>();
 
-    for (const auto& statement : setupStatements) {
-      runSetupStatement(
-          statement,
-          *suiteConnector_,
-          *suiteDuckDbRunner_,
-          [](const logical_plan::LogicalPlanNodePtr& plan) {
-            const auto buildRunner =
-                UseV2 ? makeLocalRunnerV2 : makeLocalRunner;
-            return buildRunner(
-                plan,
-                suiteExecutor_.get(),
-                /*asyncDataCache=*/nullptr,
-                suiteRootPool_,
-                suiteOptimizerPool_,
-                /*numWorkers=*/4,
-                /*numDrivers=*/4,
-                /*syntacticJoinOrder=*/false);
-          });
+    auto runnerFactory = [](const logical_plan::LogicalPlanNodePtr& plan) {
+      const auto buildRunner = UseV2 ? makeLocalRunnerV2 : makeLocalRunner;
+      return buildRunner(
+          plan,
+          suiteExecutor_.get(),
+          /*asyncDataCache=*/nullptr,
+          suiteRootPool_,
+          suiteOptimizerPool_,
+          /*numWorkers=*/4,
+          /*numDrivers=*/4,
+          /*syntacticJoinOrder=*/false);
+    };
+
+    connector::ConnectorMetadata* metadata = nullptr;
+    if (connectorKind == TestConnectorKind::kLocalHive) {
+      setUpHiveConnector();
+      metadata = suiteHiveMetadata_;
+    } else {
+      suiteConnector_ = std::make_shared<connector::TestConnector>(
+          kTestConnectorId, /*config=*/nullptr, suiteRootPool_);
+      velox::connector::ConnectorRegistry::global().insert(
+          kTestConnectorId, suiteConnector_);
+      connector::ConnectorMetadataRegistry::global().insert(
+          kTestConnectorId, suiteConnector_->metadata());
+      metadata = suiteConnector_->metadata().get();
     }
+
+    for (const auto& statement : setupStatements) {
+      suiteDuckDbRunner_->execute(stripTablePropertiesForDuckDb(statement));
+      runSetupStatement(
+          statement, connectorId(), defaultSchema(), *metadata, runnerFactory);
+    }
+  }
+
+  // Connector id / default schema the file's setup DDL and queries run against.
+  static std::string connectorId() {
+    return connectorKind == TestConnectorKind::kLocalHive
+        ? std::string(velox::exec::test::kHiveConnectorId)
+        : std::string(kTestConnectorId);
+  }
+
+  static std::string defaultSchema() {
+    return connectorKind == TestConnectorKind::kLocalHive
+        ? std::string(
+              connector::hive::LocalHiveConnectorMetadata::kDefaultSchema)
+        : std::string(connector::TestConnector::kDefaultSchema);
+  }
+
+  // Builds a suite-scoped LocalHive connector over a temp directory. Setup DDL
+  // then runs as real CREATE TABLE / INSERT / CTAS, so data, partition
+  // metadata, and write-time stats are on disk for queries to read.
+  static void setUpHiveConnector() {
+    velox::filesystems::registerLocalFileSystem();
+    velox::dwrf::registerDwrfReaderFactory();
+    velox::dwrf::registerDwrfWriterFactory();
+    velox::dwio::common::registerFileSinks();
+    suiteHiveDir_ = velox::common::testutil::TempDirectoryPath::create();
+
+    std::unordered_map<std::string, std::string> config;
+    config[connector::hive::HiveMetadataConfig::kLocalDataPath] =
+        suiteHiveDir_->getPath();
+    config[connector::hive::HiveMetadataConfig::kLocalFileFormat] = "dwrf";
+
+    velox::connector::hive::HiveConnectorFactory factory;
+    auto hiveConnector = factory.newConnector(
+        std::string(velox::exec::test::kHiveConnectorId),
+        std::make_shared<velox::config::ConfigBase>(std::move(config)),
+        suiteExecutor_.get());
+    velox::connector::ConnectorRegistry::global().insert(
+        velox::exec::test::kHiveConnectorId, hiveConnector);
+
+    auto metadata =
+        std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
+            dynamic_cast<velox::connector::hive::HiveConnector*>(
+                hiveConnector.get()),
+            suiteManager_->addRootPool("sql_test_hive_metadata"));
+    suiteHiveMetadata_ = metadata.get();
+    connector::ConnectorMetadataRegistry::global().insert(
+        velox::exec::test::kHiveConnectorId, std::move(metadata));
   }
 
   static void TearDownTestCase() {
     suiteDuckDbRunner_.reset();
-    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
-    velox::connector::ConnectorRegistry::global().erase(kTestConnectorId);
-    suiteConnector_.reset();
+    if (connectorKind == TestConnectorKind::kLocalHive) {
+      suiteHiveMetadata_ = nullptr;
+      connector::ConnectorMetadataRegistry::global().erase(
+          velox::exec::test::kHiveConnectorId);
+      velox::connector::ConnectorRegistry::global().erase(
+          velox::exec::test::kHiveConnectorId);
+      velox::dwrf::unregisterDwrfReaderFactory();
+      velox::dwrf::unregisterDwrfWriterFactory();
+      suiteHiveDir_.reset();
+    } else {
+      connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
+      velox::connector::ConnectorRegistry::global().erase(kTestConnectorId);
+      suiteConnector_.reset();
+    }
     suiteOptimizerPool_.reset();
     suiteRootPool_.reset();
     suiteExecutor_.reset();
@@ -138,19 +306,21 @@ class SqlTest : public SqlTestBase {
   // Setup statements consumed by SetUpTestCase, populated at registration time.
   static std::vector<std::string> setupStatements;
 
- protected:
-  bool createsConnectorPerTest() const override {
-    return false;
-  }
+  // Connector the file's queries run against, populated at registration time.
+  static TestConnectorKind connectorKind;
 
+ protected:
   exec::test::DuckDbQueryRunner& duckDbRunner() override {
     return *suiteDuckDbRunner_;
   }
 
   void SetUp() override {
     SqlTestBase::SetUp();
-    // connector_ is suite-scoped, set once per suite rather than per test.
+    // connector_ is suite-scoped (null in the hive suite, where queries resolve
+    // via the connector registry).
     connector_ = suiteConnector_;
+    connectorId_ = connectorId();
+    defaultSchema_ = defaultSchema();
   }
 
   void TearDown() override {
@@ -191,6 +361,9 @@ class SqlTest : public SqlTestBase {
   static std::shared_ptr<memory::MemoryPool> suiteOptimizerPool_;
   static std::shared_ptr<connector::TestConnector> suiteConnector_;
   static std::unique_ptr<exec::test::DuckDbQueryRunner> suiteDuckDbRunner_;
+  static std::shared_ptr<velox::common::testutil::TempDirectoryPath>
+      suiteHiveDir_;
+  static connector::hive::LocalHiveConnectorMetadata* suiteHiveMetadata_;
 
   QueryEntry entry_;
 };
@@ -218,12 +391,25 @@ std::unique_ptr<exec::test::DuckDbQueryRunner>
 template <FileName Name, bool UseV2>
 std::vector<std::string> SqlTest<Name, UseV2>::setupStatements;
 
+template <FileName Name, bool UseV2>
+TestConnectorKind SqlTest<Name, UseV2>::connectorKind =
+    TestConnectorKind::kTest;
+
+template <FileName Name, bool UseV2>
+std::shared_ptr<velox::common::testutil::TempDirectoryPath>
+    SqlTest<Name, UseV2>::suiteHiveDir_;
+
+template <FileName Name, bool UseV2>
+connector::hive::LocalHiveConnectorMetadata*
+    SqlTest<Name, UseV2>::suiteHiveMetadata_ = nullptr;
+
 // Registers every query in 'file' as an individual gtest test under the suite
 // 'V1/SqlTest_<name>' or 'V2/SqlTest_<name>' (per UseV2). Each query runs under
 // both cost-based (default) and syntactic join ordering.
 template <FileName Name, bool UseV2>
 void registerVariant(const SqlFile& file, const std::string& path) {
   SqlTest<Name, UseV2>::setupStatements = file.setupStatements;
+  SqlTest<Name, UseV2>::connectorKind = file.connector;
 
   const auto suiteName =
       fmt::format("{}/SqlTest_{}", UseV2 ? "V2" : "V1", Name.value);
@@ -248,10 +434,11 @@ void registerVariant(const SqlFile& file, const std::string& path) {
   }
 }
 
-// Parses a .sql file and registers its queries under both the v1 and v2
-// suites.
+// Parses a .sql file and registers its queries. Registers under both the v1 and
+// v2 suites by default; when 'v2Only' is set, registers only the v2 suite (for
+// features not yet wired in the v1 optimizer).
 template <FileName Name>
-void registerQueryFile() {
+void registerQueryFile(bool v2Only = false) {
   const std::string baseName = Name.value;
   const auto path = getTestFilePath(fmt::format("sql/{}.sql", baseName));
 
@@ -261,7 +448,14 @@ void registerQueryFile() {
   auto baseDir = std::filesystem::path(path).parent_path().string();
   auto file = SqlFile::parse(content, baseDir);
 
-  registerVariant<Name, false>(file, path);
+  VELOX_CHECK(
+      !file.entries.empty(),
+      "SQL test file registered but produced no queries: {}",
+      path);
+
+  if (!v2Only) {
+    registerVariant<Name, false>(file, path);
+  }
   registerVariant<Name, true>(file, path);
 }
 
@@ -284,6 +478,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"groupingsets">();
   registerQueryFile<"join">();
   registerQueryFile<"limit">();
+  registerQueryFile<"metadataAggregate">(/*v2Only=*/true);
   registerQueryFile<"nondeterministic">();
   registerQueryFile<"nullif">();
   registerQueryFile<"set">();

--- a/axiom/optimizer/tests/SqlTestBase.cpp
+++ b/axiom/optimizer/tests/SqlTestBase.cpp
@@ -53,25 +53,12 @@ void SqlTestBase::SetUp() {
   velox::exec::ExchangeSource::registerFactory(
       velox::exec::test::createLocalExchangeSource);
 
-  if (createsConnectorPerTest()) {
-    connector_ = std::make_shared<connector::TestConnector>(kTestConnectorId);
-    velox::connector::ConnectorRegistry::global().insert(
-        kTestConnectorId, connector_);
-    connector::ConnectorMetadataRegistry::global().insert(
-        kTestConnectorId, connector_->metadata());
-  }
-
   optimizerPool_ = rootPool_->addLeafChild("optimizer");
   executor_ = std::make_shared<folly::CPUThreadPoolExecutor>(4);
 }
 
 void SqlTestBase::TearDown() {
   optimizerPool_.reset();
-  if (createsConnectorPerTest()) {
-    connector::ConnectorMetadataRegistry::global().erase(kTestConnectorId);
-    velox::connector::ConnectorRegistry::global().erase(kTestConnectorId);
-    connector_.reset();
-  }
   velox::exec::ExchangeSource::factories().clear();
   executor_.reset();
 
@@ -234,56 +221,12 @@ std::shared_ptr<runner::LocalRunner> SqlTestBase::makeLocalRunnerV2(
       });
 }
 
-void SqlTestBase::runSetupStatement(
-    const std::string& sql,
-    connector::TestConnector& connector,
-    velox::exec::test::DuckDbQueryRunner& duckDb,
-    const std::function<std::shared_ptr<runner::LocalRunner>(
-        const logical_plan::LogicalPlanNodePtr&)>& runnerFactory) {
-  duckDb.execute(sql);
-
-  ::axiom::sql::presto::PrestoParser parser(
-      kTestConnectorId,
-      std::string(connector::TestConnector::kDefaultSchema),
-      std::make_shared<::axiom::sql::presto::ParserSession>(
-          /*queryId=*/"test",
-          /*user=*/"test",
-          ::axiom::sql::presto::ParserOptions{},
-          connector::ConnectorProperties{}));
-  auto stmt = parser.parse(sql);
-
-  if (stmt->isCreateTable()) {
-    const auto& create =
-        *stmt->as<::axiom::sql::presto::CreateTableStatement>();
-    connector.addTable(create.tableName().table, create.tableSchema());
-    return;
-  }
-
-  logical_plan::LogicalPlanNodePtr plan;
-  if (stmt->isInsert()) {
-    plan = stmt->as<::axiom::sql::presto::InsertStatement>()->plan();
-  } else if (stmt->isCreateTableAsSelect()) {
-    const auto& ctas =
-        *stmt->as<::axiom::sql::presto::CreateTableAsSelectStatement>();
-    connector.addTable(ctas.tableName().table, ctas.tableSchema());
-    plan = ctas.plan();
-  } else {
-    VELOX_USER_FAIL(
-        "Unsupported setup statement (only CREATE TABLE, INSERT INTO, "
-        "and CREATE TABLE AS SELECT are supported): {}",
-        sql);
-  }
-
-  auto runner = runnerFactory(plan);
-  runner->drain([](RowVectorPtr) {});
-}
-
 std::shared_ptr<runner::LocalRunner> SqlTestBase::makeRunner(
     std::string_view sql) {
   // Parse SQL to logical plan.
   ::axiom::sql::presto::PrestoParser parser(
-      kTestConnectorId,
-      std::string(connector::TestConnector::kDefaultSchema),
+      connectorId_,
+      defaultSchema_,
       std::make_shared<::axiom::sql::presto::ParserSession>(
           /*queryId=*/"test",
           /*user=*/"test",

--- a/axiom/optimizer/tests/SqlTestBase.h
+++ b/axiom/optimizer/tests/SqlTestBase.h
@@ -74,25 +74,6 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
       const std::string& name,
       const std::vector<velox::RowVectorPtr>& data);
 
-  /// Executes a single setup DDL statement against the Axiom TestConnector
-  /// and DuckDB. Supports:
-  ///   - CREATE TABLE name (col TYPE, ...) — registers an empty table.
-  ///   - INSERT INTO name VALUES (..., ...), (..., ...), ... — appends one
-  ///     RowVector (one TestConnector split) and runs the same statement
-  ///     in DuckDB.
-  /// Each INSERT to the same table produces a separate split, mirroring
-  /// the multi-RowVector createTable shape. The caller supplies the
-  /// connector, the DuckDB runner, and a factory that builds a LocalRunner
-  /// for an INSERT / CTAS plan. Suite-scoped fixtures use this in
-  /// SetUpTestSuite to install reference tables once into a standalone
-  /// connector backed by their own MemoryManager / executor / cache.
-  static void runSetupStatement(
-      const std::string& sql,
-      connector::TestConnector& connector,
-      velox::exec::test::DuckDbQueryRunner& duckDb,
-      const std::function<std::shared_ptr<runner::LocalRunner>(
-          const logical_plan::LogicalPlanNodePtr&)>& runnerFactory);
-
   /// Builds a LocalRunner for 'logicalPlan' using caller-supplied
   /// infrastructure. Suite-scoped fixtures use this to bind their static
   /// MemoryManager / executor / AsyncDataCache into a runnerFactory for
@@ -156,13 +137,6 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   // (axiom/optimizer/v2) instead of v1.
   bool useV2_{false};
 
-  // Override to false in subclasses that manage the TestConnector lifecycle
-  // at suite scope (i.e., create and register the connector once per
-  // fixture class in SetUpTestSuite, not once per test in SetUp).
-  virtual bool createsConnectorPerTest() const {
-    return true;
-  }
-
   // Returns the DuckDbQueryRunner used for table installation and result
   // comparison. The default returns 'duckDbQueryRunner_' (per-test,
   // inherited from OperatorTestBase). Subclasses that want suite-scoped
@@ -172,6 +146,13 @@ class SqlTestBase : public velox::exec::test::OperatorTestBase {
   }
 
   std::shared_ptr<connector::TestConnector> connector_;
+
+  // Connector id and default schema used to parse this fixture's queries.
+  // Defaults to the in-memory TestConnector; a Hive-backed fixture overrides
+  // them so queries resolve against the Hive catalog.
+  std::string connectorId_{kTestConnectorId};
+  std::string defaultSchema_{
+      std::string(connector::TestConnector::kDefaultSchema)};
 
  private:
   // Runs SQL through Axiom's full pipeline without storing results. Returns

--- a/axiom/optimizer/tests/sql/metadataAggregate.sql
+++ b/axiom/optimizer/tests/sql/metadataAggregate.sql
@@ -1,0 +1,38 @@
+-- connector: hive
+-- setup
+CREATE TABLE m (v BIGINT, k BIGINT) WITH (partitioned_by = ARRAY['k'])
+----
+INSERT INTO m VALUES
+  (CAST(NULL AS BIGINT), 0),
+  (CAST(NULL AS BIGINT), 0),
+  (5, 1),
+  (6, 1),
+  (7, 2)
+-- end_setup
+
+-- DuckDB has no approx_count_star; compare against count(*).
+-- duckdb: SELECT count(*) FROM m
+SELECT approx_count_star() FROM m
+----
+-- duckdb: SELECT k, count(*) FROM m GROUP BY 1
+SELECT k, approx_count_star() FROM m GROUP BY 1
+----
+-- duckdb: SELECT count(*) - count(v) FROM m
+SELECT approx_null_count(v) FROM m
+----
+-- duckdb: SELECT k, count(*) - count(v) FROM m GROUP BY 1
+SELECT k, approx_null_count(v) FROM m GROUP BY 1
+----
+-- duckdb: SELECT count(v) FROM m
+SELECT approx_non_null_count(v) FROM m
+----
+-- duckdb: SELECT k, count(v) FROM m GROUP BY 1
+SELECT k, approx_non_null_count(v) FROM m GROUP BY 1
+----
+-- A regular aggregate alongside a metadata aggregate.
+-- duckdb: SELECT count(*), sum(v) FROM m
+SELECT approx_count_star(), sum(v) FROM m
+----
+-- One leg is a metadata aggregate, the other a regular aggregate.
+-- duckdb: SELECT count(*) FROM m UNION ALL SELECT sum(v) FROM m
+SELECT approx_count_star() FROM m UNION ALL SELECT sum(v) FROM m

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -119,7 +119,9 @@ const optimizer::Aggregate* Builder::makeAggregate(
     ExprCP condition,
     TypeCP intermediateType,
     ExprVector orderKeys,
-    OrderTypeVector orderTypes) {
+    OrderTypeVector orderTypes,
+    std::optional<logical_plan::SpecialAggregateKind> specialKind,
+    const optimizer::Aggregate* fallback) {
   optimizer::Aggregate::KeyView view{
       name, args, isDistinct, condition, orderKeys, orderTypes};
   if (auto it = aggregateCalls_.find(view); it != aggregateCalls_.end()) {
@@ -134,7 +136,9 @@ const optimizer::Aggregate* Builder::makeAggregate(
       condition,
       intermediateType,
       std::move(orderKeys),
-      std::move(orderTypes));
+      std::move(orderTypes),
+      specialKind,
+      fallback);
   aggregateCalls_.insert(aggregate);
   return aggregate;
 }

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -88,7 +88,9 @@ class Builder {
       FunctionSet functions);
 
   /// Returns a canonical aggregate `Call`. Result type and 'intermediateType'
-  /// are determined by (name, args), so identity excludes them.
+  /// are determined by (name, args), so identity excludes them. 'specialKind'
+  /// and 'fallback' mark a metadata aggregate (see optimizer::Aggregate); they
+  /// are also excluded from identity (determined by 'name').
   const optimizer::Aggregate* makeAggregate(
       Name name,
       const Value& value,
@@ -98,7 +100,10 @@ class Builder {
       ExprCP condition,
       TypeCP intermediateType,
       ExprVector orderKeys,
-      OrderTypeVector orderTypes);
+      OrderTypeVector orderTypes,
+      std::optional<logical_plan::SpecialAggregateKind> specialKind =
+          std::nullopt,
+      const optimizer::Aggregate* fallback = nullptr);
 
   /// Canonical `Literal` for boolean constant 'value'.
   const Literal* makeBoolean(bool value) {

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
+  FoldMetadataAggregatePass.cpp
   HypergraphBuilder.cpp
   JoinCondition.cpp
   JoinFanout.cpp

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
@@ -1,0 +1,258 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/FoldMetadataAggregatePass.h"
+
+#include "folly/container/F14Map.h"
+#include "folly/container/F14Set.h"
+#include "folly/coro/BlockingWait.h"
+
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/QueryGraphContext.h"
+#include "axiom/optimizer/Schema.h"
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+using logical_plan::SpecialAggregateKind;
+
+class Folder : public NodeRewriter<NoContext> {
+ public:
+  Folder(
+      Builder& builder,
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator,
+      ScanHandleCache& scanHandles)
+      : NodeRewriter(builder),
+        session_(session),
+        evaluator_(evaluator),
+        scanHandles_(scanHandles) {}
+
+ protected:
+  NodeCP rewriteAggregate(AggregateCP node, NoContext& context) override {
+    bool anyMetadata = false;
+    bool allMetadata = true;
+    for (const optimizer::Aggregate* aggregate : node->aggregates()) {
+      if (aggregate->specialKind().has_value()) {
+        anyMetadata = true;
+      } else {
+        allMetadata = false;
+      }
+    }
+    if (!anyMetadata) {
+      return NodeRewriter::rewriteAggregate(node, context);
+    }
+
+    // The fold produces one Values row per group, so it applies only when the
+    // whole aggregation is metadata aggregates directly over a Scan.
+    if (allMetadata && node->input()->is(NodeType::kScan)) {
+      if (NodeCP folded = tryFold(node)) {
+        return folded;
+      }
+    }
+    return replaceWithFallbacks(node, context);
+  }
+
+ private:
+  // Folds an aggregation of only metadata aggregates directly over a Scan into
+  // a Values node. The caller guarantees that shape. Returns nullptr if the
+  // grouping keys are not plain columns or the connector declines.
+  NodeCP tryFold(AggregateCP node) {
+    const auto* scan = node->input()->as<Scan>();
+    const auto* layout =
+        scan->baseTable()->schemaTable->columnGroups[0]->layout;
+
+    // Grouping keys and null-count arguments must be base-table columns so they
+    // can be named for the connector (via their SchemaTable column); the
+    // connector decides (via a nullopt result) whether it can group by them.
+    std::vector<std::string> groupingColumns;
+    groupingColumns.reserve(node->groupingKeys().size());
+    folly::F14FastSet<std::string_view> seen;
+    for (ExprCP key : node->groupingKeys()) {
+      if (!key->isColumn()) {
+        return nullptr;
+      }
+      const auto* column = key->as<Column>();
+      ColumnCP schemaColumn = column->schemaColumn();
+      VELOX_CHECK_NOT_NULL(
+          schemaColumn,
+          "Metadata aggregate grouping key has no schema column: {}",
+          column->name());
+      VELOX_CHECK(
+          seen.insert(schemaColumn->name()).second,
+          "Duplicate grouping column in a metadata aggregate: {}",
+          schemaColumn->name());
+      groupingColumns.emplace_back(schemaColumn->name());
+    }
+
+    // Distinct columns whose null counts are needed, and, per aggregate, the
+    // index into that list (-1 for a row count, which needs no column). Two
+    // aggregates over the same column share one entry.
+    std::vector<std::string> nullCountColumns;
+    // Keyed by a view into the schema columns' own names (stable for the
+    // schema's lifetime), not into nullCountColumns below.
+    folly::F14FastMap<std::string_view, int32_t> nullCountColumnIndex;
+    std::vector<int32_t> nullCountIndex;
+    nullCountIndex.reserve(node->aggregates().size());
+    for (const optimizer::Aggregate* aggregate : node->aggregates()) {
+      if (*aggregate->specialKind() ==
+          SpecialAggregateKind::kMetadataRowCount) {
+        nullCountIndex.push_back(-1);
+        continue;
+      }
+      // Reached only for null / non-null count, which take exactly one input.
+      if (!aggregate->args()[0]->isColumn()) {
+        return nullptr;
+      }
+      const auto* argColumn = aggregate->args()[0]->as<Column>();
+      ColumnCP schemaColumn = argColumn->schemaColumn();
+      VELOX_CHECK_NOT_NULL(
+          schemaColumn,
+          "Metadata aggregate argument has no schema column: {}",
+          argColumn->name());
+      auto [it, inserted] = nullCountColumnIndex.try_emplace(
+          schemaColumn->name(), static_cast<int32_t>(nullCountColumns.size()));
+      if (inserted) {
+        nullCountColumns.emplace_back(schemaColumn->name());
+      }
+      nullCountIndex.push_back(it->second);
+    }
+
+    const ScanHandle& handle =
+        scanHandles_.getOrBuild(*scan, session_, evaluator_);
+    auto connectorSession =
+        session_.toConnectorSession(layout->connector()->connectorId());
+    auto result = folly::coro::blockingWait(layout->co_metadataCounts(
+        std::move(connectorSession),
+        handle.tableHandle,
+        std::move(groupingColumns),
+        std::move(nullCountColumns),
+        handle.filterConjuncts));
+    if (!result.has_value()) {
+      return nullptr;
+    }
+
+    return makeValues(node, nullCountIndex, *result);
+  }
+
+  // Builds the Values node holding one row per group: the grouping-key values
+  // followed by each aggregate's count.
+  NodeCP makeValues(
+      AggregateCP node,
+      const std::vector<int32_t>& nullCountIndex,
+      const std::vector<connector::MetadataCountGroup>& groups) {
+    std::vector<velox::Variant> rows;
+    rows.reserve(groups.size());
+    for (const auto& group : groups) {
+      VELOX_CHECK_EQ(group.key.size(), node->groupingKeys().size());
+      group.checkConsistency();
+      std::vector<velox::Variant> row;
+      row.reserve(node->outputColumns().size());
+      for (const auto& keyValue : group.key) {
+        row.push_back(keyValue);
+      }
+      for (size_t i = 0; i < node->aggregates().size(); ++i) {
+        row.push_back(
+            velox::Variant(count(
+                *node->aggregates()[i]->specialKind(),
+                nullCountIndex[i],
+                group)));
+      }
+      rows.push_back(velox::Variant::row(std::move(row)));
+    }
+
+    // A global (ungrouped) aggregate must return exactly one row even when no
+    // partitions match: count(*) over an empty input is 0, not zero rows.
+    if (rows.empty() && node->groupingKeys().empty()) {
+      std::vector<velox::Variant> row;
+      row.reserve(node->aggregates().size());
+      for (size_t i = 0; i < node->aggregates().size(); ++i) {
+        row.push_back(velox::Variant(int64_t{0}));
+      }
+      rows.push_back(velox::Variant::row(std::move(row)));
+    }
+
+    return builder().make<Values>(Values::Key{
+        .source = nullptr,
+        .rows = registerVariant(velox::Variant::array(std::move(rows))),
+        .outputColumns = node->outputColumns()});
+  }
+
+  static int64_t count(
+      SpecialAggregateKind kind,
+      int32_t nullCountIndex,
+      const connector::MetadataCountGroup& group) {
+    switch (kind) {
+      case SpecialAggregateKind::kMetadataRowCount:
+        return group.numRows;
+      case SpecialAggregateKind::kMetadataNonNullCount:
+        return group.numRows - group.numNulls.at(nullCountIndex);
+      case SpecialAggregateKind::kMetadataNullCount:
+        return group.numNulls.at(nullCountIndex);
+    }
+    VELOX_UNREACHABLE(
+        "Unhandled SpecialAggregateKind: {}", static_cast<int>(kind));
+  }
+
+  // Rebuilds the aggregation with each metadata aggregate replaced by its
+  // fallback.
+  NodeCP replaceWithFallbacks(AggregateCP node, NoContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    AggregateCallVector aggregates;
+    aggregates.reserve(node->aggregates().size());
+    for (const optimizer::Aggregate* aggregate : node->aggregates()) {
+      if (!aggregate->specialKind().has_value()) {
+        aggregates.push_back(aggregate);
+        continue;
+      }
+      VELOX_USER_CHECK_NOT_NULL(
+          aggregate->fallback(),
+          "Aggregate cannot be answered from metadata and has no fallback: {}",
+          aggregate->name());
+      aggregates.push_back(aggregate->fallback());
+    }
+
+    return builder().make<Aggregate>(Aggregate::Key{
+        .input = newInput,
+        .groupingKeys = node->groupingKeys(),
+        .aggregates = std::move(aggregates),
+        .outputColumns = node->outputColumns(),
+        .step = node->step(),
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+  }
+
+  const OptimizerSession& session_;
+  velox::core::ExpressionEvaluator& evaluator_;
+  ScanHandleCache& scanHandles_;
+};
+
+} // namespace
+
+NodeCP FoldMetadataAggregatePass::run(
+    NodeCP root,
+    Builder& builder,
+    const OptimizerSession& session,
+    velox::core::ExpressionEvaluator& evaluator,
+    ScanHandleCache& scanHandles) {
+  Folder folder(builder, session, evaluator, scanHandles);
+  return folder.rewrite(root);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.h
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+#include "axiom/optimizer/v2/ScanHandle.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Resolves metadata aggregates (an `optimizer::Aggregate` with a
+/// `specialKind`). For an aggregation whose aggregates are all metadata
+/// aggregates, directly over a `Scan`, it asks the connector for the counts
+/// (`TableLayout::co_metadataCounts`) and, on success, replaces the aggregation
+/// with a `Values` node. The connector decides whether it can group the counts
+/// by the grouping keys and declines otherwise. When the fold does not apply,
+/// each metadata aggregate is replaced by its fallback (an ordinary count /
+/// count_if); a metadata aggregate with no fallback that cannot be answered
+/// from metadata is an error.
+///
+/// Runs after `PushdownAndPrunePass`, which guarantees a `Scan` carries all of
+/// its filters (no `Filter` node sits directly over it). Every metadata
+/// aggregate is either folded, replaced by its fallback, or rejected here, so
+/// none reaches emit, where the kind name is not a Velox aggregate.
+class FoldMetadataAggregatePass {
+ public:
+  static NodeCP run(
+      NodeCP root,
+      Builder& builder,
+      const OptimizerSession& session,
+      velox::core::ExpressionEvaluator& evaluator,
+      ScanHandleCache& scanHandles);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -164,10 +164,9 @@ class Scan : public Node {
     /// NOT in this set; the connector-side read schema is computed as
     /// `outputColumns ∪ refs(filters)` when building the final Velox plan.
     ColumnVector outputColumns;
-    /// Predicates (joined with AND) offered to the connector during planning;
-    /// may be empty. The connector accepts those it can evaluate and rejects
-    /// the rest; rejected predicates are re-applied as a `Filter` node above
-    /// the `TableScan` when building the final Velox plan.
+    /// Filters on the scanned rows, as conjuncts joined with AND; may be empty.
+    /// At Emit the connector evaluates those it can; the rest are re-applied as
+    /// a `Filter` node above the `TableScan` in the final Velox plan.
     ExprVector filters;
   };
 

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -21,6 +21,7 @@
 #include "axiom/optimizer/v2/EmitPass.h"
 #include "axiom/optimizer/v2/EstimateLeafStatsPass.h"
 #include "axiom/optimizer/v2/ExpandAggregatePass.h"
+#include "axiom/optimizer/v2/FoldMetadataAggregatePass.h"
 #include "axiom/optimizer/v2/LimitAndOrderPass.h"
 #include "axiom/optimizer/v2/PlanPhysicalPass.h"
 #include "axiom/optimizer/v2/PrecomputeProjectionsPass.h"
@@ -52,11 +53,13 @@ PlanAndStats optimize(
   NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
   NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
   NodeCP pushed = PushdownAndPrunePass::run(limited, builder, evaluator);
+  NodeCP folded = FoldMetadataAggregatePass::run(
+      pushed, builder, session, evaluator, scanHandles);
   if (session.options().useFilteredTableStats) {
-    EstimateLeafStatsPass::run(pushed, session, evaluator, scanHandles);
+    EstimateLeafStatsPass::run(folded, session, evaluator, scanHandles);
   }
   NodeCP physicalPlanned = PlanPhysicalPass::run(
-      pushed,
+      folded,
       builder,
       session.options(),
       options.numWorkers,

--- a/axiom/optimizer/v2/PushdownAndPrunePass.h
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.h
@@ -52,6 +52,13 @@ namespace facebook::axiom::optimizer::v2 {
 ///    predicate.
 ///  - `Apply` must already be gone: decorrelate removes every `Apply` before
 ///    this pass, so encountering one is a logic error.
+///
+/// Post-condition: no `Filter` node sits directly above a `Scan`. Every
+/// conjunct that reaches a `Scan` is absorbed into `Scan.filters`; which of
+/// those the connector can actually evaluate is decided later (at Emit), and
+/// connector-rejected filters reappear as a `Filter` above the `TableScan` only
+/// in the final Velox plan. A rewrite running after this pass can therefore
+/// treat a `Scan` as carrying all of its predicates.
 class PushdownAndPrunePass {
  public:
   /// Returns `root` rewritten as described in the class doc. `evaluator` backs

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -965,6 +965,39 @@ const optimizer::Aggregate* Translator::toAggregateCall(
   ExprVector arguments =
       translateAll(aggregateExpr.inputs(), scope, applyTarget);
 
+  if (aggregateExpr.isSpecialFormAgg()) {
+    const auto& special = *aggregateExpr.as<lp::SpecialFormAggExpr>();
+    // A metadata aggregate does not support these modifiers. ORDER BY is
+    // allowed but ignored (order-insensitive), so it is not checked.
+    VELOX_USER_CHECK(
+        !special.isDistinct(),
+        "Metadata aggregate does not support DISTINCT: {}",
+        aggregateExpr.name());
+    VELOX_USER_CHECK_NULL(
+        special.filter(),
+        "Metadata aggregate does not support FILTER: {}",
+        aggregateExpr.name());
+    // The kind name is not a registered Velox aggregate, so skip the registry
+    // lookup and carry the kind and translated fallback for the fold pass.
+    // Result and intermediate types are BIGINT.
+    const optimizer::Aggregate* fallback = special.fallback() != nullptr
+        ? toAggregateCall(*special.fallback(), scope, applyTarget)
+        : nullptr;
+    FunctionSet funcs = Call::unionArgFunctions(FunctionSet{}, arguments);
+    return builder_.makeAggregate(
+        toName(aggregateExpr.name()),
+        Value(toType(aggregateExpr.type())),
+        std::move(arguments),
+        funcs,
+        /*isDistinct=*/false,
+        /*condition=*/nullptr,
+        toType(velox::BIGINT()),
+        /*orderKeys=*/{},
+        /*orderTypes=*/{},
+        special.kind(),
+        fallback);
+  }
+
   std::vector<velox::TypePtr> argTypes;
   argTypes.reserve(aggregateExpr.inputs().size());
   for (const auto& input : aggregateExpr.inputs()) {

--- a/axiom/pyspark/CollagenMain.cpp
+++ b/axiom/pyspark/CollagenMain.cpp
@@ -183,7 +183,8 @@ void CollagenMain::registerLocalHiveConnector() {
       std::make_shared<
           facebook::axiom::connector::hive::LocalHiveConnectorMetadata>(
           dynamic_cast<facebook::velox::connector::hive::HiveConnector*>(
-              hiveConnector.get())));
+              hiveConnector.get()),
+          facebook::velox::memory::memoryManager()->addRootPool()));
 }
 
 void CollagenMain::registerConnector() {

--- a/axiom/runner/tests/LocalRunnerTestBase.cpp
+++ b/axiom/runner/tests/LocalRunnerTestBase.cpp
@@ -88,7 +88,8 @@ void LocalRunnerTestBase::setupConnector() {
       velox::exec::test::kHiveConnectorId,
       std::make_shared<connector::hive::LocalHiveConnectorMetadata>(
           dynamic_cast<velox::connector::hive::HiveConnector*>(
-              hiveConnector.get())));
+              hiveConnector.get()),
+          velox::memory::memoryManager()->addRootPool()));
 }
 
 void LocalRunnerTestBase::makeTables(const std::vector<TableSpec>& specs) {

--- a/axiom/sql/presto/CMakeLists.txt
+++ b/axiom/sql/presto/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   SortProjection.cpp
   PrestoParser.cpp
   ShowStatsBuilder.cpp
+  SpecialAggregates.cpp
   SqlStatement.cpp
 )
 

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -26,6 +26,7 @@
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
+#include "axiom/sql/presto/SpecialAggregates.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "velox/exec/Aggregate.h"
 #include "velox/functions/prestosql/types/BigintEnumType.h"
@@ -39,6 +40,72 @@ namespace axiom::sql::presto {
 using namespace facebook::velox;
 
 namespace {
+
+// Translates a Presto call already recognized as the metadata aggregate 'kind'
+// into a SpecialFormAggCallExpr carrying its fallback. Enforces the modifier
+// semantics: window / DISTINCT / FILTER are rejected; ORDER BY is accepted and
+// ignored (these aggregates are order-insensitive).
+lp::ExprApi makeMetadataAggregate(
+    lp::SpecialAggregateKind kind,
+    const FunctionCall* call,
+    const std::vector<lp::ExprApi>& args,
+    const std::string& funcName) {
+  AXIOM_PRESTO_SEMANTIC_CHECK_NULL(
+      call->window(),
+      call->location(),
+      funcName,
+      "Metadata aggregate cannot be used as a window function: {}",
+      funcName);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      !call->isDistinct(),
+      call->location(),
+      funcName,
+      "Metadata aggregate does not support DISTINCT: {}",
+      funcName);
+  AXIOM_PRESTO_SEMANTIC_CHECK_NULL(
+      call->filter(),
+      call->location(),
+      funcName,
+      "Metadata aggregate does not support FILTER: {}",
+      funcName);
+
+  const size_t numExpectedArgs =
+      kind == lp::SpecialAggregateKind::kMetadataRowCount ? 0 : 1;
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      args.size() == numExpectedArgs,
+      call->location(),
+      funcName,
+      "Metadata aggregate has wrong number of arguments: {} expects {}, got {}",
+      funcName,
+      numExpectedArgs,
+      args.size());
+
+  std::vector<core::ExprPtr> inputs;
+  inputs.reserve(args.size());
+  for (const auto& arg : args) {
+    inputs.push_back(arg.expr());
+  }
+
+  // Each kind supplies its fallback, used when the connector cannot answer the
+  // aggregate from metadata, expressed as count / count_if.
+  const auto make = [&](const lp::ExprApi& fallback) {
+    return lp::ExprApi{std::make_shared<core::SpecialFormAggCallExpr>(
+        kind,
+        std::move(inputs),
+        fallback.expr(),
+        /*alias=*/std::nullopt,
+        funcName)};
+  };
+
+  switch (kind) {
+    case lp::SpecialAggregateKind::kMetadataRowCount:
+      return make(lp::Call("count"));
+    case lp::SpecialAggregateKind::kMetadataNonNullCount:
+      return make(lp::Call("count", args));
+    case lp::SpecialAggregateKind::kMetadataNullCount:
+      return make(lp::Call("count_if", lp::Call("is_null", args)));
+  }
+}
 
 // Returns the set of relation aliases directly visible in a simple
 // FROM clause (a single Table or AliasedRelation). Returns nullopt
@@ -126,7 +193,8 @@ class OuterScopeAggregateScanner : public DefaultTraversalVisitor {
  protected:
   void visitFunctionCall(FunctionCall* node) override {
     const auto name = canonicalizeName(node->name()->suffix());
-    if (exec::getAggregateFunctionEntry(name) != nullptr &&
+    if ((exec::getAggregateFunctionEntry(name) != nullptr ||
+         specialAggregateKind(name).has_value()) &&
         node->window() == nullptr && !node->isDistinct() &&
         node->filter() == nullptr && node->orderBy() == nullptr &&
         !node->ignoreNulls() && !node->arguments().empty()) {
@@ -1150,6 +1218,10 @@ lp::ExprApi ExpressionPlanner::toExpr(
             "NULLIF requires exactly 2 arguments, got {}",
             args.size());
         return lp::Call("nullif", args[0], args[1]);
+      }
+
+      if (auto kind = specialAggregateKind(lowerFuncName)) {
+        return makeMetadataAggregate(*kind, call, args, lowerFuncName);
       }
 
       if (call->isDistinct() || call->filter() || call->orderBy()) {

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -19,6 +19,7 @@
 #include "axiom/sql/presto/ColumnsExpansion.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/SortProjection.h"
+#include "axiom/sql/presto/SpecialAggregates.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "folly/container/F14Set.h"
 #include "velox/common/base/BitUtil.h"
@@ -224,7 +225,9 @@ class ExprAnalyzer : public DefaultTraversalVisitor {
 
   void visitFunctionCall(FunctionCall* node) override {
     const auto& name = node->name()->suffix();
-    if (exec::getAggregateFunctionEntry(name) && node->window() == nullptr) {
+    if ((exec::getAggregateFunctionEntry(name) ||
+         specialAggregateKind(name).has_value()) &&
+        node->window() == nullptr) {
       AXIOM_PRESTO_SEMANTIC_CHECK(
           !aggregateName_.has_value(),
           node->location(),

--- a/axiom/sql/presto/PrestoSqlError.h
+++ b/axiom/sql/presto/PrestoSqlError.h
@@ -172,6 +172,23 @@ PrestoErrorClassification classify(PrestoSqlErrorKind kind);
         fmt_str);                                                     \
   } while (0)
 
+/// Throws PrestoSqlError with kSyntax kind if `value` is not null.
+/// Same parameter contract as AXIOM_PRESTO_SYNTAX_CHECK.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AXIOM_PRESTO_SYNTAX_CHECK_NULL(value, location, token, fmt_str, ...) \
+  do {                                                                       \
+    if (FOLLY_UNLIKELY((value) != nullptr)) {                                \
+      assert((location).line > 0 && "Location must have 1-based line");      \
+      throw ::axiom::sql::presto::PrestoSqlError(                            \
+          fmt::format(fmt_str, ##__VA_ARGS__),                               \
+          static_cast<size_t>((location).line - 1),                          \
+          static_cast<size_t>(std::max(0, (location).charPosition)),         \
+          (token),                                                           \
+          ::axiom::sql::presto::PrestoSqlErrorKind::kSyntax,                 \
+          fmt_str);                                                          \
+    }                                                                        \
+  } while (0)
+
 /// Throws PrestoSqlError with kSemantic kind if `condition` is false.
 /// Same parameter contract as AXIOM_PRESTO_SYNTAX_CHECK.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
@@ -201,6 +218,23 @@ PrestoErrorClassification classify(PrestoSqlErrorKind kind);
         (token),                                                      \
         ::axiom::sql::presto::PrestoSqlErrorKind::kSemantic,          \
         fmt_str);                                                     \
+  } while (0)
+
+/// Throws PrestoSqlError with kSemantic kind if `value` is not null.
+/// Same parameter contract as AXIOM_PRESTO_SYNTAX_CHECK.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AXIOM_PRESTO_SEMANTIC_CHECK_NULL(value, location, token, fmt_str, ...) \
+  do {                                                                         \
+    if (FOLLY_UNLIKELY((value) != nullptr)) {                                  \
+      assert((location).line > 0 && "Location must have 1-based line");        \
+      throw ::axiom::sql::presto::PrestoSqlError(                              \
+          fmt::format(fmt_str, ##__VA_ARGS__),                                 \
+          static_cast<size_t>((location).line - 1),                            \
+          static_cast<size_t>(std::max(0, (location).charPosition)),           \
+          (token),                                                             \
+          ::axiom::sql::presto::PrestoSqlErrorKind::kSemantic,                 \
+          fmt_str);                                                            \
+    }                                                                          \
   } while (0)
 
 /// Throws PrestoSqlError with kSemantic kind if val1 != val2.

--- a/axiom/sql/presto/RecursiveCteValidator.cpp
+++ b/axiom/sql/presto/RecursiveCteValidator.cpp
@@ -18,6 +18,7 @@
 
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
+#include "axiom/sql/presto/SpecialAggregates.h"
 #include "axiom/sql/presto/ast/DefaultTraversalVisitor.h"
 #include "velox/exec/Aggregate.h"
 
@@ -85,13 +86,13 @@ class RecursiveTermValidator : public DefaultTraversalVisitor {
         node->location(),
         cteName_,
         "WITH RECURSIVE recursive term does not support DISTINCT");
-    AXIOM_PRESTO_SYNTAX_CHECK(
-        node->groupBy() == nullptr,
+    AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+        node->groupBy(),
         node->location(),
         cteName_,
         "WITH RECURSIVE recursive term does not support GROUP BY");
-    AXIOM_PRESTO_SYNTAX_CHECK(
-        node->having() == nullptr,
+    AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+        node->having(),
         node->location(),
         cteName_,
         "WITH RECURSIVE recursive term does not support HAVING");
@@ -102,13 +103,14 @@ class RecursiveTermValidator : public DefaultTraversalVisitor {
 
   void visitFunctionCall(FunctionCall* node) override {
     const auto& name = node->name()->suffix();
-    AXIOM_PRESTO_SYNTAX_CHECK(
-        node->window() == nullptr,
+    AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+        node->window(),
         node->location(),
         cteName_,
         "WITH RECURSIVE recursive term does not support window functions");
     AXIOM_PRESTO_SYNTAX_CHECK(
-        facebook::velox::exec::getAggregateFunctionEntry(name) == nullptr,
+        facebook::velox::exec::getAggregateFunctionEntry(name) == nullptr &&
+            !specialAggregateKind(name).has_value(),
         node->location(),
         cteName_,
         "WITH RECURSIVE recursive term does not support aggregate functions");
@@ -184,8 +186,8 @@ class RecursiveTermValidator : public DefaultTraversalVisitor {
       const std::shared_ptr<OrderBy>& orderBy,
       const std::optional<std::string>& limit,
       const std::shared_ptr<Offset>& offset) {
-    AXIOM_PRESTO_SYNTAX_CHECK(
-        orderBy == nullptr,
+    AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+        orderBy,
         location,
         cteName_,
         "WITH RECURSIVE does not support ORDER BY in the recursive CTE");
@@ -194,8 +196,8 @@ class RecursiveTermValidator : public DefaultTraversalVisitor {
         location,
         cteName_,
         "WITH RECURSIVE does not support LIMIT in the recursive CTE");
-    AXIOM_PRESTO_SYNTAX_CHECK(
-        offset == nullptr,
+    AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+        offset,
         location,
         cteName_,
         "WITH RECURSIVE does not support OFFSET in the recursive CTE");
@@ -247,8 +249,8 @@ const Union* RecursiveCteValidator::extractAndValidateRecursiveUnion(
 
   // ORDER BY / LIMIT / OFFSET on the wrapping Query are meaningless in a
   // recursive CTE (executor decides per-iteration order; ANSI forbids).
-  AXIOM_PRESTO_SYNTAX_CHECK(
-      bodyQuery->orderBy() == nullptr,
+  AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+      bodyQuery->orderBy(),
       bodyQuery->location(),
       cteName,
       "WITH RECURSIVE does not support ORDER BY in the recursive CTE");
@@ -257,8 +259,8 @@ const Union* RecursiveCteValidator::extractAndValidateRecursiveUnion(
       bodyQuery->location(),
       cteName,
       "WITH RECURSIVE does not support LIMIT in the recursive CTE");
-  AXIOM_PRESTO_SYNTAX_CHECK(
-      bodyQuery->offset() == nullptr,
+  AXIOM_PRESTO_SYNTAX_CHECK_NULL(
+      bodyQuery->offset(),
       bodyQuery->location(),
       cteName,
       "WITH RECURSIVE does not support OFFSET in the recursive CTE");

--- a/axiom/sql/presto/SpecialAggregates.cpp
+++ b/axiom/sql/presto/SpecialAggregates.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "axiom/sql/presto/SpecialAggregates.h"
+
+#include <array>
+#include <cctype>
+
+namespace axiom::sql::presto {
+
+namespace {
+// Case-insensitive comparison against an already-lowercase candidate, without
+// allocating (this runs for every function call while parsing).
+bool equalsLowercase(std::string_view name, std::string_view lowercase) {
+  if (name.size() != lowercase.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < name.size(); ++i) {
+    if (std::tolower(static_cast<unsigned char>(name[i])) != lowercase[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace
+
+std::optional<lp::SpecialAggregateKind> specialAggregateKind(
+    std::string_view name) {
+  static constexpr std::array<
+      std::pair<std::string_view, lp::SpecialAggregateKind>,
+      3>
+      kByName = {{
+          {"approx_count_star", lp::SpecialAggregateKind::kMetadataRowCount},
+          {"approx_null_count", lp::SpecialAggregateKind::kMetadataNullCount},
+          {"approx_non_null_count",
+           lp::SpecialAggregateKind::kMetadataNonNullCount},
+      }};
+
+  for (const auto& [candidate, kind] : kByName) {
+    if (equalsLowercase(name, candidate)) {
+      return kind;
+    }
+  }
+  return std::nullopt;
+}
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/SpecialAggregates.h
+++ b/axiom/sql/presto/SpecialAggregates.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+#include <string_view>
+
+#include "axiom/logical_plan/Expr.h"
+
+namespace axiom::sql::presto {
+
+namespace lp = facebook::axiom::logical_plan;
+
+/// Maps a Presto function name (case-insensitive) to the metadata aggregate
+/// kind it exposes, or std::nullopt if the name is not a metadata aggregate.
+/// This is the Presto dialect's surface for the optimizer's
+/// SpecialAggregateKind contract: the dialect chooses which names expose which
+/// kinds.
+std::optional<lp::SpecialAggregateKind> specialAggregateKind(
+    std::string_view name);
+
+} // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/ExprMatcher.cpp
+++ b/axiom/sql/presto/tests/ExprMatcher.cpp
@@ -488,6 +488,21 @@ bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
       return !::testing::Test::HasNonfatalFailure();
     }
 
+    case ExprKind::kSpecialFormAgg: {
+      const auto* expectedCall =
+          dynamic_cast<const velox::core::SpecialFormAggCallExpr*>(
+              expected.get());
+      EXPECT_NE(expectedCall, nullptr) << "Expected SpecialFormAggCallExpr.";
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      const auto* aggregate = actual->as<SpecialFormAggExpr>();
+      EXPECT_EQ(aggregate->kind(), expectedCall->specialAggregateKind());
+      AXIOM_RETURN_FALSE_IF_FAILURE
+
+      matchChildren(aggregate->inputs(), expectedCall->inputs());
+      return !::testing::Test::HasNonfatalFailure();
+    }
+
     case ExprKind::kWindow: {
       EXPECT_TRUE(expected->is(velox::core::IExpr::Kind::kWindow))
           << "Expected WindowCallExpr.";


### PR DESCRIPTION
Summary:

Adds three aggregates the v2 optimizer answers from table metadata instead of by reading the data:

- `approx_count_star()` — row count
- `approx_null_count(c)` — null count of a column
- `approx_non_null_count(c)` — non-null count of a column

For example,

    SELECT approx_count_star() FROM t

folds to a constant instead of scanning every file. Unlike `count(*)`, these read no data when the connector can supply the counts.

The optimizer models them as a closed set of metadata aggregates keyed by a kind, each carrying an ordinary-aggregate fallback. A new v2 pass folds an aggregation made only of metadata aggregates directly over a scan into a `Values` node, using a new connector API (`co_metadataCounts`). Otherwise each metadata aggregate is replaced by its fallback and the query reads the data. The fold does not apply when:

- the grouping key is not a partition column,
- a filter references a data column, or
- a metadata aggregate is mixed with an ordinary one.

Implements `co_metadataCounts` for the local Hive connector. Wired in v2 only.

Also extends the shared test framework:

- `PlanMatcher` can assert a `Values` node's literal rows.
- A `.sql` file can register for the v2 optimizer only.

Reviewed By: amitkdutta

Differential Revision: D112266832
