### PR TITLE
test(coercion): Cover array constructor over IPPREFIX (#1600)

### DIFF
--- a/axiom/optimizer/tests/sql/coercion.sql
+++ b/axiom/optimizer/tests/sql/coercion.sql
@@ -17,3 +17,8 @@ SELECT CAST(c AS DECIMAL(4,1)) = CAST(b AS DOUBLE) FROM t
 SELECT CAST(c AS DECIMAL(4,1)) / CAST(b AS DOUBLE) FROM t
 ----
 SELECT SIN(CAST(c AS DECIMAL(4,1))) FROM t
+----
+-- duckdb: SELECT 2
+SELECT cardinality(
+    CAST(ARRAY[CAST('2803:6082:f836::/48' AS ipprefix), CAST('2803:6082:f837::/48' AS ipprefix)]
+            AS array(varchar)))


### PR DESCRIPTION
Summary:

Add a regression test for an array constructor over two IPPREFIX values. Resolving this expression computes the least common super type of two identical custom types, which previously failed.

Reviewed By: natashasehgal, amitkdutta

Differential Revision: D112479483
