### PR TITLE
feat(optimizer): Prune scans the connector proves empty (#1595)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -368,9 +368,13 @@ struct SampleResult {
   int64_t numMatched;
 };
 
-/// Result of estimating filtered table statistics from the connector.
+/// Result of estimated or proven facts about a filtered table scan.
 struct FilteredTableStats {
-  /// Estimated row count after applying filters.
+  /// True when the connector proves the scan returns no rows. This is an exact
+  /// guarantee, not an estimate. When true, numRows must be 0.
+  bool guaranteedEmpty{false};
+
+  /// Row count after applying filters. This may be an estimate.
   uint64_t numRows{0};
 
   /// Per-column statistics corresponding 1:1 to the 'columns' parameter of
@@ -540,10 +544,16 @@ class TableLayout {
     VELOX_UNSUPPORTED("Sampling is not supported for this layout");
   }
 
-  /// Returns estimated statistics for a table scan with the given filters.
-  /// Connectors that have access to partition-level metadata (e.g., Hive
-  /// Metastore) can resolve matching partitions and aggregate their stats
-  /// without reading data.
+  /// Returns estimated statistics, or exact emptiness, for a table scan with
+  /// the given filters. Connectors that have access to partition-level metadata
+  /// (e.g., Hive Metastore) can resolve matching partitions and aggregate their
+  /// stats without reading data.
+  ///
+  /// A nullopt result means the connector has no information. A present result
+  /// with guaranteedEmpty set to false is an estimate. A present result with
+  /// guaranteedEmpty set to true is an exact proof that the scan returns no
+  /// rows, and must have numRows set to 0. A numRows == 0 estimate is not
+  /// treated as proof unless guaranteedEmpty is true.
   ///
   /// @param session Connector session for the current query.
   /// @param tableHandle Table handle for the table.

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -311,7 +311,9 @@ FilteredTableStats estimateStatsFromPartitionStats(
   }
 
   return FilteredTableStats{
-      totalRows, std::move(columnStats), std::move(rejectedFilterIndices)};
+      .numRows = totalRows,
+      .columnStats = std::move(columnStats),
+      .rejectedFilterIndices = std::move(rejectedFilterIndices)};
 }
 
 } // namespace

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -229,6 +229,14 @@ void TestTable::setStats(
   }
 }
 
+void TestTable::setKnownEmpty(bool knownEmpty) {
+  exportedLayout_->setKnownEmpty(knownEmpty);
+}
+
+void TestTable::setFilteredStats(FilteredTableStats filteredStats) {
+  exportedLayout_->setFilteredStats(std::move(filteredStats));
+}
+
 namespace {
 
 struct BucketedRows {
@@ -771,7 +779,10 @@ TestTableLayout::co_estimateStats(
   if (const auto& inspector = testConnector->onEstimateStats()) {
     inspector(filterConjuncts);
   }
-  co_return std::nullopt;
+  if (knownEmpty_) {
+    co_return FilteredTableStats{.guaranteedEmpty = true, .numRows = 0};
+  }
+  co_return filteredStats_;
 }
 
 std::shared_ptr<TestTable> TestConnectorMetadata::addTable(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -139,6 +139,16 @@ class TestTableLayout : public TableLayout {
   std::unique_ptr<DiscretePredicates> discretePredicates(
       const std::vector<const Column*>& columns) const override;
 
+  /// Makes co_estimateStats() report this layout as guaranteed empty.
+  void setKnownEmpty(bool knownEmpty) {
+    knownEmpty_ = knownEmpty;
+  }
+
+  /// Sets filtered scan stats returned by co_estimateStats().
+  void setFilteredStats(std::optional<FilteredTableStats> filteredStats) {
+    filteredStats_ = std::move(filteredStats);
+  }
+
   velox::connector::ColumnHandlePtr createColumnHandle(
       const ConnectorSessionPtr& session,
       const std::string& columnName,
@@ -155,8 +165,7 @@ class TestTableLayout : public TableLayout {
       velox::RowTypePtr dataColumns,
       std::optional<LookupKeys> lookupKeys) const override;
 
-  // Forwards the received conjuncts to the installed estimate-stats inspector,
-  // then returns std::nullopt (no stats), as the base does.
+  /// Returns configured filtered stats, or a guaranteed-empty result.
   folly::coro::Task<std::optional<FilteredTableStats>> co_estimateStats(
       ConnectorSessionPtr session,
       velox::connector::ConnectorTableHandlePtr tableHandle,
@@ -167,6 +176,8 @@ class TestTableLayout : public TableLayout {
   std::vector<const Column*> discreteValueColumns_;
   std::vector<velox::Variant> discreteValues_;
   std::shared_ptr<const PartitionType> partitionType_;
+  bool knownEmpty_{false};
+  std::optional<FilteredTableStats> filteredStats_;
 };
 
 /// RowVectors are appended using the addData() interface and the vector
@@ -225,6 +236,12 @@ class TestTable : public Table {
   void setStats(
       uint64_t numRows,
       const std::unordered_map<std::string, ColumnStatistics>& columnStats);
+
+  /// Makes co_estimateStats() report this table as guaranteed empty.
+  void setKnownEmpty(bool knownEmpty);
+
+  /// Sets filtered scan stats returned by this table's layout.
+  void setFilteredStats(FilteredTableStats filteredStats);
 
  private:
   // Per-column state for incremental stat computation during addData.

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1157,6 +1157,10 @@ struct BaseTable : public TableObject {
   /// the cardinality is unknown.
   std::optional<float> filteredCardinality{0};
 
+  /// True when connector metadata proves that this table scan returns no rows.
+  /// This is an exact semantic fact, not a cardinality estimate.
+  bool knownEmpty{false};
+
   SubfieldSet controlSubfields;
 
   SubfieldSet payloadSubfields;

--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -476,6 +476,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"cte">();
   registerQueryFile<"datetime">();
   registerQueryFile<"distinctAggregation">();
+  registerQueryFile<"emptyFold">(/*v2Only=*/true);
   registerQueryFile<"filterPushdown">();
   registerQueryFile<"groupingsets">();
   registerQueryFile<"join">();

--- a/axiom/optimizer/tests/sql/emptyFold.sql
+++ b/axiom/optimizer/tests/sql/emptyFold.sql
@@ -1,0 +1,124 @@
+-- setup_file: common_setup.sql
+
+-- Queries over empty inputs.
+
+-- Empty scan returns no rows.
+-- count 0
+SELECT a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- LIMIT 0 returns no rows.
+-- count 0
+SELECT * FROM t LIMIT 0
+----
+-- ORDER BY + LIMIT 0 returns no rows.
+-- count 0
+SELECT * FROM t ORDER BY a LIMIT 0
+----
+-- Inner (equi) join with an empty side returns no rows.
+-- count 0
+SELECT t.a AS ta, s.a AS sa FROM t JOIN (SELECT * FROM t LIMIT 0) s ON t.a = s.a
+----
+-- Cross join with an empty side returns no rows.
+-- count 0
+SELECT t.a AS ta, s.a AS sa FROM t CROSS JOIN (SELECT * FROM t LIMIT 0) s
+----
+-- Chained inner joins return no rows when any input is empty.
+-- count 0
+SELECT t1.a FROM t t1 JOIN t t2 ON t1.a = t2.a JOIN (SELECT a FROM t LIMIT 0) e ON t2.a = e.a
+----
+-- Projection, filter, order by, and limit over empty input return no rows.
+-- count 0
+SELECT a + 1 AS x FROM (SELECT * FROM t LIMIT 0) s WHERE a > 1 ORDER BY 1 LIMIT 5
+----
+-- Window over empty input returns no rows.
+-- count 0
+SELECT row_number() OVER (ORDER BY a) AS rn FROM (SELECT * FROM t LIMIT 0) s
+----
+-- GROUP BY over empty input returns no rows.
+-- count 0
+SELECT a, count(*) AS n FROM (SELECT * FROM t LIMIT 0) s GROUP BY a
+----
+-- DISTINCT over empty input returns no rows.
+-- count 0
+SELECT DISTINCT a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- Global aggregation over empty input returns one row.
+SELECT count(*) AS n FROM (SELECT * FROM t LIMIT 0) s
+----
+-- Global aggregation with a column argument over empty input (one row, NULL).
+SELECT sum(a) AS s FROM (SELECT * FROM t LIMIT 0) x
+----
+-- Global aggregation over an expression on empty input (one row, NULL).
+SELECT sum(a + 1) AS s FROM (SELECT * FROM t LIMIT 0) x
+----
+-- Left join with an empty right side preserves the left rows, null-filling right.
+SELECT t.a AS ta, s.a AS sa FROM t LEFT JOIN (SELECT * FROM t LIMIT 0) s ON t.a = s.a
+----
+-- Right join with an empty left side preserves the right rows, null-filling left.
+SELECT e.a AS ea, t.a AS ta FROM (SELECT * FROM t LIMIT 0) e RIGHT JOIN t ON e.a = t.a
+----
+-- Full join with one empty side preserves the non-empty side, null-filling the other.
+SELECT t.a AS ta, s.a AS sa FROM t FULL JOIN (SELECT * FROM t LIMIT 0) s ON t.a = s.a
+----
+-- Left join with an empty preserved side returns no rows.
+-- count 0
+SELECT e.a AS ea, t.a AS ta FROM (SELECT * FROM t LIMIT 0) e LEFT JOIN t ON e.a = t.a
+----
+-- Right join with an empty preserved side returns no rows.
+-- count 0
+SELECT t.a AS ta, e.a AS ea FROM t RIGHT JOIN (SELECT * FROM t LIMIT 0) e ON t.a = e.a
+----
+-- Full join with both sides empty returns no rows.
+-- count 0
+SELECT e1.a AS a1, e2.a AS a2 FROM (SELECT * FROM t LIMIT 0) e1 FULL JOIN (SELECT * FROM t LIMIT 0) e2 ON e1.a = e2.a
+----
+-- Semi join (EXISTS) with an empty filtering side yields no rows.
+-- count 0
+SELECT a FROM t WHERE EXISTS (SELECT 1 FROM (SELECT * FROM t LIMIT 0) s WHERE s.a = t.a)
+----
+-- Anti join (NOT EXISTS) with an empty filtering side keeps all rows.
+SELECT a FROM t WHERE NOT EXISTS (SELECT 1 FROM (SELECT * FROM t LIMIT 0) s WHERE s.a = t.a)
+----
+-- INTERSECT ALL with an empty side returns no rows.
+-- count 0
+SELECT a FROM t INTERSECT ALL SELECT a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- IN over an empty subquery keeps input rows and marks the predicate false.
+SELECT a IN (SELECT a FROM (SELECT * FROM t LIMIT 0) s) AS in_empty FROM t
+----
+-- EXCEPT ALL with an empty right side keeps the left rows.
+-- duckdb: SELECT a FROM t
+SELECT a FROM t EXCEPT ALL SELECT a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- GROUPING SETS without a global grouping set over empty input returns no rows.
+-- count 0
+SELECT a, b, count(*) AS n FROM (SELECT * FROM t LIMIT 0) s GROUP BY GROUPING SETS ((a), (b))
+----
+-- GROUPING SETS with a global grouping set over empty input keeps the grand-total row.
+SELECT a, count(*) AS n FROM (SELECT * FROM t LIMIT 0) s GROUP BY GROUPING SETS ((a), ())
+----
+-- UNNEST over empty input returns no rows.
+-- count 0
+SELECT item FROM (SELECT * FROM t LIMIT 0) s CROSS JOIN UNNEST(ARRAY[a]) AS u(item)
+----
+-- UNION ALL with an empty second input keeps the first.
+SELECT a FROM t UNION ALL SELECT a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- UNION ALL with an empty first input keeps the second.
+SELECT a FROM (SELECT * FROM t LIMIT 0) s UNION ALL SELECT a FROM t
+----
+-- UNION ALL with all inputs empty returns no rows.
+-- count 0
+SELECT a FROM (SELECT * FROM t LIMIT 0) s UNION ALL SELECT a FROM (SELECT * FROM t LIMIT 0) r
+----
+-- UNION ALL with one empty input and two surviving inputs keeps the survivors.
+SELECT a FROM t UNION ALL SELECT a FROM (SELECT * FROM t LIMIT 0) s UNION ALL SELECT a FROM t
+----
+-- UNION ALL whose single surviving leg is a TopN preserves ORDER BY + LIMIT.
+(SELECT a FROM t ORDER BY a LIMIT 3) UNION ALL SELECT a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- UNION ALL with reordered and duplicated columns returns the surviving rows.
+SELECT b, a, b FROM t UNION ALL SELECT a, b, a FROM (SELECT * FROM t LIMIT 0) s
+----
+-- UNION DISTINCT with one empty input keeps the dedup over the non-empty input.
+SELECT a FROM (SELECT * FROM t LIMIT 0) s UNION SELECT a FROM t

--- a/axiom/optimizer/v2/CMakeLists.txt
+++ b/axiom/optimizer/v2/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(
   ExprEmitter.cpp
   ExprFactory.cpp
   ExprSimplifier.cpp
+  FoldEmptyInputsPass.cpp
   FoldMetadataAggregatePass.cpp
   HypergraphBuilder.cpp
   JoinCondition.cpp

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -61,13 +61,13 @@ void applyColumnStats(
   const_cast<Value&>(existing) = value;
 }
 
-// Applies one base table's connector stats result. Sets filteredCardinality to
-// the connector's post-filter row count, scaled by the optimizer's own
-// selectivity for any filters the connector rejected. A nullopt result (the
-// connector does not support stats) leaves filteredCardinality at 0 so
-// downstream estimation falls back to constraint-based selectivity. Rejected
-// filters scale only the row count; per-column constraints are re-derived
-// downstream.
+// Applies one base table's connector stats result. Records exact empty facts
+// before applying row-count stats, then sets filteredCardinality to the
+// connector's post-filter row count, scaled by the optimizer's own selectivity
+// for any filters the connector rejected. A nullopt result (the connector does
+// not support stats) leaves filteredCardinality at 0 so downstream estimation
+// falls back to constraint-based selectivity. Rejected filters scale only the
+// row count; per-column constraints are re-derived downstream.
 void applyFilteredStats(
     const Scan& scan,
     const std::vector<ColumnCP>& statColumns,
@@ -77,6 +77,13 @@ void applyFilteredStats(
   }
 
   auto* baseTable = const_cast<BaseTable*>(scan.baseTable());
+  const bool guaranteedEmpty = stats->guaranteedEmpty;
+  if (guaranteedEmpty) {
+    VELOX_CHECK_EQ(stats->numRows, 0);
+    baseTable->knownEmpty = true;
+    baseTable->filteredCardinality = 0;
+    return;
+  }
 
   if (!stats->columnStats.empty()) {
     VELOX_CHECK_EQ(stats->columnStats.size(), statColumns.size());

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -101,6 +101,9 @@ Estimate EstimateProvider::compute(NodeCP node) {
       const auto* scan = node->as<Scan>();
       const auto* baseTable = scan->baseTable();
       Estimate result;
+      VELOX_CHECK(
+          !baseTable->knownEmpty,
+          "Known-empty scans should be folded to empty Values before estimation");
       // Narrow per-column constraints from the scan filters; join propagation
       // reads these regardless of the cardinality source. The filter
       // selectivity is unknown when `conjunctsSelectivity` cannot estimate it;
@@ -232,7 +235,8 @@ Estimate EstimateProvider::compute(NodeCP node) {
       for (NodeCP input : node->inputs()) {
         total = add(total, estimate(input).cardinality);
       }
-      result.cardinality = maxOf(1.0f, total);
+      bool isEmpty = (total.has_value() && *total == 0);
+      result.cardinality = isEmpty ? 0 : maxOf(1.0f, total);
       return result;
     }
 
@@ -240,7 +244,11 @@ Estimate EstimateProvider::compute(NodeCP node) {
       const auto* values = node->as<Values>();
       Estimate result;
       if (values->rows() != nullptr) {
-        result.cardinality = std::max<float>(1, values->rows()->array().size());
+        const auto numRows = static_cast<float>(values->rows()->array().size());
+        result.cardinality = numRows == 0 ? 0 : std::max(1.0f, numRows);
+      } else if (values->source() == nullptr) {
+        // No source and no folded rows is the schema-only empty Values shape.
+        result.cardinality = 0;
       } else {
         result.cardinality = kDefaultLeafCardinality;
       }

--- a/axiom/optimizer/v2/FoldEmptyInputsPass.cpp
+++ b/axiom/optimizer/v2/FoldEmptyInputsPass.cpp
@@ -1,0 +1,499 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/v2/FoldEmptyInputsPass.h"
+
+#include <algorithm>
+#include <optional>
+
+#include "axiom/optimizer/v2/NodeRewriter.h"
+
+namespace facebook::axiom::optimizer::v2 {
+namespace {
+
+enum class JoinSide {
+  kLeft,
+  kRight,
+};
+
+bool sameColumns(const ColumnVector& left, const ColumnVector& right) {
+  if (left.size() != right.size()) {
+    return false;
+  }
+  for (size_t i = 0; i < left.size(); ++i) {
+    if (left[i] != right[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+ExprVector toExprs(const ColumnVector& columns) {
+  ExprVector exprs;
+  exprs.reserve(columns.size());
+  for (ColumnCP column : columns) {
+    exprs.push_back(column);
+  }
+  return exprs;
+}
+
+bool isEmptyValues(NodeCP node) {
+  if (!node->is(NodeType::kValues)) {
+    return false;
+  }
+  const auto* values = node->as<Values>();
+  if (values->source() != nullptr) {
+    return false;
+  }
+  return values->rows() == nullptr || values->rows()->array().empty();
+}
+
+bool isEmptyPreservingAggregation(AggregateCP node) {
+  return !node->groupingKeys().empty() && node->globalGroupingSets().empty();
+}
+
+class Folder : public NodeRewriter<NoContext> {
+ public:
+  // Creates a bottom-up empty-input folder using 'builder' for rewritten nodes.
+  explicit Folder(Builder& builder) : NodeRewriter(builder) {}
+
+ private:
+  // Produces an empty Values node with the same output columns as 'node'.
+  NodeCP makeEmptyLike(NodeCP node) {
+    return builder().makeEmptyValues(node->outputColumns());
+  }
+
+  // Folds a unary operator whose empty input implies empty output.
+  NodeCP foldUnaryEmptyPreserving(NodeCP original, NodeCP rewrittenInput) {
+    if (isEmptyValues(rewrittenInput)) {
+      return makeEmptyLike(original);
+    }
+    return nullptr;
+  }
+
+  // Returns a replacement if a unary node folds, or the original node when its
+  // input is unchanged.
+  NodeCP tryFoldUnary(NodeCP original, NodeCP originalInput, NodeCP newInput) {
+    if (NodeCP folded = foldUnaryEmptyPreserving(original, newInput)) {
+      return folded;
+    }
+    if (newInput == originalInput) {
+      return original;
+    }
+    return nullptr;
+  }
+
+  // Replaces connector-proven empty scans with schema-preserving empty Values.
+  NodeCP rewriteScan(const Scan* node, NoContext& /*context*/) override {
+    if (node->baseTable()->knownEmpty) {
+      return makeEmptyLike(node);
+    }
+    return node;
+  }
+
+  // Rewrites a filter, preserving emptiness from its input.
+  NodeCP rewriteFilter(const Filter* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<Filter>({newInput, node->predicates()});
+  }
+
+  // Rewrites a project, preserving the project's output schema on empty input.
+  NodeCP rewriteProject(const Project* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<Project>(
+        {newInput, node->exprs(), node->outputColumns()});
+  }
+
+  // Rewrites a limit, preserving emptiness from its input.
+  NodeCP rewriteLimit(const Limit* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<Limit>({newInput, node->offset(), node->count()});
+  }
+
+  // Rewrites a sort, preserving emptiness from its input.
+  NodeCP rewriteSort(const Sort* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<Sort>(
+        {newInput, node->orderKeys(), node->orderTypes()});
+  }
+
+  // Rewrites a TopN, preserving emptiness from its input.
+  NodeCP rewriteTopN(const TopN* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<TopN>(
+        {newInput,
+         node->orderKeys(),
+         node->orderTypes(),
+         node->offset(),
+         node->count()});
+  }
+
+  // Folds only aggregate forms that produce no rows over empty input.
+  NodeCP rewriteAggregate(const Aggregate* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (isEmptyValues(newInput) && isEmptyPreservingAggregation(node)) {
+      return makeEmptyLike(node);
+    }
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder().make<Aggregate>(Aggregate::Key{
+        .input = newInput,
+        .groupingKeys = node->groupingKeys(),
+        .aggregates = node->aggregates(),
+        .outputColumns = node->outputColumns(),
+        .step = node->step(),
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
+  }
+
+  // Rewrites GroupId, preserving emptiness from its input.
+  NodeCP rewriteGroupId(const GroupId* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<GroupId>(
+        {newInput,
+         node->groupingKeys(),
+         node->aggregationInputs(),
+         node->groupingSets(),
+         node->groupingKeyColumns(),
+         node->groupId(),
+         node->outputColumns()});
+  }
+
+  // Rewrites MarkDistinct, preserving emptiness from its input.
+  NodeCP rewriteMarkDistinct(const MarkDistinct* node, NoContext& context)
+      override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<MarkDistinct>(
+        {newInput,
+         node->markers(),
+         node->distinctKeys(),
+         node->masks(),
+         node->outputColumns()});
+  }
+
+  // Drops empty UNION ALL legs and remaps a single survivor to union outputs.
+  NodeCP rewriteUnionAll(const UnionAll* node, NoContext& context) override {
+    NodeVector inputs;
+    QGVector<ColumnVector> legColumns;
+    bool changed = false;
+    for (size_t i = 0; i < node->inputs().size(); ++i) {
+      NodeCP newInput = rewrite(node->inputs()[i], context);
+      changed |= (newInput != node->inputs()[i]);
+      if (!isEmptyValues(newInput)) {
+        ColumnVector newLegColumns = node->legColumns()[i];
+        // Avoid a redundant column-remapping Project.
+        if (auto composed = composeColumnRemap(newInput, newLegColumns)) {
+          newInput = composed->first;
+          newLegColumns = std::move(composed->second);
+          changed = true;
+        }
+        inputs.push_back(newInput);
+        legColumns.push_back(std::move(newLegColumns));
+      } else {
+        changed = true;
+      }
+    }
+
+    if (inputs.empty()) {
+      return makeEmptyLike(node);
+    }
+
+    if (inputs.size() == 1) {
+      return projectColumnRemap(
+          inputs[0], legColumns[0], node->outputColumns());
+    }
+
+    if (!changed) {
+      return node;
+    }
+    return builder().make<UnionAll>(
+        {std::move(inputs), std::move(legColumns), node->outputColumns()});
+  }
+
+  // Rewrites Unnest, preserving emptiness from its input.
+  NodeCP rewriteUnnest(const Unnest* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<Unnest>(
+        {newInput,
+         node->unnestExpressions(),
+         node->replicatedColumns(),
+         node->unnestColumns(),
+         node->ordinalityColumn(),
+         node->outputColumns()});
+  }
+
+  // Folds joins according to each join type's empty-side semantics.
+  NodeCP rewriteJoin(const Join* node, NoContext& context) override {
+    NodeCP newLeft = rewrite(node->left(), context);
+    NodeCP newRight = rewrite(node->right(), context);
+    const bool leftEmpty = isEmptyValues(newLeft);
+    const bool rightEmpty = isEmptyValues(newRight);
+
+    if (!leftEmpty && !rightEmpty) {
+      if (newLeft == node->left() && newRight == node->right()) {
+        return node;
+      }
+      return rebuildJoin(node, newLeft, newRight);
+    }
+
+    switch (node->joinType()) {
+      case velox::core::JoinType::kInner:
+        return makeEmptyLike(node);
+
+      case velox::core::JoinType::kLeft:
+        return leftEmpty ? makeEmptyLike(node)
+                         : projectJoinOutput(node, newLeft, JoinSide::kLeft);
+
+      case velox::core::JoinType::kRight:
+        return rightEmpty ? makeEmptyLike(node)
+                          : projectJoinOutput(node, newRight, JoinSide::kRight);
+
+      case velox::core::JoinType::kFull:
+        if (leftEmpty && rightEmpty) {
+          return makeEmptyLike(node);
+        }
+        return leftEmpty ? projectJoinOutput(node, newRight, JoinSide::kRight)
+                         : projectJoinOutput(node, newLeft, JoinSide::kLeft);
+
+      case velox::core::JoinType::kLeftSemiFilter:
+      case velox::core::JoinType::kCountingLeftSemiFilter:
+        return makeEmptyLike(node);
+
+      case velox::core::JoinType::kRightSemiFilter:
+        return makeEmptyLike(node);
+
+      case velox::core::JoinType::kLeftSemiProject:
+        return leftEmpty ? makeEmptyLike(node)
+                         : projectJoinOutput(
+                               node,
+                               newLeft,
+                               JoinSide::kLeft,
+                               /*semiProjectMarkValue=*/false);
+
+      case velox::core::JoinType::kRightSemiProject:
+        return rightEmpty ? makeEmptyLike(node)
+                          : projectJoinOutput(
+                                node,
+                                newRight,
+                                JoinSide::kRight,
+                                /*semiProjectMarkValue=*/false);
+
+      case velox::core::JoinType::kAnti:
+      case velox::core::JoinType::kCountingAnti:
+        return leftEmpty ? makeEmptyLike(node)
+                         : projectJoinOutput(node, newLeft, JoinSide::kLeft);
+
+      case velox::core::JoinType::kNumJoinTypes:
+        break;
+    }
+    VELOX_UNREACHABLE();
+  }
+
+  // Rewrites Window, preserving emptiness from its input.
+  NodeCP rewriteWindow(const Window* node, NoContext& context) override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<Window>(
+        {newInput,
+         node->functions(),
+         node->partitionKeys(),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->outputColumns()});
+  }
+
+  // Rewrites TopNRowNumber, preserving emptiness from its input.
+  NodeCP rewriteTopNRowNumber(const TopNRowNumber* node, NoContext& context)
+      override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<TopNRowNumber>(
+        {newInput,
+         node->rankFunction(),
+         node->partitionKeys(),
+         node->orderKeys(),
+         node->orderTypes(),
+         node->limit(),
+         node->rankColumn(),
+         node->outputColumns()});
+  }
+
+  // Rewrites AssignUniqueId, preserving emptiness from its input.
+  NodeCP rewriteAssignUniqueId(const AssignUniqueId* node, NoContext& context)
+      override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<AssignUniqueId>({newInput, node->idColumn()});
+  }
+
+  // Rewrites EnforceDistinct, preserving emptiness from its input.
+  NodeCP rewriteEnforceDistinct(const EnforceDistinct* node, NoContext& context)
+      override {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (NodeCP replacement = tryFoldUnary(node, node->input(), newInput)) {
+      return replacement;
+    }
+    return builder().make<EnforceDistinct>(
+        {newInput, node->distinctKeys(), node->errorMessage()});
+  }
+
+  // Rebuilds a join with rewritten children and the original join semantics.
+  NodeCP rebuildJoin(const Join* node, NodeCP left, NodeCP right) {
+    return builder().make<Join>(
+        {left,
+         right,
+         node->joinType(),
+         node->leftKeys(),
+         node->rightKeys(),
+         node->filter(),
+         node->nullAware(),
+         node->nullAsValue(),
+         node->outputColumns()});
+  }
+
+  // Creates a Project unless the input already exposes the requested columns.
+  NodeCP project(
+      NodeCP input,
+      ExprVector exprs,
+      ColumnVector outputColumns,
+      bool force = false) {
+    if (!force && sameColumns(input->outputColumns(), outputColumns)) {
+      return input;
+    }
+    return builder().make<Project>(
+        {input, std::move(exprs), std::move(outputColumns)});
+  }
+
+  // Removes a column-renaming Project by collapsing the renaming as output
+  // columns of the Project's input.
+  std::optional<std::pair<NodeCP, ColumnVector>> composeColumnRemap(
+      NodeCP projection,
+      const ColumnVector& inputColumns) {
+    if (!projection->is(NodeType::kProject)) {
+      return std::nullopt;
+    }
+
+    const auto* project = projection->as<Project>();
+    for (ExprCP expr : project->exprs()) {
+      if (!expr->isColumn()) {
+        return std::nullopt;
+      }
+    }
+
+    ColumnVector composedColumns;
+    composedColumns.reserve(inputColumns.size());
+    const auto& projectOutputs = project->outputColumns();
+    for (ColumnCP inputColumn : inputColumns) {
+      auto it =
+          std::find(projectOutputs.begin(), projectOutputs.end(), inputColumn);
+      VELOX_CHECK(
+          it != projectOutputs.end(),
+          "Column remap references a column not produced by input: {}",
+          inputColumn->toString());
+      composedColumns.push_back(
+          project->exprs()[std::distance(projectOutputs.begin(), it)]
+              ->as<Column>());
+    }
+    return std::pair{project->input(), std::move(composedColumns)};
+  }
+
+  // Projects a surviving union input's leg columns into union output columns.
+  NodeCP projectColumnRemap(
+      NodeCP input,
+      const ColumnVector& legColumns,
+      const ColumnVector& outputColumns) {
+    if (sameColumns(legColumns, outputColumns) &&
+        sameColumns(input->outputColumns(), outputColumns)) {
+      return input;
+    }
+
+    return project(input, toExprs(legColumns), outputColumns, /*force=*/true);
+  }
+
+  // Projects a surviving join side into the original join output schema.
+  NodeCP projectJoinOutput(
+      JoinCP join,
+      NodeCP input,
+      JoinSide survivingSide,
+      std::optional<bool> semiProjectMarkValue = std::nullopt) {
+    const auto& survivingColumns = survivingSide == JoinSide::kLeft
+        ? join->left()->outputColumns()
+        : join->right()->outputColumns();
+    const auto& missingColumns = survivingSide == JoinSide::kLeft
+        ? join->right()->outputColumns()
+        : join->left()->outputColumns();
+    const auto survivingSet = PlanObjectSet::fromObjects(survivingColumns);
+    const auto missingSet = PlanObjectSet::fromObjects(missingColumns);
+
+    ExprVector exprs;
+    exprs.reserve(join->outputColumns().size());
+    for (ColumnCP output : join->outputColumns()) {
+      if (survivingSet.contains(output)) {
+        exprs.push_back(output);
+      } else if (missingSet.contains(output)) {
+        exprs.push_back(builder().makeNull(output->value().type));
+      } else {
+        VELOX_CHECK(
+            semiProjectMarkValue.has_value(),
+            "Join output column is not produced by either input: {}",
+            output->toString());
+        exprs.push_back(builder().makeBoolean(*semiProjectMarkValue));
+      }
+    }
+
+    return project(input, std::move(exprs), join->outputColumns());
+  }
+};
+
+} // namespace
+
+NodeCP FoldEmptyInputsPass::run(NodeCP root, Builder& builder) {
+  Folder folder(builder);
+  return folder.rewrite(root);
+}
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/FoldEmptyInputsPass.h
+++ b/axiom/optimizer/v2/FoldEmptyInputsPass.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "axiom/optimizer/v2/Builder.h"
+
+namespace facebook::axiom::optimizer::v2 {
+
+/// Propagates exact empty-input facts through the logical tree.
+class FoldEmptyInputsPass {
+ public:
+  /// Returns `root` with known-empty scans and empty-preserving operators
+  /// folded to empty `Values`, preserving each rewritten node's output schema.
+  static NodeCP run(NodeCP root, Builder& builder);
+};
+
+} // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -23,6 +23,7 @@
 #include "axiom/optimizer/v2/EstimateLeafStatsPass.h"
 #include "axiom/optimizer/v2/EstimateProvider.h"
 #include "axiom/optimizer/v2/ExpandAggregatePass.h"
+#include "axiom/optimizer/v2/FoldEmptyInputsPass.h"
 #include "axiom/optimizer/v2/FoldMetadataAggregatePass.h"
 #include "axiom/optimizer/v2/LimitAndOrderPass.h"
 #include "axiom/optimizer/v2/PlanPhysicalPass.h"
@@ -90,6 +91,7 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
   if (session_.options().useFilteredTableStats) {
     EstimateLeafStatsPass::run(folded, session_, evaluator_, scanHandles);
   }
+  folded = FoldEmptyInputsPass::run(folded, builder);
   NodeCP physicalPlanned = PlanPhysicalPass::run(
       folded,
       builder,
@@ -156,13 +158,14 @@ QueryStats Optimizer::estimateQueryStats() {
   Builder builder;
 
   auto frontend = translateAndPushdown(plan_, schema, evaluator_, builder);
+  NodeCP folded = frontend.pushed;
   if (session_.options().useFilteredTableStats) {
-    EstimateLeafStatsPass::run(
-        frontend.pushed, session_, evaluator_, scanHandles);
+    EstimateLeafStatsPass::run(folded, session_, evaluator_, scanHandles);
   }
+  folded = FoldEmptyInputsPass::run(folded, builder);
 
   EstimateProvider estimateProvider;
-  const Estimate& estimate = estimateProvider.estimate(frontend.pushed);
+  const Estimate& estimate = estimateProvider.estimate(folded);
 
   const auto& columns = frontend.translated.outputColumns;
   const auto& names = frontend.translated.outputNames;

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -78,8 +78,12 @@ class Optimizer {
   ///   - Decorrelate — rewrite correlated subqueries as joins;
   ///   - LimitAndOrder — fold limits into ordering operators;
   ///   - PushdownAndPrune — push predicates down, prune unused columns;
+  ///   - FoldMetadataAggregate — answer metadata-only aggregates from
+  ///   connector stats when available;
   ///   - EstimateLeafStats — populate base-table cardinalities from the
   ///   connector;
+  ///   - FoldEmptyInputs — propagate exact empty-input facts through logical
+  ///   operators;
   ///   - PlanPhysical — cost-based join order and distribution;
   ///   - PrecomputeProjections — lift compound expressions into `Project`s
   ///   where
@@ -108,10 +112,9 @@ class Optimizer {
   /// Estimates the result statistics of the plan (the estimate behind
   /// SHOW STATS FOR (<query>)). Runs the shared front end (translate +
   /// pushdown) and, when the `useFilteredTableStats` option is set,
-  /// EstimateLeafStatsPass, then reads the root estimate via EstimateProvider —
-  /// the v2 analogue of v1 reading the root DerivedTable after logical
-  /// optimization. The returned pointers are valid only for the enclosing
-  /// QueryGraphContext's lifetime.
+  /// EstimateLeafStatsPass, folds exact empty-input facts, then reads the root
+  /// estimate via EstimateProvider. The returned pointers are valid only for
+  /// the enclosing QueryGraphContext's lifetime.
   QueryStats estimateQueryStats();
 
  private:

--- a/axiom/optimizer/v2/tests/CMakeLists.txt
+++ b/axiom/optimizer/v2/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   axiom_optimizer_v2_test
   AlgebraicPropertiesTest.cpp
+  EmptyFoldTest.cpp
   JoinHypergraphTest.cpp
   RelationSetTest.cpp
   TpchPlanTest.cpp

--- a/axiom/optimizer/v2/tests/EmptyFoldTest.cpp
+++ b/axiom/optimizer/v2/tests/EmptyFoldTest.cpp
@@ -1,0 +1,527 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "axiom/optimizer/v2/EmitPass.h"
+#include "axiom/optimizer/v2/FoldEmptyInputsPass.h"
+#include "axiom/optimizer/v2/Optimize.h"
+#include "velox/expression/Expr.h"
+
+namespace facebook::axiom::optimizer::v2::test {
+namespace {
+
+using namespace facebook::velox;
+
+class EmptyFoldTest : public optimizer::test::QueryTestBase {
+ public:
+  EmptyFoldTest() {
+    useV2_ = true;
+  }
+
+ protected:
+  struct TestCase {
+    const char* name;
+    const char* query;
+    std::shared_ptr<core::PlanMatcher> matcher;
+  };
+
+  void addSingleColumnTables() {
+    testConnector_->addTable("t", ROW({"a"}, BIGINT()));
+    testConnector_->addTable("u", ROW({"x"}, BIGINT()));
+  }
+
+  void addKnownEmptyJoinTables() {
+    testConnector_->addTable("t", ROW({"a"}, BIGINT()));
+    testConnector_->addTable("empty_u", ROW({"x"}, BIGINT()))
+        ->setKnownEmpty(true);
+  }
+
+  void initializeV2Context() {
+    allocator_ = std::make_unique<HashStringAllocator>(&optimizerPool());
+    v2Context_ = std::make_unique<QueryGraphContext>(*allocator_);
+    queryCtx() = v2Context_.get();
+    builder_ = std::make_unique<Builder>();
+    veloxQueryCtx_ = getQueryCtx();
+    evaluator_ = std::make_unique<exec::SimpleExpressionEvaluator>(
+        veloxQueryCtx_.get(), &optimizerPool());
+    session_ = std::make_unique<OptimizerSession>(
+        veloxQueryCtx_->queryId(),
+        "test",
+        optimizerOptions_,
+        connector::ConnectorProperties{});
+    options_.queryId = veloxQueryCtx_->queryId();
+    options_.numWorkers = 1;
+    options_.numDrivers = 1;
+  }
+
+  void resetV2Context() {
+    session_.reset();
+    evaluator_.reset();
+    veloxQueryCtx_.reset();
+    builder_.reset();
+    queryCtx() = nullptr;
+    v2Context_.reset();
+    allocator_.reset();
+  }
+
+  void TearDown() override {
+    resetV2Context();
+    QueryTestBase::TearDown();
+  }
+
+  core::PlanNodePtr emitFoldedPlan(
+      NodeCP node,
+      const ColumnVector& outputColumns) {
+    std::vector<std::string> outputNames;
+    outputNames.reserve(outputColumns.size());
+    for (ColumnCP column : outputColumns) {
+      outputNames.push_back(column->outputName());
+    }
+
+    ScanHandleCache scanHandles;
+
+    auto emitted = EmitPass::run(
+        FoldEmptyInputsPass::run(node, *builder_),
+        outputColumns,
+        outputNames,
+        *session_,
+        *evaluator_,
+        scanHandles,
+        options_);
+    VELOX_CHECK_EQ(emitted.fragments.size(), 1);
+    return emitted.fragments.front().fragment.planNode;
+  }
+
+  std::unique_ptr<HashStringAllocator> allocator_;
+  std::unique_ptr<QueryGraphContext> v2Context_;
+  std::unique_ptr<Builder> builder_;
+  std::shared_ptr<core::QueryCtx> veloxQueryCtx_;
+  std::unique_ptr<exec::SimpleExpressionEvaluator> evaluator_;
+  std::unique_ptr<OptimizerSession> session_;
+  MultiFragmentPlan::Options options_;
+};
+
+TEST_F(EmptyFoldTest, zeroLimitOverEmpty) {
+  addSingleColumnTables();
+
+  const std::vector<TestCase> testCases{
+      {
+          "equi",
+          "SELECT * FROM t, (SELECT * FROM u LIMIT 0) s WHERE a = x",
+          core::PlanMatcherBuilder{}.values().build(),
+      },
+      {
+          "cross",
+          "SELECT * FROM t CROSS JOIN (SELECT * FROM u LIMIT 0) s",
+          core::PlanMatcherBuilder{}.values().build(),
+      },
+      {
+          "unaryOperators",
+          "SELECT a + 1 FROM (SELECT * FROM t LIMIT 0) s "
+          "WHERE a > 10 ORDER BY 1 LIMIT 5",
+          core::PlanMatcherBuilder{}.values().build(),
+      },
+      {
+          "window",
+          "SELECT row_number() OVER (ORDER BY a) FROM "
+          "(SELECT * FROM t LIMIT 0) s",
+          core::PlanMatcherBuilder{}.values().build(),
+      },
+      {
+          "groupBy",
+          "SELECT a, count(*) FROM (SELECT * FROM t LIMIT 0) s GROUP BY a",
+          core::PlanMatcherBuilder{}.values().build(),
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    SCOPED_TRACE(testCase.query);
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(testCase.query, kTestConnectorId)),
+        testCase.matcher);
+  }
+}
+
+TEST_F(EmptyFoldTest, emptyScan) {
+  testConnector_->addTable("empty_t", ROW({"a"}, BIGINT()))
+      ->setKnownEmpty(true);
+
+  const auto query = "SELECT a FROM empty_t";
+  SCOPED_TRACE(query);
+  const auto matcher = core::PlanMatcherBuilder{}.values().build();
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSelect(query, kTestConnectorId)), matcher);
+}
+
+TEST_F(EmptyFoldTest, notFoldableScans) {
+  int numEstimateStatsCalls{0};
+  auto table = testConnector_->addTable("not_foldable_t", ROW({"a"}, BIGINT()));
+  table->setFilteredStats(connector::FilteredTableStats{.numRows = 0});
+
+  // A zero-row estimate without an exact empty guarantee is not foldable.
+  {
+    const auto query = "SELECT a FROM not_foldable_t";
+    SCOPED_TRACE("zeroRowStatsWithoutKnownEmpty");
+    SCOPED_TRACE(query);
+    table->setKnownEmpty(false);
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(query, kTestConnectorId)),
+        matchScan("not_foldable_t").build());
+  }
+
+  // Disabling filtered stats prevents connector-proven emptiness from folding.
+  {
+    const auto query = "SELECT a FROM not_foldable_t";
+    SCOPED_TRACE("filteredStatsDisabled");
+    SCOPED_TRACE(query);
+    table->setKnownEmpty(true);
+    optimizerOptions_.useFilteredTableStats = false;
+    testConnector_->setOnEstimateStats(
+        [&](const auto&) { ++numEstimateStatsCalls; });
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(query, kTestConnectorId)),
+        matchScan("not_foldable_t").build());
+  }
+
+  EXPECT_EQ(numEstimateStatsCalls, 0);
+}
+
+TEST_F(EmptyFoldTest, nonInnerJoinsOverEmpty) {
+  addKnownEmptyJoinTables();
+
+  const std::vector<TestCase> sqlTestCases{
+      {
+          "leftEmptyRight",
+          "SELECT t.a, empty_u.x FROM t LEFT JOIN empty_u "
+          "ON t.a = empty_u.x",
+          matchScan("t").project({"a", "null"}).build(),
+      },
+      {
+          "rightEmptyLeft",
+          "SELECT empty_u.x, t.a FROM empty_u RIGHT JOIN t "
+          "ON empty_u.x = t.a",
+          matchScan("t").project({"null", "a"}).build(),
+      },
+      {
+          "fullEmptyRight",
+          "SELECT t.a, empty_u.x FROM t FULL JOIN empty_u "
+          "ON t.a = empty_u.x",
+          matchScan("t").project({"a", "null"}).build(),
+      },
+      {
+          "leftEmptyPreservedSide",
+          "SELECT empty_u.x, t.a FROM empty_u LEFT JOIN t "
+          "ON empty_u.x = t.a",
+          matchValues().build(),
+      },
+      {
+          "rightEmptyPreservedSide",
+          "SELECT t.a, empty_u.x FROM t RIGHT JOIN empty_u "
+          "ON t.a = empty_u.x",
+          matchValues().build(),
+      },
+      {
+          "fullBothEmpty",
+          "SELECT e1.x, e2.x FROM empty_u e1 FULL JOIN empty_u e2 "
+          "ON e1.x = e2.x",
+          matchValues()
+              .aliases({"e1_x", "e2_x"})
+              .project({"e1_x", "e2_x"})
+              .build(),
+      },
+      {
+          "semiEmptyFilteringSide",
+          "SELECT a FROM t WHERE EXISTS "
+          "(SELECT 1 FROM empty_u WHERE empty_u.x = t.a)",
+          matchValues().build(),
+      },
+      {
+          "antiEmptyFilteringSide",
+          "SELECT a FROM t WHERE NOT EXISTS "
+          "(SELECT 1 FROM empty_u WHERE empty_u.x = t.a)",
+          matchScan("t").build(),
+      },
+      {
+          "countingLeftSemiFilter",
+          "SELECT a FROM t INTERSECT ALL SELECT x FROM empty_u",
+          matchValues().build(),
+      },
+      {
+          "leftSemiProject",
+          "SELECT a IN (SELECT x FROM empty_u) FROM t",
+          matchScan("t").project({"false"}).build(),
+      },
+      {
+          "countingAnti",
+          "SELECT a FROM t EXCEPT ALL SELECT x FROM empty_u",
+          matchScan("t").build(),
+      },
+  };
+
+  for (const auto& testCase : sqlTestCases) {
+    SCOPED_TRACE(testCase.name);
+    SCOPED_TRACE(testCase.query);
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(testCase.query, kTestConnectorId)),
+        testCase.matcher);
+  }
+
+  // These join forms are optimizer IR variants that are not produced by the
+  // SQL queries above, so build them directly.
+  struct IrTestCase {
+    const char* name;
+    core::JoinType joinType;
+    bool hasMarkColumn;
+  };
+
+  const std::vector<IrTestCase> irTestCases{
+      {
+          "rightSemiFilter",
+          core::JoinType::kRightSemiFilter,
+          false,
+      },
+      {
+          "rightSemiProject",
+          core::JoinType::kRightSemiProject,
+          true,
+      },
+  };
+
+  initializeV2Context();
+
+  auto makeNonEmptyValues = [&](ColumnCP column) {
+    std::vector<Variant> values{static_cast<int64_t>(1)};
+    std::vector<Variant> rows;
+    rows.push_back(Variant::row(std::move(values)));
+    return builder_->makeValues(
+        /*source=*/nullptr,
+        registerVariant(Variant::array(std::move(rows))),
+        {column});
+  };
+
+  for (const auto& testCase : irTestCases) {
+    SCOPED_TRACE(testCase.name);
+    ColumnCP leftColumn =
+        Column::create("left", Value(queryCtx()->toType(BIGINT())));
+    ColumnCP rightColumn =
+        Column::create("r", Value(queryCtx()->toType(BIGINT())));
+    ColumnVector outputColumns{rightColumn};
+    if (testCase.hasMarkColumn) {
+      outputColumns.push_back(
+          Column::create("mark", Value(queryCtx()->toType(BOOLEAN()))));
+    }
+
+    NodeCP left = builder_->makeEmptyValues({leftColumn});
+    NodeCP right = makeNonEmptyValues(rightColumn);
+
+    const auto plan = emitFoldedPlan(
+        builder_->make<Join>(
+            {left,
+             right,
+             testCase.joinType,
+             ExprVector{},
+             ExprVector{},
+             ExprVector{},
+             /*nullAware=*/false,
+             /*nullAsValue=*/false,
+             outputColumns}),
+        outputColumns);
+    const auto matcher = testCase.hasMarkColumn
+        ? matchValues().project({rightColumn->outputName(), "false"}).build()
+        : matchValues().build();
+    EXPECT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+  }
+}
+
+TEST_F(EmptyFoldTest, aggregationsOverEmpty) {
+  testConnector_->addTable("empty_t", ROW({"a"}, BIGINT()))
+      ->setKnownEmpty(true);
+
+  const std::vector<TestCase> testCases{
+      {
+          "globalCount",
+          "SELECT count(*) FROM empty_t",
+          core::PlanMatcherBuilder{}
+              .values()
+              .singleAggregation({}, {"count(*)"})
+              .build(),
+      },
+      {
+          "globalSum",
+          "SELECT sum(a) FROM empty_t",
+          core::PlanMatcherBuilder{}
+              .values()
+              .singleAggregation({}, {"sum(a)"})
+              .build(),
+      },
+      {
+          "globalExpressionSum",
+          "SELECT sum(a + 1) FROM empty_t",
+          core::PlanMatcherBuilder{}
+              .values()
+              .aliases({"a"})
+              .project({"a + 1 as p"})
+              .singleAggregation({}, {"sum(p)"})
+              .build(),
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    SCOPED_TRACE(testCase.query);
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(testCase.query, kTestConnectorId)),
+        testCase.matcher);
+  }
+
+  {
+    const auto query = "SELECT a, count(*) FROM empty_t GROUP BY a";
+    SCOPED_TRACE("estimateQueryStats");
+    SCOPED_TRACE(query);
+    auto logicalPlan = parseSelect(query, kTestConnectorId);
+    initializeV2Context();
+    connector::SchemaResolver schemaResolver{
+        connector::ConnectorMetadataRegistry::global()};
+    const auto stats =
+        Optimizer(*logicalPlan, schemaResolver, *session_, *evaluator_)
+            .estimateQueryStats();
+    ASSERT_TRUE(stats.cardinality.has_value());
+    EXPECT_EQ(*stats.cardinality, 0);
+  }
+}
+
+TEST_F(EmptyFoldTest, groupingSetsOverEmpty) {
+  testConnector_->addTable("empty_t", ROW({"a", "b"}, {BIGINT(), BIGINT()}))
+      ->setKnownEmpty(true);
+
+  const std::vector<TestCase> testCases{
+      {
+          "withoutGlobalSet",
+          "SELECT a, b, count(*) FROM empty_t "
+          "GROUP BY GROUPING SETS ((a), (b))",
+          matchValues()
+              .aliases({"a", "b", "gid", "count"})
+              .project({"a", "b", "count"})
+              .build(),
+      },
+      {
+          "withGlobalSet",
+          "SELECT a, count(*) FROM empty_t GROUP BY GROUPING SETS ((a), ())",
+          core::PlanMatcherBuilder{}
+              .values()
+              .singleAggregation()
+              .aliases({"a", "gid", "count"})
+              .project({"a", "count"})
+              .build(),
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    SCOPED_TRACE(testCase.query);
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(testCase.query, kTestConnectorId)),
+        testCase.matcher);
+  }
+}
+
+TEST_F(EmptyFoldTest, unnestOverEmpty) {
+  testConnector_->addTable("empty_t", ROW({"items"}, {ARRAY(BIGINT())}))
+      ->setKnownEmpty(true);
+
+  const auto query =
+      "SELECT item FROM empty_t CROSS JOIN UNNEST(items) AS u(item)";
+  SCOPED_TRACE(query);
+  AXIOM_ASSERT_PLAN(
+      toSingleNodePlan(parseSelect(query, kTestConnectorId)),
+      matchValues().build());
+}
+
+TEST_F(EmptyFoldTest, unionsOverEmpty) {
+  testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), BIGINT()}));
+  testConnector_->addTable("u", ROW({"x"}, BIGINT()));
+  testConnector_
+      ->addTable(
+          "empty_u", ROW({"x", "y", "z"}, {BIGINT(), BIGINT(), BIGINT()}))
+      ->setKnownEmpty(true);
+  testConnector_->addTable("v", ROW({"y"}, BIGINT()));
+
+  const std::vector<TestCase> testCases{
+      {
+          "unionAllEmptySecondInput",
+          "SELECT a FROM t "
+          "UNION ALL "
+          "SELECT x FROM (SELECT * FROM u LIMIT 0) empty_u",
+          matchScan("t").project({"a"}).build(),
+      },
+      {
+          "unionAllEmptyFirstInput",
+          "SELECT a FROM (SELECT * FROM t LIMIT 0) empty_t "
+          "UNION ALL "
+          "SELECT x FROM u",
+          matchScan("u").project({"x"}).build(),
+      },
+      {
+          "unionAllInputsEmpty",
+          "SELECT a FROM (SELECT * FROM t LIMIT 0) empty_t "
+          "UNION ALL "
+          "SELECT x FROM (SELECT * FROM u LIMIT 0) empty_u",
+          matchValues().build(),
+      },
+      {
+          "unionAllRebuildsAfterDroppingEmpty",
+          "SELECT a FROM t "
+          "UNION ALL "
+          "SELECT x FROM empty_u "
+          "UNION ALL "
+          "SELECT y FROM v",
+          matchScan("t")
+              .project({"a"})
+              .localPartition(
+                  {matchScan("v").aliases({"y"}).project({"y"}).build()})
+              .build(),
+      },
+      {
+          "unionAllOneNonEmptyRemains",
+          "SELECT b, a, b FROM t "
+          "UNION ALL "
+          "SELECT x, y, z FROM empty_u",
+          matchScan("t").project({"b", "a", "b"}).build(),
+      },
+      {
+          "unionDistinctOneNonEmptyRemains",
+          "SELECT a FROM (SELECT * FROM t LIMIT 0) empty_t "
+          "UNION "
+          "SELECT x FROM u",
+          matchScan("u").project({"x"}).singleAggregation().build(),
+      },
+  };
+
+  for (const auto& testCase : testCases) {
+    SCOPED_TRACE(testCase.name);
+    SCOPED_TRACE(testCase.query);
+    AXIOM_ASSERT_PLAN(
+        toSingleNodePlan(parseSelect(testCase.query, kTestConnectorId)),
+        testCase.matcher);
+  }
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer::v2::test


### PR DESCRIPTION
Summary:

Presto folds a table scan to an empty result when connector metadata proves no rows match the filter. Axiom optimizer previously kept that scan and fell back to normal cardinality estimation, so it planned and ran work guaranteed to return nothing. For example,

    SELECT * FROM t WHERE ds = '2020-01-01'

where no partition matches now plans as an empty `Values` node instead of a `TableScan`, and empty-preserving work above it folds away.

Connectors report the exact empty-scan fact through the existing `TableLayout::co_estimateStats` API. `FilteredTableStats` now has `guaranteedEmpty`, so the result has three distinct meanings: `nullopt` means no information, `guaranteedEmpty == false` means estimated stats, and `guaranteedEmpty == true` means an exact proof of zero rows. A `numRows == 0` estimate is not treated as proof unless `guaranteedEmpty` is set.

The v2 optimizer records `guaranteedEmpty` on the base table, replaces the scan
with an empty `Values`, and folds the empty input through joins, unions, grouped
aggregation, grouping sets, unnest, and empty-preserving postprocessing. Global
aggregation is preserved, so `SELECT count(*)` over an empty scan still returns
one row. Non-inner joins keep their join semantics.

Differential Revision: D112377407


