### PR TITLE
fix(optimizer): Preserve source order for mixed-type commutative args (#1594)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1073,6 +1073,11 @@ namespace {
 //
 //  #2. If none are literal, but the id on the left is higher.
 bool shouldInvert(ExprCP left, ExprCP right) {
+  // Only reorder operands of the same type.
+  if (left->value().type != right->value().type) {
+    return false;
+  }
+
   if (left->is(PlanType::kLiteralExpr) &&
       right->isNot(PlanType::kLiteralExpr)) {
     return true;

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -474,6 +474,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"basic">();
   registerQueryFile<"coercion">();
   registerQueryFile<"cte">();
+  registerQueryFile<"datetime">();
   registerQueryFile<"distinctAggregation">();
   registerQueryFile<"groupingsets">();
   registerQueryFile<"join">();

--- a/axiom/optimizer/tests/sql/datetime.sql
+++ b/axiom/optimizer/tests/sql/datetime.sql
@@ -1,0 +1,3 @@
+-- setup_file: common_setup.sql
+
+SELECT day(DATE '2026-07-14' + INTERVAL '1' DAY * n) FROM (VALUES (1), (2)) _(n)

--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -35,6 +35,10 @@ namespace {
 // right, or — when neither side is a literal — to put the lower-id
 // expression on the left.
 bool shouldInvert(ExprCP left, ExprCP right) {
+  // Only reorder operands of the same type.
+  if (left->value().type != right->value().type) {
+    return false;
+  }
   const bool leftIsLiteral = left->is(PlanType::kLiteralExpr);
   const bool rightIsLiteral = right->is(PlanType::kLiteralExpr);
   if (leftIsLiteral && !rightIsLiteral) {


### PR DESCRIPTION
Summary:

Adding a date and an interval failed to plan. The query

    SELECT DATE '2026-07-14' + INTERVAL '1' DAY * n FROM t

failed with:

    Scalar function plus not registered with arguments: (INTERVAL DAY TO SECOND, DATE)

`canonicalizeCall` reorders the arguments of a commutative function into a canonical form, putting a literal (or the lower-id expression) first. For `plus(date, interval)` this produced `plus(interval, date)`, a signature Velox does not register. The reorder now applies only when both operands have the same type, so a mixed-type operation keeps its source order.

Reviewed By: mbasmanova

Differential Revision: D112372331


