### PR TITLE
feat(cli): Ctrl+C cancels the query, clears the prompt line (#1597)

### DIFF
--- a/axiom/cli/CMakeLists.txt
+++ b/axiom/cli/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   Connectors.cpp
   Console.cpp
   LiveProgressDisplay.cpp
+  QueryInterruptHandler.cpp
   SqlQueryRunner.cpp
   SystemUser.cpp
   ResultPrinter.cpp

--- a/axiom/cli/Console.cpp
+++ b/axiom/cli/Console.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/cli/Console.h"
 #include <fmt/core.h>
+#include <folly/CancellationToken.h>
 #include <folly/FileUtil.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -25,6 +26,7 @@
 #include <optional>
 #include <set>
 #include "axiom/cli/LiveProgressDisplay.h"
+#include "axiom/cli/QueryInterruptHandler.h"
 #include "axiom/cli/ResultPrinter.h"
 #include "axiom/cli/StdinReader.h"
 #include "axiom/cli/Timing.h"
@@ -147,6 +149,14 @@ void Console::run() {
 
   VELOX_USER_CHECK_GE(FLAGS_repeat, 1, "--repeat must be at least 1");
 
+  // Install session-wide so Ctrl+C cancels the running query instead of the
+  // CLI; see QueryInterruptHandler.
+  QueryInterruptHandler interrupt;
+  interrupt_ = &interrupt;
+  SCOPE_EXIT {
+    interrupt_ = nullptr;
+  };
+
   if (!FLAGS_init.empty()) {
     std::string sql;
     auto success = folly::readFile(FLAGS_init.c_str(), sql);
@@ -225,6 +235,17 @@ bool Console::runOnce(
           [&](const QueryCompletionInfo& info) { completionInfo = info; },
   };
 
+  // Arm cancellation so Ctrl+C cancels the running query; run() honors the
+  // token.
+  if (interrupt_ != nullptr) {
+    options.cancellationToken = interrupt_->arm();
+  }
+  SCOPE_EXIT {
+    if (interrupt_ != nullptr) {
+      interrupt_->disarm();
+    }
+  };
+
   // When enabled by the caller, draw a live status grid on stderr while the
   // query runs.
   std::optional<cli::LiveProgressDisplay> progress;
@@ -262,12 +283,19 @@ bool Console::runOnce(
                 << formatTiming(completionInfo.timing, cpuTiming) << std::endl;
     }
     return true;
+  } catch (const QueryCancelledError&) {
+    // A user cancellation (Ctrl+C) is reported plainly.
+    if (progress) {
+      progress->clear();
+    }
+    std::cerr << "Query cancelled." << std::endl;
+    return false;
   } catch (const std::exception&) {
     if (progress) {
       progress->clear();
     }
-    // run() threw after firing the completion callback, so telemetry was
-    // captured.
+    // run() sets errorInfo before throwing (see SqlQueryRunner), so the deref
+    // is safe; a violation should surface here, not be masked.
     std::cerr << "Query failed: " << completionInfo.errorInfo->message
               << std::endl;
     if (printTiming) {

--- a/axiom/cli/Console.h
+++ b/axiom/cli/Console.h
@@ -24,6 +24,8 @@ DECLARE_bool(debug);
 
 namespace axiom::sql {
 
+class QueryInterruptHandler;
+
 /// Executes SQL through a SqlQueryRunner, driven from command-line flags, an
 /// init/`.run` file, piped stdin, or an interactive REPL, and prints results
 /// and timing to stdout/stderr.
@@ -85,6 +87,11 @@ class Console {
   readCommands(const std::string& prompt, bool printTiming, bool showProgress);
 
   SqlQueryRunner& runner_;
+
+  // Non-owning; points to the session's interrupt handler while run() is
+  // active, else null. runOnce() arms it around each query so Ctrl+C cancels
+  // the query, not the CLI.
+  QueryInterruptHandler* interrupt_{nullptr};
 };
 
 } // namespace axiom::sql

--- a/axiom/cli/QueryInterruptHandler.cpp
+++ b/axiom/cli/QueryInterruptHandler.cpp
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/QueryInterruptHandler.h"
+
+#include <fcntl.h>
+#include <unistd.h>
+#include <cerrno>
+
+#include <folly/ScopeGuard.h>
+
+#include "velox/common/base/Exceptions.h"
+
+namespace axiom::sql {
+namespace {
+
+// Write end of the SIGINT self-pipe; -1 when no handler is installed.
+// File-scope atomic because a signal handler cannot capture state.
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+std::atomic<int> gInterruptPipeWriteFd{-1};
+
+// Monotonic count of SIGINTs observed. arm() snapshots it when a query arms;
+// the drain thread cancels only if the count advanced past that snapshot,
+// so a SIGINT buffered before the query armed (init script, --repeat) can't
+// cancel it. Lock-free atomic: the signal handler mutates it.
+// NOLINTNEXTLINE(facebook-avoid-non-const-global-variables)
+std::atomic<uint64_t> gInterruptSignalSeq{0};
+static_assert(
+    std::atomic<uint64_t>::is_always_lock_free,
+    "SIGINT sequence counter must be lock-free to be async-signal-safe");
+
+// SIGINT handler: async-signal-safe. Bumps the signal count and nudges the
+// self-pipe. A full pipe (EAGAIN) is fine -- one pending byte wakes the reader.
+void interruptSignalHandler(int /*sig*/) {
+  const int fd = gInterruptPipeWriteFd.load(std::memory_order_relaxed);
+  if (fd >= 0) {
+    // Bump before the wakeup so the drain thread, which loads the count after
+    // reading the byte, observes this signal.
+    gInterruptSignalSeq.fetch_add(1, std::memory_order_seq_cst);
+    // Save/restore errno: SIGINT may be delivered to any thread (including a
+    // Velox executor thread mid-syscall), and write() can clobber errno.
+    const int savedErrno = errno;
+    const char byte{1};
+    const ssize_t ignored = write(fd, &byte, 1);
+    (void)ignored;
+    errno = savedErrno;
+  }
+}
+} // namespace
+
+QueryInterruptHandler::QueryInterruptHandler() {
+  // Enforce the single-live-handler invariant (see class doc).
+  VELOX_CHECK_EQ(
+      gInterruptPipeWriteFd.load(),
+      -1,
+      "A QueryInterruptHandler is already installed");
+  VELOX_CHECK_EQ(pipe(pipeFds_), 0, "Failed to create interrupt pipe");
+  // No destructor runs on a partially constructed object, so undo the pipe and
+  // handler here if a later step throws.
+  bool sigactionInstalled{false};
+  SCOPE_FAIL {
+    if (sigactionInstalled) {
+      sigaction(SIGINT, &savedAction_, nullptr);
+    }
+    close(pipeFds_[0]);
+    close(pipeFds_[1]);
+  };
+  // Non-blocking write end so the handler never blocks; OR into existing flags.
+  const int flags = fcntl(pipeFds_[1], F_GETFL, 0);
+  VELOX_CHECK_GE(flags, 0, "Failed to read interrupt pipe flags");
+  VELOX_CHECK_EQ(
+      fcntl(pipeFds_[1], F_SETFL, flags | O_NONBLOCK),
+      0,
+      "Failed to set interrupt pipe non-blocking");
+
+  struct sigaction action{};
+  action.sa_handler = interruptSignalHandler;
+  sigemptyset(&action.sa_mask);
+  // Restart syscalls interrupted on other threads (e.g. executor I/O) instead
+  // of failing them with EINTR.
+  action.sa_flags = SA_RESTART;
+  VELOX_CHECK_EQ(
+      sigaction(SIGINT, &action, &savedAction_),
+      0,
+      "Failed to install SIGINT handler");
+  sigactionInstalled = true;
+
+  // All fallible steps done. Start the drain thread, then publish the write fd
+  // last (noexcept) so no failure path leaves it pointing at a closed pipe.
+  thread_ = std::thread([this] { drainPipe(); });
+  gInterruptPipeWriteFd.store(pipeFds_[1]);
+}
+
+QueryInterruptHandler::~QueryInterruptHandler() {
+  // Ignore SIGINT during teardown so no new handler runs while we clear the fd
+  // and close the pipe; a late Ctrl+C is dropped rather than nudging a closing
+  // pipe or taking the default terminate action.
+  //
+  // Accepted race: SIG_IGN does not stop a handler already running on another
+  // thread. It may write() to the write-fd after we close it below -- a
+  // harmless EBADF, or a stray byte if that fd number was reused by then. The
+  // handler can't be interrupted from here, so this narrow window is accepted.
+  struct sigaction ignore{};
+  ignore.sa_handler = SIG_IGN;
+  sigemptyset(&ignore.sa_mask);
+  sigaction(SIGINT, &ignore, nullptr);
+
+  gInterruptPipeWriteFd.store(-1);
+  stop_.store(true);
+  // Close the write end so the drain thread's blocked read() returns EOF and
+  // its loop exits, so join() cannot hang. (A wakeup byte could be dropped if
+  // the non-blocking pipe were full; EOF is the guarantee.)
+  close(pipeFds_[1]);
+  thread_.join();
+  close(pipeFds_[0]);
+
+  // Restore the previous SIGINT disposition now that the pipe is gone.
+  sigaction(SIGINT, &savedAction_, nullptr);
+}
+
+folly::CancellationToken QueryInterruptHandler::arm() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  // Snapshot the count so only SIGINTs after this cancel the new source (see
+  // gInterruptSignalSeq). A fresh source each time so a prior cancellation
+  // cannot carry over.
+  armSignalSeq_ = gInterruptSignalSeq.load(std::memory_order_seq_cst);
+  source_.emplace();
+  return source_->getToken();
+}
+
+void QueryInterruptHandler::disarm() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  source_.reset();
+}
+
+void QueryInterruptHandler::drainPipe() {
+  char buffer[64];
+  for (;;) {
+    const ssize_t bytes = read(pipeFds_[0], buffer, sizeof(buffer));
+    if (bytes <= 0) {
+      if (bytes < 0 && errno == EINTR) {
+        continue;
+      }
+      break;
+    }
+    if (stop_.load()) {
+      break;
+    }
+    // Snapshot the count once: it drives the cancel decision and is published
+    // as the processed-sequence fence, so both must agree on the same value.
+    const uint64_t observedSeq =
+        gInterruptSignalSeq.load(std::memory_order_seq_cst);
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (source_.has_value() && observedSeq > armSignalSeq_) {
+        source_->requestCancellation();
+      }
+      lastProcessedSignalSeq_ = observedSeq;
+    }
+    processedCv_.notify_all();
+  }
+}
+
+uint64_t QueryInterruptHandler::testingSignalSeq() const {
+  return gInterruptSignalSeq.load(std::memory_order_seq_cst);
+}
+
+bool QueryInterruptHandler::testingWaitForProcessedSignalSeq(
+    uint64_t targetSeq,
+    std::chrono::milliseconds timeout) {
+  std::unique_lock<std::mutex> lock(mutex_);
+  return processedCv_.wait_for(
+      lock, timeout, [&] { return lastProcessedSignalSeq_ >= targetSeq; });
+}
+
+} // namespace axiom::sql

--- a/axiom/cli/QueryInterruptHandler.h
+++ b/axiom/cli/QueryInterruptHandler.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <signal.h>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+#include <folly/CancellationToken.h>
+
+namespace axiom::sql {
+
+/// Cancels the in-flight query on SIGINT while keeping the CLI alive: while a
+/// query runs, Ctrl+C trips the armed cancellation token instead of terminating
+/// the process.
+///
+/// Install one for the session, then arm() around each query and pass the
+/// returned token to the runner via RunOptions::cancellationToken:
+/// @code
+///   QueryInterruptHandler interrupt;
+///   options.cancellationToken = interrupt.arm();
+///   SCOPE_EXIT { interrupt.disarm(); };
+///   runner.run(sql, options); // Ctrl+C trips the token, cancelling the query
+/// @endcode
+///
+/// A signal handler (not sigwait) is used so the process-wide disposition
+/// covers every thread: SIGINT delivered to a Velox executor thread runs the
+/// handler rather than terminating, so no thread needs SIGINT blocked.
+/// requestCancellation() is not async-signal-safe, so the handler only nudges a
+/// self-pipe and a drain thread does the cancellation.
+///
+/// Invariants:
+/// - Only one handler may be live at a time (the constructor VELOX_CHECKs this;
+///   the signal handler reads a single file-scope pipe fd).
+/// - Not copyable or movable.
+/// - The constructor installs the SIGINT handler; the destructor restores the
+///   previous disposition.
+class QueryInterruptHandler {
+ public:
+  QueryInterruptHandler();
+  ~QueryInterruptHandler();
+
+  QueryInterruptHandler(const QueryInterruptHandler&) = delete;
+  QueryInterruptHandler& operator=(const QueryInterruptHandler&) = delete;
+  QueryInterruptHandler(QueryInterruptHandler&&) = delete;
+  QueryInterruptHandler& operator=(QueryInterruptHandler&&) = delete;
+
+  /// Arms cancellation for the next query: creates a fresh cancellation source
+  /// and returns its token to pass to the runner via
+  /// RunOptions::cancellationToken. A SIGINT delivered after this trips it.
+  folly::CancellationToken arm();
+
+  /// Disarms cancellation between queries, so a stray SIGINT is absorbed rather
+  /// than cancelling the next query.
+  void disarm();
+
+  /// Count of SIGINTs observed so far. Read after raise() to learn the target
+  /// sequence, then fence on it with testingWaitForProcessedSignalSeq().
+  /// Testing only.
+  uint64_t testingSignalSeq() const;
+
+  /// Blocks until the drain thread has processed every SIGINT up to and
+  /// including 'targetSeq' (decided whether to cancel), or 'timeout' elapses;
+  /// returns true if the fence was reached. Lets a test prove a signal did not
+  /// cancel a source without a fixed sleep. Testing only.
+  bool testingWaitForProcessedSignalSeq(
+      uint64_t targetSeq,
+      std::chrono::milliseconds timeout);
+
+ private:
+  // Reads the self-pipe on a background thread; on a wakeup, trips 'source_'.
+  void drainPipe();
+
+  int pipeFds_[2]{-1, -1};
+  struct sigaction savedAction_{};
+  std::mutex mutex_;
+  // Owned; arm() re-creates it (so a prior cancellation never carries over) and
+  // disarm() clears it. Set only while a query is armed. Guarded by mutex_.
+  std::optional<folly::CancellationSource> source_;
+  // SIGINT count observed when the current source armed; a signal cancels the
+  // source only if the count has advanced past this. Guarded by mutex_.
+  uint64_t armSignalSeq_{0};
+  // Highest SIGINT sequence number the drain thread has finished acting on.
+  // Advances after each cancel/absorb decision so a test can fence on a
+  // specific signal. Guarded by mutex_.
+  uint64_t lastProcessedSignalSeq_{0};
+  // Notified when lastProcessedSignalSeq_ advances.
+  std::condition_variable processedCv_;
+  std::atomic_bool stop_{false};
+  std::thread thread_;
+};
+
+} // namespace axiom::sql

--- a/axiom/cli/README.md
+++ b/axiom/cli/README.md
@@ -272,6 +272,27 @@ root stage that produces the final result first), with a single-letter state
 (`P`lanned, `R`unning, `F`inished) and per-stage row/byte counts, rates, and
 split tallies.
 
+## Cancelling Queries
+
+Press **Ctrl+C** while a query is running to cancel it. The query stops and the
+CLI prints to stderr:
+
+```
+Query cancelled.
+```
+
+Cancellation works on every execution path — `--init`, `--query`, piped stdin,
+`--repeat`, and the interactive REPL. In the REPL the prompt returns and the
+session stays alive; on the non-interactive paths the cancelled statement ends
+the run, so any remaining statements or `--repeat` iterations are skipped.
+
+At the prompt, with no query running:
+
+| Key | Behavior |
+|-----|----------|
+| **Ctrl+C** | Discard the partially typed command — including a half-entered multi-line statement — and redraw a fresh prompt. Does not exit. |
+| **Ctrl+D** | End input and exit the CLI (like `.exit`). |
+
 ## Exit Status
 
 | Condition | Exit code |

--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -565,20 +565,24 @@ std::string messageTemplateOf(const std::exception& e) {
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
     std::string_view sql,
     const RunOptions& options) {
+  // Compose the caller's cancellation token onto the drain so tripping it stops
+  // the query (surfacing QueryCancelledError). A default token never cancels.
   return folly::coro::blockingWait(
-      folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
-        SqlResult result;
-        auto generator = co_run(std::string(sql), options);
-        while (auto chunk = co_await generator.next()) {
-          if (chunk->message.has_value()) {
-            result.message = std::move(chunk->message);
-          }
-          if (chunk->batch != nullptr) {
-            result.results.push_back(std::move(chunk->batch));
-          }
-        }
-        co_return result;
-      }));
+      folly::coro::co_withCancellation(
+          options.cancellationToken,
+          folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
+            SqlResult result;
+            auto generator = co_run(std::string(sql), options);
+            while (auto chunk = co_await generator.next()) {
+              if (chunk->message.has_value()) {
+                result.message = std::move(chunk->message);
+              }
+              if (chunk->batch != nullptr) {
+                result.results.push_back(std::move(chunk->batch));
+              }
+            }
+            co_return result;
+          })));
 }
 
 folly::coro::AsyncGenerator<SqlQueryRunner::SqlResultChunk>

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -272,6 +272,12 @@ class SqlQueryRunner {
     /// telemetry only: timing, query ID, error info, row counts. Results
     /// are returned from run(), not passed through callbacks.
     QueryCompletionCallback onComplete;
+
+    /// Cancels the query's execution when tripped. run() composes it onto the
+    /// result drain; a cancelled query throws QueryCancelledError. Defaults to
+    /// a never-cancelled token. (For the co_run() generator, compose the token
+    /// with folly::coro::co_withCancellation instead.)
+    folly::CancellationToken cancellationToken;
   };
 
   /// One increment of a streamed query result, yielded by co_run(). Exactly one

--- a/axiom/cli/StdinReader.cpp
+++ b/axiom/cli/StdinReader.cpp
@@ -17,6 +17,7 @@
 #include "axiom/cli/StdinReader.h"
 #include <fmt/format.h>
 #include <algorithm>
+#include <cerrno>
 #include <sstream>
 #include "axiom/cli/linenoise/linenoise.h"
 #include "folly/ScopeGuard.h"
@@ -80,11 +81,25 @@ std::string readCommand(const std::string& prompt, bool& atEnd) {
   bool stripLeadingSpaces = true;
   bool inBlockComment = false;
 
-  while (char* rawLine = linenoise(prompt.c_str())) {
-    SCOPE_EXIT {
-      if (rawLine != nullptr) {
-        free(rawLine);
+  for (;;) {
+    errno = 0;
+    char* rawLine = linenoise(prompt.c_str());
+    if (rawLine == nullptr) {
+      // linenoise runs the terminal in raw mode with ISIG cleared, so Ctrl+C is
+      // not a signal here -- it returns nullptr with errno == EAGAIN (Ctrl+D
+      // and EOF set ENOENT). Map Ctrl+C to "discard the partial command and
+      // re-prompt" (like readline/psql); Ctrl+D and EOF end input.
+      if (errno == EAGAIN) {
+        command.str("");
+        command.clear();
+        stripLeadingSpaces = true;
+        inBlockComment = false;
+        continue;
       }
+      break;
+    }
+    SCOPE_EXIT {
+      free(rawLine);
     };
 
     std::string line(rawLine);

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(
   ConsoleTest.cpp
   LiveProgressDisplayTest.cpp
   QueryIdGeneratorTest.cpp
+  QueryInterruptHandlerTest.cpp
 )
 
 add_test(NAME axiom_cli_test COMMAND axiom_cli_test)

--- a/axiom/cli/tests/ConsoleTest.cpp
+++ b/axiom/cli/tests/ConsoleTest.cpp
@@ -15,10 +15,20 @@
  */
 
 #include "axiom/cli/Console.h"
+#include <folly/CancellationToken.h>
+#include <folly/ScopeGuard.h>
+#include <folly/coro/AsyncGenerator.h>
+#include <folly/coro/CurrentExecutor.h>
+#include <folly/synchronization/Baton.h>
 #include <gtest/gtest.h>
+#include <signal.h>
+#include <atomic>
+#include <chrono>
+#include <thread>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "velox/connectors/ConnectorRegistry.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
 
 DECLARE_string(query);
 
@@ -27,7 +37,53 @@ using namespace facebook::velox;
 namespace axiom::sql {
 namespace {
 
-class ConsoleTest : public ::testing::Test {
+// A SqlQueryRunner whose co_run() blocks until cancellation, then reports it
+// exactly as the real co_run() does. Lets the Console cancellation path be
+// tested deterministically: the test waits for co_run() to be entered (the
+// query's source is armed by runOnce beforehand), delivers one SIGINT, and the
+// fake observes the resulting cancellation -- no query executes and no
+// signal-retry loop is needed.
+class FakeCancelRunner : public SqlQueryRunner {
+ public:
+  using SqlQueryRunner::SqlQueryRunner;
+
+  // Posted once co_run() has been entered and the cancellation source is armed.
+  folly::Baton<>& entered() {
+    return entered_;
+  }
+
+  // Whether the RunOptions handed to co_run() carried a live token, i.e.
+  // Console set RunOptions::cancellationToken and run() forwarded it down.
+  bool sawCancellableToken() const {
+    return sawCancellableToken_.load();
+  }
+
+  folly::coro::AsyncGenerator<SqlResultChunk> co_run(
+      std::string /*sql*/,
+      RunOptions options) override {
+    sawCancellableToken_.store(options.cancellationToken.canBeCancelled());
+    entered_.post();
+    // Observe cancellation the way the real co_run() does: ambiently, through
+    // the token run() composes onto the drain from options.cancellationToken.
+    // Reacting to options.cancellationToken directly would still pass if run()
+    // stopped composing the token, so read the ambient one it actually
+    // installs.
+    const auto token = co_await folly::coro::co_current_cancellation_token;
+    folly::Baton<> cancelled;
+    folly::CancellationCallback callback(token, [&] { cancelled.post(); });
+    // Bounded so a cancellation regression fails the test instead of hanging.
+    if (!cancelled.try_wait_for(std::chrono::seconds(30))) {
+      co_return;
+    }
+    throw QueryCancelledError{};
+  }
+
+ private:
+  folly::Baton<> entered_;
+  std::atomic<bool> sawCancellableToken_{false};
+};
+
+class ConsoleTest : public ::testing::Test, public test::VectorTestBase {
  protected:
   static void SetUpTestCase() {
     facebook::velox::memory::MemoryManager::testingSetInstance(
@@ -43,9 +99,9 @@ class ConsoleTest : public ::testing::Test {
     }
   }
 
-  std::unique_ptr<SqlQueryRunner> makeRunner(
-      PermissionCheck permissionCheck = {}) {
-    auto runner = std::make_unique<SqlQueryRunner>("test_user");
+  template <typename RunnerT = SqlQueryRunner>
+  std::unique_ptr<RunnerT> makeRunner(PermissionCheck permissionCheck = {}) {
+    auto runner = std::make_unique<RunnerT>("test_user");
 
     runner->initialize(
         [&]() {
@@ -101,6 +157,57 @@ TEST_F(ConsoleTest, permissionCheckCalledBeforeExecution) {
   ASSERT_TRUE(called);
   EXPECT_EQ(capturedSql, "SELECT 1");
   EXPECT_FALSE(capturedCatalog.empty());
+}
+
+// SIGINT during a running query cancels that query and leaves the CLI alive:
+// run() installs the interrupt handler for the session, runOnce registers the
+// query's cancellation source, and Console reports the cancellation rather than
+// terminating. FakeCancelRunner holds run() open until the source is tripped,
+// so the signal is delivered at a deterministic point (no retry loop).
+TEST_F(ConsoleTest, sigintCancelsRunningQuery) {
+  auto runner = makeRunner<FakeCancelRunner>();
+  ASSERT_TRUE(runner);
+
+  Console console{*runner};
+  console.initialize();
+  FLAGS_query = "SELECT 1";
+
+  // Ignore SIGINT outside run()'s handler window (before it installs, after it
+  // restores) so a signal landing there is harmless rather than terminating the
+  // test process.
+  struct sigaction ignore{};
+  ignore.sa_handler = SIG_IGN;
+  sigemptyset(&ignore.sa_mask);
+  ASSERT_EQ(sigaction(SIGINT, &ignore, nullptr), 0);
+
+  testing::internal::CaptureStderr();
+  std::thread queryThread([&] { console.run(); });
+  // Join on any early exit (e.g. an ASSERT failure below) so the thread is
+  // never destroyed while joinable -- that would std::terminate the test
+  // process.
+  SCOPE_EXIT {
+    if (queryThread.joinable()) {
+      queryThread.join();
+    }
+  };
+
+  // Wait until run() is executing with the query's cancellation source armed,
+  // then deliver exactly one SIGINT. The handler trips the armed source and the
+  // fake runner observes the cancellation, so run() returns on its own.
+  ASSERT_TRUE(runner->entered().try_wait_for(std::chrono::seconds(30)));
+  raise(SIGINT);
+  queryThread.join();
+
+  // run() carried Console's per-query token through RunOptions into co_run.
+  EXPECT_TRUE(runner->sawCancellableToken());
+
+  const std::string captured = testing::internal::GetCapturedStderr();
+  EXPECT_NE(captured.find("Query cancelled."), std::string::npos);
+
+  struct sigaction dfl{};
+  dfl.sa_handler = SIG_DFL;
+  sigemptyset(&dfl.sa_mask);
+  sigaction(SIGINT, &dfl, nullptr);
 }
 
 } // namespace

--- a/axiom/cli/tests/QueryInterruptHandlerTest.cpp
+++ b/axiom/cli/tests/QueryInterruptHandlerTest.cpp
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/QueryInterruptHandler.h"
+
+#include <signal.h>
+#include <chrono>
+
+#include <folly/CancellationToken.h>
+#include <folly/synchronization/Baton.h>
+#include <gtest/gtest.h>
+
+namespace axiom::sql {
+namespace {
+
+// Blocks until 'token' is cancelled or 'timeout' elapses; returns whether it
+// was cancelled. Event-driven: the CancellationCallback posts the baton the
+// moment cancellation is requested, and fires inline if 'token' is already
+// cancelled, so there is no poll and no fixed sleep.
+bool waitForCancellation(
+    const folly::CancellationToken& token,
+    std::chrono::milliseconds timeout) {
+  folly::Baton<> baton;
+  folly::CancellationCallback callback(token, [&] { baton.post(); });
+  return baton.try_wait_for(timeout);
+}
+
+// A SIGINT delivered while armed trips the armed token. raise() runs the
+// handler on this thread; the drain thread then requests cancellation, so the
+// cancellation lands shortly after (bounded wait, not a race).
+TEST(QueryInterruptHandlerTest, sigintCancelsArmedToken) {
+  QueryInterruptHandler handler;
+  const auto token = handler.arm();
+
+  raise(SIGINT);
+
+  EXPECT_TRUE(waitForCancellation(token, std::chrono::seconds(5)));
+}
+
+// With cancellation disarmed, SIGINT is absorbed: nothing is cancelled and the
+// process is not terminated.
+TEST(QueryInterruptHandlerTest, disarmedSigintIsAbsorbed) {
+  QueryInterruptHandler handler;
+  const auto token = handler.arm();
+  handler.disarm();
+
+  raise(SIGINT);
+
+  // Fence on the drain thread finishing with this exact signal, then confirm it
+  // absorbed it rather than cancelling -- deterministic, no fixed sleep.
+  const uint64_t seq = handler.testingSignalSeq();
+  ASSERT_TRUE(
+      handler.testingWaitForProcessedSignalSeq(seq, std::chrono::seconds(5)));
+  EXPECT_FALSE(token.isCancellationRequested());
+}
+
+// A SIGINT delivered before arming must not cancel the next query: only a
+// signal counted after arm() cancels its token. Guards against a stray Ctrl+C
+// between statements (init script, --repeat) cancelling the next query.
+TEST(QueryInterruptHandlerTest, staleSigintDoesNotCancelNextQuery) {
+  QueryInterruptHandler handler;
+
+  // SIGINT arrives before arming. raise() runs the handler synchronously on
+  // this thread, so the signal is counted before arm().
+  raise(SIGINT);
+
+  const auto token = handler.arm();
+
+  // The pre-arm signal must not cancel this token. Fence on the drain thread
+  // finishing with it, then assert it was not applied -- deterministic.
+  const uint64_t staleSeq = handler.testingSignalSeq();
+  ASSERT_TRUE(handler.testingWaitForProcessedSignalSeq(
+      staleSeq, std::chrono::seconds(5)));
+  EXPECT_FALSE(token.isCancellationRequested());
+
+  // A signal delivered after arming does cancel it.
+  raise(SIGINT);
+  EXPECT_TRUE(waitForCancellation(token, std::chrono::seconds(5)));
+}
+
+// The handler restores the previous SIGINT disposition when it is destroyed.
+TEST(QueryInterruptHandlerTest, restoresPreviousDispositionOnDestruction) {
+  struct sigaction ignore{};
+  ignore.sa_handler = SIG_IGN;
+  sigemptyset(&ignore.sa_mask);
+  ASSERT_EQ(sigaction(SIGINT, &ignore, nullptr), 0);
+
+  {
+    QueryInterruptHandler handler;
+    // While installed, the disposition is the handler's, not the prior SIG_IGN.
+    struct sigaction current{};
+    ASSERT_EQ(sigaction(SIGINT, nullptr, &current), 0);
+    EXPECT_NE(current.sa_handler, SIG_IGN);
+  }
+
+  // After destruction the prior disposition (SIG_IGN) is back.
+  struct sigaction restored{};
+  ASSERT_EQ(sigaction(SIGINT, nullptr, &restored), 0);
+  EXPECT_EQ(restored.sa_handler, SIG_IGN);
+
+  // Leave SIGINT at the default so a stray signal cannot wedge later tests.
+  struct sigaction dfl{};
+  dfl.sa_handler = SIG_DFL;
+  sigemptyset(&dfl.sa_mask);
+  sigaction(SIGINT, &dfl, nullptr);
+}
+
+// A second live handler is rejected: the singleton self-pipe fd would otherwise
+// be redirected.
+TEST(QueryInterruptHandlerTest, rejectsSecondConcurrentHandler) {
+  QueryInterruptHandler handler;
+  EXPECT_ANY_THROW({ QueryInterruptHandler second; });
+}
+
+} // namespace
+} // namespace axiom::sql

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -156,6 +156,30 @@ TEST_F(SqlQueryRunnerTest, externalCancellation) {
   EXPECT_FALSE(completion->errorInfo.has_value());
 }
 
+TEST_F(SqlQueryRunnerTest, runHonorsCancellationToken) {
+  // run() composes RunOptions::cancellationToken onto its co_run() drain: a
+  // token tripped before the call surfaces as QueryCancelledError. This is the
+  // synchronous cancellation path -- run(), not the co_run() generator.
+  testConnector_->addTable("t", ROW("c", BIGINT()));
+
+  folly::CancellationSource source;
+  source.requestCancellation();
+
+  std::optional<QueryCompletionInfo> completion;
+  SqlQueryRunner::RunOptions options;
+  options.cancellationToken = source.getToken();
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    completion = info;
+  };
+
+  EXPECT_THROW(
+      runner_->run("SELECT count(*) FROM t", options), QueryCancelledError);
+
+  ASSERT_TRUE(completion.has_value());
+  EXPECT_TRUE(completion->cancelled);
+  EXPECT_FALSE(completion->errorInfo.has_value());
+}
+
 TEST_F(SqlQueryRunnerTest, coRunYieldsChunks) {
   // co_run() is a generator: a SELECT yields batch chunks (no message); a
   // statement that returns a status line yields a single message chunk.


### PR DESCRIPTION
Summary:

Makes Ctrl+C cancel an in-flight query while keeping the CLI alive, and clears the partially typed line at the prompt. Ctrl+D exits.

Two paths, matching how the terminal delivers Ctrl+C:
- At the prompt, linenoise runs the terminal in raw mode with ISIG cleared, so Ctrl+C is a byte (0x03), not a signal: linenoise returns nullptr with errno EAGAIN. `readCommand` branches on errno -- EAGAIN discards the partial (possibly multi-line) command and re-prompts; ENOENT/EOF (Ctrl+D) ends input.
- During execution the terminal is in cooked mode, so Ctrl+C arrives as SIGINT. A `QueryInterruptHandler` (its own header), installed by `run()` for the whole session, catches SIGINT, nudges a self-pipe (async-signal-safe), and a drain thread trips the running query's `folly::CancellationSource`. A signal handler rather than `sigwait` is used so the process-wide disposition also covers the runner's executor threads.

Cancellation is encapsulated in the runner: `RunOptions` gains a `cancellationToken` that `run()` composes onto its `co_run()` drain, so tripping the token stops the query and surfaces `QueryCancelledError`. `Console` sets that token from the interrupt source and calls `run()` -- no drain reimplemented at the call site -- and reports `QueryCancelledError` plainly as "Query cancelled." rather than as a failure.

Reviewed By: mbasmanova

Differential Revision: D112430321


