### PR TITLE
test: Make executionTimeout robust across hosts and build modes (#1596)

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -169,17 +169,20 @@ TEST_F(SqlQueryRunnerTest, runSingleStatement) {
 }
 
 TEST_F(SqlQueryRunnerTest, executionTimeout) {
-  // A multi-way cross product over the small nation table (25 rows) produces
-  // ~244M rows, far more than can complete within the 10ms deadline, so the
-  // execution timeout fires deterministically during execution and the query
-  // fails with a user error.
-  testConnector_->addTpchTables();
+  // A six-way cross join over 25 rows produces 25^6 = ~244M rows, far more than
+  // can be processed within the 10ms deadline, and the max of the concatenated
+  // values cannot be short-circuited. So the run is still executing when the
+  // deadline elapses and the query fails with a timeout user error.
+  testConnector_->addTable("t", ROW("s", VARCHAR()))
+      ->addData(makeRowVector({makeFlatVector<std::string>(
+          25, [](auto row) { return fmt::format("value_{:04d}", row); })}));
+
   SqlQueryRunner::RunOptions options;
   options.timeoutMicros = 10'000; // 10ms
   VELOX_ASSERT_THROW(
       runner_->run(
-          "SELECT count(*) FROM nation a, nation b, nation c, "
-          "nation d, nation e, nation f",
+          "SELECT max(a.s || b.s || c.s || d.s || e.s || f.s) "
+          "FROM t a, t b, t c, t d, t e, t f",
           options),
       "exceeded maximum time limit");
 }


### PR DESCRIPTION
Summary:

executionTimeout asserts that a query with a 10ms deadline throws. It was flaky across hosts and build modes -- passing on some (e.g. macOS release) and failing on others (e.g. macOS debug) with "Expected an exception".

Root cause: the test called the no-arg `TestConnector::addTpchTables()`, which registers schema only. `TestDataSource::next()` serves rows exclusively from data added via `appendData`/`addData`, so the `nation` tables were empty -- the query processed no rows and the "244M-row cross join" it assumed never existed. Whether the deadline fired at all came down to incidental nested-loop-join setup overhead racing the 10ms window, which varies by host and build mode.

Fix: load real rows so the query does genuine work that far outlasts the deadline everywhere. Register a single-column table, load 25 rows, and cross-join it six ways with a per-row aggregate that cannot be short-circuited (`max` of the concatenated values): the run must materialize the 25^6 = ~244M-row product. `drain()` already enforces the deadline correctly (`folly::coro::timeout` reliably throws once its timer fires), so no runner change is needed.

Reviewed By: mbasmanova

Differential Revision: D112428981


