### PR TITLE
fix(optimizer): Fix v2 plan gaps and cardinality overflow (#1601)

### DIFF
--- a/axiom/optimizer/EstimateMath.h
+++ b/axiom/optimizer/EstimateMath.h
@@ -17,20 +17,40 @@
 #pragma once
 
 #include <algorithm>
+#include <limits>
 #include <optional>
 
 /// Arithmetic over optional statistical estimates (cardinality, fanout, ...).
 /// Unknown (nullopt) propagates: if any operand is unknown, the result is
 /// unknown. This keeps callers from silently treating a missing estimate as a
 /// concrete value. Use these instead of unwrapping at estimate-combining sites.
+///
+/// Results saturate to the finite float range: a chain of estimate operations
+/// (e.g. the cardinality of many cross joins) can exceed what a float holds,
+/// and a non-finite estimate breaks downstream consumers. Saturating keeps a
+/// pathological-but-valid query plannable instead of overflowing to infinity.
 namespace facebook::axiom::optimizer {
+
+/// Clamps a value that overflowed to +/- infinity back to the finite range.
+/// NaN is intentionally not handled: it cannot arise from the finite-operand
+/// arithmetic here, so a NaN estimate signals a bug upstream and must reach the
+/// downstream isfinite() check rather than being masked by a fabricated value.
+inline float saturate(float value) {
+  if (value > std::numeric_limits<float>::max()) {
+    return std::numeric_limits<float>::max();
+  }
+  if (value < std::numeric_limits<float>::lowest()) {
+    return std::numeric_limits<float>::lowest();
+  }
+  return value;
+}
 
 /// Multiplication.
 inline std::optional<float> mul(
     std::optional<float> a,
     std::optional<float> b) {
   if (a.has_value() && b.has_value()) {
-    return *a * *b;
+    return saturate(*a * *b);
   }
   return std::nullopt;
 }
@@ -40,7 +60,7 @@ inline std::optional<float> add(
     std::optional<float> a,
     std::optional<float> b) {
   if (a.has_value() && b.has_value()) {
-    return *a + *b;
+    return saturate(*a + *b);
   }
   return std::nullopt;
 }
@@ -50,7 +70,7 @@ inline std::optional<float> subtract(
     std::optional<float> a,
     std::optional<float> b) {
   if (a.has_value() && b.has_value()) {
-    return *a - *b;
+    return saturate(*a - *b);
   }
   return std::nullopt;
 }
@@ -60,7 +80,7 @@ inline std::optional<float> divide(
     std::optional<float> a,
     std::optional<float> b) {
   if (a.has_value() && b.has_value() && *b != 0) {
-    return *a / *b;
+    return saturate(*a / *b);
   }
   return std::nullopt;
 }

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -259,7 +259,11 @@ void RelationOp::checkInputCardinality() const {
     // Only validate when the cardinality is known; an unknown estimate
     // legitimately propagates as nullopt.
     if (inputCardinality.has_value()) {
-      VELOX_CHECK(std::isfinite(*inputCardinality));
+      VELOX_CHECK(
+          std::isfinite(*inputCardinality),
+          "Input cardinality is not finite; estimate arithmetic should saturate "
+          "to a finite value. Operator: {}",
+          relTypeName());
 
       // TODO Assert that inputCardinality > 0.
       VELOX_CHECK_GE(*inputCardinality, 0);

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -2215,7 +2215,9 @@ lp::ExprPtr ToGraph::processLeftJoinSubqueries(
       std::make_move_iterator(it), std::make_move_iterator(conjuncts.end()));
   conjuncts.erase(it, conjuncts.end());
 
-  VELOX_CHECK(!subqueryConjuncts.empty());
+  VELOX_CHECK(
+      !subqueryConjuncts.empty(),
+      "processLeftJoinSubqueries requires a condition with at least one subquery conjunct");
 
   auto* outerDt = std::exchange(currentDt_, newDt());
   makeQueryGraph(right, kAllAllowedInDt, /*orderObservedAbove=*/false);
@@ -2477,7 +2479,7 @@ void ToGraph::finalizeDt(
   if (!outerDt) {
     outerDt = newDt();
   }
-  VELOX_DCHECK_NOT_NULL(currentDt_);
+  VELOX_DCHECK_NOT_NULL(currentDt_, "finalizeDt has no current DT to finalize");
 
   DerivedTableP dt = currentDt_;
   setDtUsedOutput(dt, node);
@@ -2671,7 +2673,8 @@ void ToGraph::makeBaseTable(const lp::TableScanNode& tableScan) {
   const auto& type = tableScan.outputType();
   const auto& names = tableScan.columnNames();
   for (auto i : channels) {
-    VELOX_DCHECK_LT(i, type->size());
+    VELOX_DCHECK_LT(
+        i, type->size(), "Used channel index out of range for output type");
 
     const auto& name = names[i];
     const auto* columnName = toName(name);
@@ -2727,7 +2730,8 @@ void ToGraph::makePushdownBaseTable(
   const auto channels = usedChannels(root);
   const auto& type = root.outputType();
   for (auto i : channels) {
-    VELOX_DCHECK_LT(i, type->size());
+    VELOX_DCHECK_LT(
+        i, type->size(), "Used channel index out of range for output type");
     const auto* outputName = toName(type->nameOf(i));
     auto* schemaColumn = schemaTable->findColumn(outputName);
     VELOX_CHECK_NOT_NULL(
@@ -2793,7 +2797,8 @@ ValuesTable* ToGraph::makeValuesTable(
   const auto& names = type->names();
   const auto cardinality = valuesTable->cardinality();
   for (auto i : usedChannels(node)) {
-    VELOX_DCHECK_LT(i, type->size());
+    VELOX_DCHECK_LT(
+        i, type->size(), "Used channel index out of range for output type");
 
     const auto& name = names[i];
     const auto* columnName = toName(name);
@@ -3042,7 +3047,9 @@ void ToGraph::appendOuterAggregationCarryForwards(
 
 DerivedTableP ToGraph::translateSubqueryBody(
     const logical_plan::LogicalPlanNode& node) {
-  VELOX_CHECK(applyContext_.lifted.empty());
+  VELOX_CHECK(
+      applyContext_.lifted.empty(),
+      "Lifted correlation state must be cleared before translating a subquery body");
 
   // 'outerDt' is the only ApplyContext field saved here; the lifted
   // accumulators are scoped at the call site via 'saveAndClearLifted'.
@@ -3153,7 +3160,10 @@ ToGraph::CorrelationKeys ToGraph::extractCorrelationKeys(
 
   for (const auto* conjunct : correlatedConjuncts) {
     const auto tables = conjunct->allTables().toObjects();
-    VELOX_CHECK_EQ(2, tables.size());
+    VELOX_CHECK_EQ(
+        2,
+        tables.size(),
+        "Correlated conjunct must reference exactly two tables (outer and subquery)");
 
     ExprCP left = nullptr;
     ExprCP right = nullptr;
@@ -3248,7 +3258,9 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(
     return nullptr;
   }
 
-  VELOX_CHECK(agg->groupingKeys().empty());
+  VELOX_CHECK(
+      agg->groupingKeys().empty(),
+      "Correlated aggregation to decorrelate must be global (no grouping keys)");
 
   // Check if all conjuncts are equalities. If any are non-equi, we'll
   // handle decorrelation at the outer level using AssignUniqueId.
@@ -3265,7 +3277,10 @@ AggregationPlanCP ToGraph::processCorrelatedAggregation(
   ExprVector leftKeys;
   for (const auto* conjunct : liftedPredicates) {
     const auto tables = conjunct->allTables().toObjects();
-    VELOX_CHECK_EQ(2, tables.size());
+    VELOX_CHECK_EQ(
+        2,
+        tables.size(),
+        "Correlated conjunct must reference exactly two tables (outer and subquery)");
 
     ExprCP left = nullptr;
     ExprCP right = nullptr;
@@ -3484,10 +3499,14 @@ DerivedTableP ToGraph::wrapAroundSubquery(DerivedTableP subqueryDt) {
 }
 
 ExprCP ToGraph::processUncorrelatedScalarSubquery(DerivedTableP subqueryDt) {
-  VELOX_CHECK_EQ(1, subqueryDt->columns.size());
+  VELOX_CHECK_EQ(
+      1, subqueryDt->columns.size(), "Scalar subquery must produce one column");
 
   if (auto valuesNode = tryFoldConstantDt(subqueryDt, evaluator_.pool())) {
-    VELOX_CHECK_EQ(1, valuesNode->outputType()->size());
+    VELOX_CHECK_EQ(
+        1,
+        valuesNode->outputType()->size(),
+        "Folded scalar subquery must produce one column");
     if (valuesNode->cardinality() == 1) {
       // Replace subquery with a constant value.
       const auto value =
@@ -3623,9 +3642,14 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
   // 'splitCorrelatedProjection' when the caller is the projection path.
   if (correlation.nonEquiConjuncts.empty() && hasAggregation) {
     VELOX_CHECK_EQ(
-        applyContext_.lifted.predicates.size() + 1, subqueryDt->columns.size());
+        applyContext_.lifted.predicates.size() + 1,
+        subqueryDt->columns.size(),
+        "Decorrelated aggregated subquery must expose one result column plus one per lifted correlation key");
   } else {
-    VELOX_CHECK_GE(subqueryDt->columns.size(), 1);
+    VELOX_CHECK_GE(
+        subqueryDt->columns.size(),
+        1,
+        "Subquery must produce at least one result column");
   }
 
   applyContext_.lifted.predicates.clear();
@@ -3737,7 +3761,9 @@ ExprCP ToGraph::processCorrelatedScalarSubquery(
 
   // The caller wraps currentDt_ before each subsequent heavy-path subquery,
   // so the aggregation slot must be fresh here.
-  VELOX_CHECK_NULL(currentDt_->aggregation);
+  VELOX_CHECK_NULL(
+      currentDt_->aggregation,
+      "Outer aggregation slot must be fresh before adding the correlated subquery's aggregation");
   currentDt_->aggregation = make<AggregationPlan>(
       ExprVector{chain.rowNumberColumn}, allAggregates, allColumns, allColumns);
 
@@ -3786,7 +3812,9 @@ ExprCP ToGraph::buildCorrelatedAggregation(
         }
       });
     }
-    VELOX_CHECK_NOT_NULL(leftTable);
+    VELOX_CHECK_NOT_NULL(
+        leftTable,
+        "Correlated aggregate must reference at least one outer table for AssignUniqueId");
   }
 
   // Rewrite each aggregate's args/orderKeys/condition so inner-column
@@ -3855,7 +3883,9 @@ ExprCP ToGraph::buildCorrelatedAggregation(
   appendOuterAggregationCarryForwards(
       input, chain, outerLifted, rewrittenAggregates, allColumns);
 
-  VELOX_CHECK_NULL(currentDt_->aggregation);
+  VELOX_CHECK_NULL(
+      currentDt_->aggregation,
+      "Outer aggregation slot must be fresh before adding the correlated subquery's aggregation");
   currentDt_->aggregation = make<AggregationPlan>(
       ExprVector{chain.rowNumberColumn},
       rewrittenAggregates,
@@ -3873,7 +3903,10 @@ ExprCP ToGraph::processProjectionCorrelatedScalarSubquery(
   // Scalar subqueries produce exactly one SELECT expression, so
   // 'addDtColumn' pushes at most one residual into 'liftedProjections'
   // for this scope.
-  VELOX_CHECK_EQ(1, applyContext_.lifted.projections.size());
+  VELOX_CHECK_EQ(
+      1,
+      applyContext_.lifted.projections.size(),
+      "Scalar subquery produces exactly one correlated projection");
   auto* column = applyContext_.lifted.projections.front();
   applyContext_.lifted.projections.clear();
 
@@ -3984,11 +4017,17 @@ void ToGraph::processInPredicates(
     // inner-DT column; otherwise the inner DT exposes a single column.
     ExprCP inRightKey;
     if (!applyContext_.lifted.projections.empty()) {
-      VELOX_CHECK_EQ(1, applyContext_.lifted.projections.size());
+      VELOX_CHECK_EQ(
+          1,
+          applyContext_.lifted.projections.size(),
+          "IN subquery's correlated right side must be a single projection");
       inRightKey = applyContext_.lifted.projections.front();
       applyContext_.lifted.projections.clear();
     } else {
-      VELOX_CHECK_EQ(1, subqueryDt->columns.size());
+      VELOX_CHECK_EQ(
+          1,
+          subqueryDt->columns.size(),
+          "IN subquery must expose a single column");
       inRightKey = subqueryDt->columns.front();
     }
 
@@ -4345,7 +4384,10 @@ ExprCP ToGraph::processCorrelatedExists(DerivedTableP subqueryDt) {
   auto decorrelated = extractDecorrelatedJoin(
       functionNames_, applyContext_.lifted.predicates, subqueryDt);
   if (decorrelated.leftKeys.empty()) {
-    VELOX_CHECK_EQ(decorrelated.leftTables.size(), 1);
+    VELOX_CHECK_EQ(
+        decorrelated.leftTables.size(),
+        1,
+        "Correlated subquery with only non-equi correlation must reference exactly one outer table");
   }
   applyContext_.lifted.predicates.clear();
 

--- a/axiom/optimizer/tests/CardinalityEstimationTest.cpp
+++ b/axiom/optimizer/tests/CardinalityEstimationTest.cpp
@@ -1280,6 +1280,20 @@ TEST_F(CardinalityEstimationTest, unnest) {
       });
 }
 
+// A cartesian product of large tables pushes the cardinality estimate past the
+// float range. The estimate must saturate to a finite value so the planner can
+// still produce a plan.
+TEST_F(CardinalityEstimationTest, cardinalityOverflowSaturates) {
+  testConnector_->addTable("t", ROW({"a"}, {BIGINT()}))
+      ->setStats(10'000'000'000'000'000'000ULL, {{"a", {.numDistinct = 100}}});
+
+  verifyPlan("SELECT 1 FROM t t1, t t2, t t3", [](const Plan& plan) {
+    const auto cardinality = plan.op->resultCardinality();
+    ASSERT_TRUE(cardinality.has_value());
+    EXPECT_TRUE(std::isfinite(*cardinality));
+  });
+}
+
 // Verifies that LIMIT reduces output cardinality and adjusts column
 // constraints accordingly.
 TEST_F(CardinalityEstimationTest, limit) {

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -50,14 +50,18 @@ namespace {
 template <typename T = PlanNode>
 class PlanMatcherImpl : public PlanMatcher {
  public:
-  PlanMatcherImpl() = default;
-
-  explicit PlanMatcherImpl(const std::shared_ptr<PlanMatcher>& sourceMatcher)
-      : sourceMatchers_{{sourceMatcher}} {}
+  explicit PlanMatcherImpl(parse::ParseOptions options = {})
+      : PlanMatcher(std::move(options)) {}
 
   explicit PlanMatcherImpl(
-      const std::vector<std::shared_ptr<PlanMatcher>>& sourceMatchers)
-      : sourceMatchers_{sourceMatchers} {}
+      const std::shared_ptr<PlanMatcher>& sourceMatcher,
+      parse::ParseOptions options = {})
+      : PlanMatcher(std::move(options)), sourceMatchers_{{sourceMatcher}} {}
+
+  explicit PlanMatcherImpl(
+      const std::vector<std::shared_ptr<PlanMatcher>>& sourceMatchers,
+      parse::ParseOptions options = {})
+      : PlanMatcher(std::move(options)), sourceMatchers_{sourceMatchers} {}
 
   MatchResult match(
       const PlanNodePtr& plan,
@@ -286,8 +290,7 @@ class HiveScanMatcher : public PlanMatcherImpl<TableScanNode> {
           << "Expected no remaining filter, but got "
           << remainingFilter->toString();
     } else {
-      auto expected =
-          parse::DuckSqlExpressionsParser().parseExpr(remainingFilter_);
+      auto expected = parseExpr(remainingFilter_);
       EXPECT_EQ(remainingFilter->toString(), expected->toString());
     }
 
@@ -337,8 +340,10 @@ class FilterMatcher : public PlanMatcherImpl<FilterNode> {
 
   FilterMatcher(
       const std::shared_ptr<PlanMatcher>& matcher,
-      const std::string& predicate)
-      : PlanMatcherImpl<FilterNode>({matcher}), predicate_{predicate} {}
+      const std::string& predicate,
+      const parse::ParseOptions& options)
+      : PlanMatcherImpl<FilterNode>({matcher}, options),
+        predicate_{predicate} {}
 
   MatchResult matchDetails(
       const FilterNode& plan,
@@ -347,8 +352,7 @@ class FilterMatcher : public PlanMatcherImpl<FilterNode> {
     SCOPED_TRACE(plan.toString(true, false));
 
     if (predicate_.has_value()) {
-      auto expected =
-          parse::DuckSqlExpressionsParser().parseExpr(predicate_.value());
+      auto expected = parseExpr(predicate_.value());
       if (!symbols.empty()) {
         expected = rewriteInputNames(expected, symbols);
       }
@@ -372,8 +376,10 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
 
   ProjectMatcher(
       const std::shared_ptr<PlanMatcher>& matcher,
-      const std::vector<std::string>& expressions)
-      : PlanMatcherImpl<ProjectNode>({matcher}), expressions_{expressions} {}
+      const std::vector<std::string>& expressions,
+      const parse::ParseOptions& options)
+      : PlanMatcherImpl<ProjectNode>({matcher}, options),
+        expressions_{expressions} {}
 
   MatchResult matchDetails(
       const ProjectNode& plan,
@@ -391,8 +397,7 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
     for (auto i = 0; i < plan.projections().size(); ++i) {
       // Verify the expression (if one was given) and capture its alias.
       if (!expressions_.empty()) {
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr(expressions_[i]);
+        auto expected = parseExpr(expressions_[i]);
         if (expected->alias()) {
           newSymbols[expected->alias().value()] = plan.names()[i];
         }
@@ -450,8 +455,7 @@ class ParallelProjectMatcher : public PlanMatcherImpl<ParallelProjectNode> {
       AXIOM_TEST_RETURN_IF_FAILURE
 
       for (auto i = 0; i < expressions_.size(); ++i) {
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr(expressions_[i]);
+        auto expected = parseExpr(expressions_[i]);
         ExprMatcher::match(plan.projections()[i], expected->dropAlias());
         AXIOM_TEST_RETURN_IF_FAILURE
       }
@@ -488,8 +492,7 @@ class UnnestMatcher : public PlanMatcherImpl<UnnestNode> {
       AXIOM_TEST_RETURN_IF_FAILURE
 
       for (auto i = 0; i < replicateExprs_->size(); ++i) {
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr((*replicateExprs_)[i]);
+        auto expected = parseExpr((*replicateExprs_)[i]);
         if (!symbols.empty()) {
           expected = rewriteInputNames(expected, symbols);
         }
@@ -505,8 +508,7 @@ class UnnestMatcher : public PlanMatcherImpl<UnnestNode> {
       AXIOM_TEST_RETURN_IF_FAILURE
 
       for (auto i = 0; i < unnestExprs_->size(); ++i) {
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr((*unnestExprs_)[i]);
+        auto expected = parseExpr((*unnestExprs_)[i]);
         if (!symbols.empty()) {
           expected = rewriteInputNames(expected, symbols);
         }
@@ -708,8 +710,7 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
       AXIOM_TEST_RETURN_IF_FAILURE
 
       for (auto i = 0; i < groupingKeys_.size(); ++i) {
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr(groupingKeys_[i]);
+        auto expected = parseExpr(groupingKeys_[i]);
         if (!symbols.empty()) {
           expected = rewriteInputNames(expected, symbols);
         }
@@ -912,8 +913,7 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
         EXPECT_NE(plan.filter(), nullptr);
         AXIOM_TEST_RETURN_IF_FAILURE
 
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr(filter_.value());
+        auto expected = parseExpr(filter_.value());
         if (!symbols.empty()) {
           expected = rewriteInputNames(expected, symbols);
         }
@@ -1338,8 +1338,7 @@ class EnforceDistinctMatcher : public PlanMatcherImpl<EnforceDistinctNode> {
       AXIOM_TEST_RETURN_IF_FAILURE
 
       for (auto i = 0; i < distinctKeys_.size(); ++i) {
-        auto expected =
-            parse::DuckSqlExpressionsParser().parseExpr(distinctKeys_[i]);
+        auto expected = parseExpr(distinctKeys_[i]);
         if (!symbols.empty()) {
           expected = rewriteInputNames(expected, symbols);
         }
@@ -1846,8 +1845,7 @@ class GroupIdMatcher : public PlanMatcherImpl<GroupIdNode> {
       AXIOM_TEST_RETURN_IF_FAILURE
 
       for (auto i = 0; i < aggregationInputs_->size(); ++i) {
-        auto expected = parse::DuckSqlExpressionsParser().parseExpr(
-            (*aggregationInputs_)[i]);
+        auto expected = parseExpr((*aggregationInputs_)[i]);
         if (!symbols.empty()) {
           expected = rewriteInputNames(expected, symbols);
         }
@@ -1956,9 +1954,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::filter() {
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::filter(const std::string& predicate) {
+PlanMatcherBuilder& PlanMatcherBuilder::filter(
+    const std::string& predicate,
+    const parse::ParseOptions& options) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<FilterMatcher>(matcher_, predicate);
+  matcher_ = std::make_shared<FilterMatcher>(matcher_, predicate, options);
   return *this;
 }
 
@@ -1969,9 +1969,10 @@ PlanMatcherBuilder& PlanMatcherBuilder::project() {
 }
 
 PlanMatcherBuilder& PlanMatcherBuilder::project(
-    const std::vector<std::string>& expressions) {
+    const std::vector<std::string>& expressions,
+    const parse::ParseOptions& options) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ = std::make_shared<ProjectMatcher>(matcher_, expressions);
+  matcher_ = std::make_shared<ProjectMatcher>(matcher_, expressions, options);
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -19,6 +19,7 @@
 #include <functional>
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "velox/core/PlanNode.h"
+#include "velox/parse/ExpressionsParser.h"
 #include "velox/type/Filter.h"
 
 namespace facebook::velox::core {
@@ -138,12 +139,25 @@ class PlanMatcher {
   }
 
  protected:
+  explicit PlanMatcher(parse::ParseOptions options = {})
+      : options_{std::move(options)} {}
+
+  /// Parses `expr` as a DuckDB SQL expression using this matcher's parse
+  /// options. Use instead of constructing a DuckSqlExpressionsParser directly
+  /// so the matcher's options (e.g. integer-literal kind) are honored.
+  ExprPtr parseExpr(const std::string& expr) const {
+    return parse::DuckSqlExpressionsParser(options_).parseExpr(expr);
+  }
+
   // Aliases bound to the matched node's output columns by position.
   // Applied on successful match by PlanMatcherImpl::match().
   std::vector<std::optional<std::string>> aliases_;
 
   // Invoked with the matched node on a successful match, if set.
   std::function<void(const PlanNodePtr&)> onMatch_;
+
+  // Parse options for SQL expressions this matcher parses.
+  const parse::ParseOptions options_;
 };
 
 /// Match details for a HashJoin node beyond join type. Each field is
@@ -223,6 +237,12 @@ class PlanMatcherBuilder {
   /// Matches any Filter node regardless of predicate.
   PlanMatcherBuilder& filter();
 
+  /// Adds a Filter matcher (see filter()) only when 'condition' is true;
+  /// otherwise a no-op.
+  PlanMatcherBuilder& filterIf(bool condition) {
+    return condition ? filter() : *this;
+  }
+
   /// Matches a Filter node with the specified predicate expression.
   /// Supports symbol rewriting from child matchers.
   /// @param predicate The expected filter predicate (DuckDB SQL syntax).
@@ -238,17 +258,49 @@ class PlanMatcherBuilder {
   ///     kind. A bare integer such as '24' is INTEGER and will not match a
   ///     constant the optimizer coerced to the column's type. Write '24.0' to
   ///     compare against a DOUBLE column.
-  PlanMatcherBuilder& filter(const std::string& predicate);
+  /// @param options Parse options for 'predicate'. Defaults parse integer
+  /// literals as BIGINT; pass '{.parseIntegerAsBigint = false}' when the plan
+  /// uses INTEGER literals.
+  PlanMatcherBuilder& filter(
+      const std::string& predicate,
+      const parse::ParseOptions& options = {});
+
+  PlanMatcherBuilder& filterIf(
+      bool condition,
+      const std::string& predicate,
+      const parse::ParseOptions& options = {}) {
+    return condition ? filter(predicate, options) : *this;
+  }
 
   /// Matches any Project node regardless of expressions.
   PlanMatcherBuilder& project();
+
+  /// Adds a Project matcher (see project()) only when 'condition' is true;
+  /// otherwise a no-op.
+  PlanMatcherBuilder& projectIf(bool condition) {
+    return condition ? project() : *this;
+  }
 
   /// Matches a Project node with the specified projection expressions.
   /// Expressions with aliases (e.g., "a + b as c") capture the alias for use
   /// in parent matchers via symbol rewriting.
   /// @param expressions The expected projection expressions (DuckDB SQL
   /// syntax).
-  PlanMatcherBuilder& project(const std::vector<std::string>& expressions);
+  /// @param options Parse options for 'expressions'. Defaults parse integer
+  /// literals as BIGINT; pass '{.parseIntegerAsBigint = false}' when the plan
+  /// uses INTEGER literals (e.g. Presto array constructors) and the expression
+  /// contains a complex constant where the scalar INTEGER/BIGINT tolerance does
+  /// not apply.
+  PlanMatcherBuilder& project(
+      const std::vector<std::string>& expressions,
+      const parse::ParseOptions& options = {});
+
+  PlanMatcherBuilder& projectIf(
+      bool condition,
+      const std::vector<std::string>& expressions,
+      const parse::ParseOptions& options = {}) {
+    return condition ? project(expressions, options) : *this;
+  }
 
   /// Matches any ParallelProject node regardless of expressions.
   PlanMatcherBuilder& parallelProject();

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -24,10 +24,12 @@ namespace {
 using namespace velox;
 namespace lp = facebook::axiom::logical_plan;
 
-class UnnestTest : public test::QueryTestBase {
+class UnnestTest : public test::QueryTestBase,
+                   public ::testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
     test::QueryTestBase::SetUp();
+    useV2_ = GetParam();
 
     rowVector_ = makeRowVector(
         {"x", "a_a_y", "a_a_z"},
@@ -80,7 +82,7 @@ class UnnestTest : public test::QueryTestBase {
 // - limit before and after unnest
 // - join before and after unnest
 
-TEST_F(UnnestTest, unnest) {
+TEST_P(UnnestTest, unnest) {
   {
     SCOPED_TRACE("unnest");
 
@@ -93,9 +95,8 @@ TEST_F(UnnestTest, unnest) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder{}.values().project().unnest().build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan =
         exec::test::PlanBuilder{}
@@ -128,14 +129,8 @@ TEST_F(UnnestTest, unnest) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .project()
-                       .unnest()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().project().unnest().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan =
         exec::test::PlanBuilder{}
@@ -195,7 +190,7 @@ TEST_F(UnnestTest, unnest) {
             .unnest({"x"}, {"y", "z"})
             .project(expectedNames)
             .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
     ASSERT_EQ(plan->outputType()->names(), expectedNames);
   }
   {
@@ -210,9 +205,8 @@ TEST_F(UnnestTest, unnest) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder{}.values().project().unnest().build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = exec::test::PlanBuilder{}
                              .values({rowVector_})
@@ -242,7 +236,7 @@ TEST_F(UnnestTest, unnest) {
 
     auto plan = toSingleNodePlan(logicalPlan);
     auto matcher = matchValues().project().unnest().build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     checkSame(logicalPlan, referencePlan);
   }
@@ -273,13 +267,13 @@ TEST_F(UnnestTest, unnest) {
 
     auto plan = toSingleNodePlan(logicalPlan);
     auto matcher = matchValues().project().unnest().project({"v", "e"}).build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     checkSame(logicalPlan, referencePlan);
   }
 }
 
-TEST_F(UnnestTest, project) {
+TEST_P(UnnestTest, project) {
   auto startLogicalPlan = [&]() {
     return lp::PlanBuilder{}.values({rowVector_});
   };
@@ -303,16 +297,17 @@ TEST_F(UnnestTest, project) {
                            })
                            .build();
 
+    auto plan = toSingleNodePlan(logicalPlan);
+
     // TODO We probably want pushdown projection closer to data source.
     // Because compared to other joins, unnest only increase work.
-    auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .project()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+
+    // v1's Unnest replicates the original input columns, not the unnested
+    // arrays, so a trailing Project re-derives the output arrays
+    // (array_distinct again). v2's Unnest replicates the unnested arrays, so it
+    // needs no trailing Project.
+    auto matcher = matchValues().project().unnest().projectIf(!useV2_).build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan =
         startReferencePlan()
@@ -340,13 +335,8 @@ TEST_F(UnnestTest, project) {
     // TODO We probably want pushdown projection closer to data source.
     // Because compared to other joins, unnest only increase work.
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .project()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().project().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -372,13 +362,8 @@ TEST_F(UnnestTest, project) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .project()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().project().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan =
         startReferencePlan()
@@ -395,7 +380,7 @@ TEST_F(UnnestTest, project) {
   }
 }
 
-TEST_F(UnnestTest, filter) {
+TEST_P(UnnestTest, filter) {
   auto startLogicalPlan = [&]() {
     return lp::PlanBuilder{}.values({rowVector_});
   };
@@ -417,14 +402,8 @@ TEST_F(UnnestTest, filter) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .filter()
-                       .project()
-                       .unnest()
-                       .project()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().filter().project().unnest().project().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .filter("x % 2 = 0")
@@ -452,14 +431,8 @@ TEST_F(UnnestTest, filter) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .filter()
-                       .project()
-                       .unnest()
-                       .project()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().filter().project().unnest().project().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -491,8 +464,7 @@ TEST_F(UnnestTest, filter) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
+    auto matcher = matchValues()
                        .project()
                        .unnest()
                        .project()
@@ -500,7 +472,7 @@ TEST_F(UnnestTest, filter) {
                        .filter()
                        .project()
                        .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -538,8 +510,7 @@ TEST_F(UnnestTest, filter) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
+    auto matcher = matchValues()
                        .filter()
                        .project()
                        .unnest()
@@ -547,7 +518,7 @@ TEST_F(UnnestTest, filter) {
                        .unnest()
                        .project()
                        .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -585,8 +556,7 @@ TEST_F(UnnestTest, filter) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
+    auto matcher = matchValues()
                        .project()
                        .unnest()
                        .filter()
@@ -594,7 +564,7 @@ TEST_F(UnnestTest, filter) {
                        .unnest()
                        .project()
                        .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -617,7 +587,7 @@ TEST_F(UnnestTest, filter) {
   }
 }
 
-TEST_F(UnnestTest, groupBy) {
+TEST_P(UnnestTest, groupBy) {
   const auto names = rowVector_->rowType()->names();
 
   auto startLogicalPlan = [&]() {
@@ -641,13 +611,8 @@ TEST_F(UnnestTest, groupBy) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .singleAggregation()
-                       .project()
-                       .unnest()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().singleAggregation().project().unnest().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .singleAggregation(names, {})
@@ -673,13 +638,8 @@ TEST_F(UnnestTest, groupBy) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .singleAggregation()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().singleAggregation().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan =
         startReferencePlan()
@@ -696,7 +656,7 @@ TEST_F(UnnestTest, groupBy) {
   }
 }
 
-TEST_F(UnnestTest, orderBy) {
+TEST_P(UnnestTest, orderBy) {
   const std::vector<std::string> names{"x", "a_a_y", "a_a_z"};
 
   auto startLogicalPlan = [&]() {
@@ -720,13 +680,8 @@ TEST_F(UnnestTest, orderBy) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .orderBy()
-                       .project()
-                       .unnest()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().orderBy().project().unnest().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .orderBy(names, {})
@@ -753,13 +708,8 @@ TEST_F(UnnestTest, orderBy) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .orderBy()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().orderBy().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -788,13 +738,8 @@ TEST_F(UnnestTest, orderBy) {
     // TODO We probably want pushdown orderBy closer to data source.
     // Because compared to other joins, unnest only increase work.
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .orderBy()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().orderBy().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -810,7 +755,7 @@ TEST_F(UnnestTest, orderBy) {
   }
 }
 
-TEST_F(UnnestTest, limit) {
+TEST_P(UnnestTest, limit) {
   auto startLogicalPlan = [&]() {
     return lp::PlanBuilder{}.values({rowVector_});
   };
@@ -832,9 +777,8 @@ TEST_F(UnnestTest, limit) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder{}.values().limit().project().unnest().build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().limit().project().unnest().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .limit(1, 1, {})
@@ -861,9 +805,8 @@ TEST_F(UnnestTest, limit) {
                            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder{}.values().project().unnest().limit().build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    auto matcher = matchValues().project().unnest().limit().build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
 
     auto referencePlan = startReferencePlan()
                              .project({
@@ -879,9 +822,10 @@ TEST_F(UnnestTest, limit) {
   }
 }
 
-TEST_F(UnnestTest, join) {
+TEST_P(UnnestTest, join) {
   auto startLogicalPlan = [&](lp::PlanBuilder::Context& ctx) {
-    return lp::PlanBuilder{ctx}.values({rowVector_});
+    return lp::PlanBuilder{ctx, /*allowAmbiguousOutputNames=*/true}.values(
+        {rowVector_});
   };
 
   auto startReferencePlan = [&](auto& planNodeIdGenerator) {
@@ -914,16 +858,15 @@ TEST_F(UnnestTest, join) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .hashJoin(core::PlanMatcherBuilder{}.values().build())
+    auto matcher = matchValues()
+                       .hashJoin(matchValues().build())
                        .project()
                        .unnest()
                        .project()
                        .unnest()
                        .project()
                        .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
     ASSERT_EQ(plan->outputType()->names(), expectedNames);
 
     auto generator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -986,16 +929,15 @@ TEST_F(UnnestTest, join) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .hashJoin(core::PlanMatcherBuilder{}.values().build())
+    auto matcher = matchValues()
+                       .hashJoin(matchValues().build())
                        .project()
                        .unnest()
                        .project()
                        .unnest()
                        .project()
                        .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    AXIOM_ASSERT_PLAN(plan, matcher);
     ASSERT_EQ(plan->outputType()->names(), expectedNames);
 
     auto generator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -1058,22 +1000,26 @@ TEST_F(UnnestTest, join) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher =
-        core::PlanMatcherBuilder{}
-            .values()
-            .project()
-            .unnest()
-            .project()
-            .hashJoin(
-                core::PlanMatcherBuilder{}
-                    .values()
-                    .project()
-                    .unnest()
-                    .project()
-                    .build())
-            .project() // TODO Fix the Optimizer to remove this project.
-            .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    // The join key is independent of the unnested columns, so v2 joins before
+    // unnesting (fewer rows through the join) and unnests each side above the
+    // join; v1 keeps the query's unnest-then-join order.
+    auto matcher = useV2_
+        ? matchValues()
+              .hashJoin(matchValues().build())
+              .project()
+              .unnest()
+              .project()
+              .unnest()
+              .project()
+              .build()
+        : matchValues()
+              .project()
+              .unnest()
+              .project()
+              .hashJoin(matchValues().project().unnest().project().build())
+              .project() // TODO Fix the Optimizer to remove this project.
+              .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
     ASSERT_EQ(plan->outputType()->names(), expectedNames);
 
     auto generator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -1136,20 +1082,16 @@ TEST_F(UnnestTest, join) {
             .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
-    auto matcher = core::PlanMatcherBuilder{}
-                       .values()
-                       .project()
-                       .unnest()
-                       .hashJoin(
-                           core::PlanMatcherBuilder{}
-                               .values()
-                               .project()
-                               .unnest()
-                               .project()
-                               .build())
-                       .project()
-                       .build();
-    ASSERT_TRUE(matcher->match(plan)) << plan->toString(true, true);
+    // v1 emits a trailing project on the build side of the join; v2 elides it.
+    auto matcher =
+        matchValues()
+            .project()
+            .unnest()
+            .hashJoin(
+                matchValues().project().unnest().projectIf(!useV2_).build())
+            .project()
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
     ASSERT_EQ(plan->outputType()->names(), expectedNames);
 
     auto generator = std::make_shared<core::PlanNodeIdGenerator>();
@@ -1188,7 +1130,8 @@ TEST_F(UnnestTest, join) {
   }
 }
 
-TEST_F(UnnestTest, ordinality) {
+TEST_P(UnnestTest, ordinality) {
+  const parse::ParseOptions options = {.parseIntegerAsBigint = false};
   {
     auto query =
         "SELECT a, b, c FROM unnest(array[1, 2, 3], array[4, 5]) WITH ORDINALITY AS t(a, b, c)";
@@ -1197,11 +1140,12 @@ TEST_F(UnnestTest, ordinality) {
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
     // Two arrays are unnested with ordinality column.
-    auto matcher = matchValues()
-                       .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"})
-                       .unnest({}, {"foo", "bar"}, "ordinality")
-                       .project({"e", "e_0", "ordinality"})
-                       .build();
+    auto matcher =
+        matchValues()
+            .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"}, options)
+            .unnest({}, {"foo", "bar"}, "ordinality")
+            .project({"e", "e_0", "ordinality"})
+            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1214,11 +1158,12 @@ TEST_F(UnnestTest, ordinality) {
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
     // Ordinality column is pruned because it's not used.
-    auto matcher = matchValues()
-                       .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"})
-                       .unnest({}, {"foo", "bar"}, std::nullopt)
-                       .project({"e", "e_0"})
-                       .build();
+    auto matcher =
+        matchValues()
+            .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"}, options)
+            .unnest({}, {"foo", "bar"}, std::nullopt)
+            .project({"e", "e_0"})
+            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1231,11 +1176,12 @@ TEST_F(UnnestTest, ordinality) {
     auto logicalPlan = parseSelect(query, kTestConnectorId);
 
     // Ordinality column is pruned because it's not used.
-    auto matcher = matchValues()
-                       .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"})
-                       .unnest({}, {"foo", "bar"}, std::nullopt)
-                       .project({"1"})
-                       .build();
+    auto matcher =
+        matchValues()
+            .project({"array[1, 2, 3] as foo", "array[4, 5] as bar"}, options)
+            .unnest({}, {"foo", "bar"}, std::nullopt)
+            .project({"1"})
+            .build();
 
     auto plan = toSingleNodePlan(logicalPlan);
     AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1243,7 +1189,7 @@ TEST_F(UnnestTest, ordinality) {
 }
 
 // Unnest with a WHERE filter referencing unnested columns.
-TEST_F(UnnestTest, unnestWithFilter) {
+TEST_P(UnnestTest, unnestWithFilter) {
   testConnector_->addTable(
       "t", ROW({"a", "b"}, {MAP(VARCHAR(), INTEGER()), VARCHAR()}));
 
@@ -1258,7 +1204,7 @@ TEST_F(UnnestTest, unnestWithFilter) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(UnnestTest, multipleTables) {
+TEST_P(UnnestTest, multipleTables) {
   testConnector_->addTable("t", ROW({"a"}, ARRAY(BIGINT())));
 
   auto query = "SELECT * FROM t, UNNEST(a, array[1, 2, 3]) AS u(x, y)";
@@ -1270,7 +1216,7 @@ TEST_F(UnnestTest, multipleTables) {
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(UnnestTest, unnestWithJoinAndFilter) {
+TEST_P(UnnestTest, unnestWithJoinAndFilter) {
   testConnector_->addTable("t", ROW("a", ARRAY(INTEGER())));
   testConnector_->addTable("u", ROW("x", INTEGER()));
 
@@ -1279,21 +1225,31 @@ TEST_F(UnnestTest, unnestWithJoinAndFilter) {
   auto logicalPlan = parseSelect(query, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
 
-  // The filter n = x must not be converted to a join key between
-  // UnnestTable and table u. It must remain as a post-unnest filter.
-  auto matcher = matchScan("u")
-                     .nestedLoopJoin(matchScan("t").build())
-                     .unnest()
-                     .filter("x = n")
-                     .project({"1"})
-                     .build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
+  // The filter n = x must not be converted to a join key between the
+  // UnnestTable and table u; it must remain a post-unnest filter.
+
+  // v1 and v2 pick opposite operand orders for this empty-table (tied-cost)
+  // cross join.
+  auto matchJoin = [&](const std::pair<std::string, std::string>& sides) {
+    return matchScan(sides.first)
+        .nestedLoopJoin(matchScan(sides.second).build())
+        .unnest()
+        .filter("x = n")
+        .project({"1"})
+        .build();
+  };
+
+  if (useV2_) {
+    AXIOM_ASSERT_PLAN(plan, matchJoin({"t", "u"}));
+  } else {
+    AXIOM_ASSERT_PLAN(plan, matchJoin({"u", "t"}));
+  }
 }
 
 // A column added by a CROSS JOIN with a single-row aggregate subquery
 // must remain in scope when followed by an UNNEST and both the SELECT
 // list and a WHERE filter reference that column.
-TEST_F(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
+TEST_P(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
   testConnector_->addTable(
       "t", ROW({"a", "ids"}, {INTEGER(), ARRAY(INTEGER())}));
   testConnector_->addTable("u", ROW("x", INTEGER()));
@@ -1306,21 +1262,23 @@ TEST_F(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
 
   auto logicalPlan = parseSelect(query, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
-  auto matcher =
+
+  // v2 fuses the filter into the join; v1 keeps it separate.
+  AXIOM_ASSERT_PLAN(
+      plan,
       matchScan("t")
           .nestedLoopJoin(
               matchScan("u").singleAggregation({}, {"count(*) as c"}).build())
-          .filter("c > a::BIGINT")
+          .filterIf(!useV2_, "c > a::BIGINT")
           .unnest({"c"}, {"ids"})
           .project({"n", "c"})
-          .build();
-  AXIOM_ASSERT_PLAN(plan, matcher);
+          .build());
 }
 
 // A LEFT JOIN whose ON clause references a single-row subquery's column via
 // a non-equi predicate must place the subquery's cross-join on the
 // preserved side before the LEFT join.
-TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
+TEST_P(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
   testConnector_->addTable("t", ROW({"a", "b"}, {INTEGER(), ARRAY(INTEGER())}));
   testConnector_->addTable("u", ROW("x", INTEGER()));
   testConnector_->addTable("v", ROW("x", INTEGER()));
@@ -1335,12 +1293,15 @@ TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
 
   auto logicalPlan = parseSelect(query, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
+  // v2 materializes y = x + count in a Project before the join; v1 inlines it
+  // into the join filter.
   auto matcher =
       matchScan("t")
           .unnest({"a"}, {"b"})
           .nestedLoopJoin(matchScan("u")
                               .singleAggregation({}, {"count(*) as count"})
                               .build())
+          .projectIf(useV2_, {"a", "cast(x as bigint) + count as y"})
           .hashJoin(matchScan("v").build(), core::JoinType::kLeft)
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
@@ -1349,7 +1310,7 @@ TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquery) {
 // Same shape as leftJoinFilterOnSingleRowSubquery but with a small preserved
 // (left) side and a large optional (right) side, so the cost-based hash-right
 // variant wins.
-TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquerySmallPreservedSide) {
+TEST_P(UnnestTest, leftJoinFilterOnSingleRowSubquerySmallPreservedSide) {
   testConnector_->addTable("t", ROW({"a", "b"}, {INTEGER(), ARRAY(INTEGER())}))
       ->setStats(1, {{"a", {.numDistinct = 1}}});
   testConnector_->addTable("u", ROW("x", INTEGER()))
@@ -1367,21 +1328,25 @@ TEST_F(UnnestTest, leftJoinFilterOnSingleRowSubquerySmallPreservedSide) {
 
   auto logicalPlan = parseSelect(query, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
-  auto matcher = matchScan("v")
-                     .hashJoin(
-                         matchScan("t")
-                             .unnest({"a"}, {"b"})
-                             .nestedLoopJoin(matchScan("u")
-                                                 .singleAggregation(
-                                                     {}, {"count(*) as count"})
-                                                 .build())
-                             .build(),
-                         core::JoinType::kRight)
-                     .build();
+  // v2 materializes y = x + count in a Project before the join; v1 inlines it
+  // into the join filter.
+  auto matcher =
+      matchScan("v")
+          .hashJoin(
+              matchScan("t")
+                  .unnest({"a"}, {"b"})
+                  .nestedLoopJoin(
+                      matchScan("u")
+                          .singleAggregation({}, {"count(*) as count"})
+                          .build())
+                  .projectIf(useV2_, {"a", "cast(x as bigint) + count as y"})
+                  .build(),
+              core::JoinType::kRight)
+          .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
 
-TEST_F(UnnestTest, crossJoinUnnestOnWindowFunctionOutput) {
+TEST_P(UnnestTest, crossJoinUnnestOnWindowFunctionOutput) {
   testConnector_->addTable("t", ROW({"a"}, {INTEGER()}));
 
   auto query =
@@ -1401,6 +1366,22 @@ TEST_F(UnnestTest, crossJoinUnnestOnWindowFunctionOutput) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
+
+// Many chained unnests multiply the cardinality estimate past the float range.
+// The optimizer must saturate the estimate to a finite value and still produce
+// a plan rather than failing on a non-finite cardinality.
+TEST_P(UnnestTest, manyUnnestsCardinalityOverflow) {
+  std::string sql = "SELECT 1 FROM (VALUES 1) AS t(x)";
+  for (int32_t i = 0; i < 100; ++i) {
+    sql += fmt::format(
+        " CROSS JOIN UNNEST(ARRAY[1, 2, 3, 4, 5]) AS u{}(v{})", i, i);
+  }
+
+  auto logicalPlan = parseSelect(sql, kTestConnectorId);
+  ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
+}
+
+AXIOM_INSTANTIATE_V1_V2(UnnestTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -18,6 +18,7 @@
 
 #include <folly/container/F14Map.h>
 #include <folly/container/F14Set.h>
+#include <numeric>
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/QueryGraphContext.h"
 #include "axiom/optimizer/v2/Node.h"
@@ -115,12 +116,24 @@ class Builder {
     return makeLiteral(velox::Variant::null(type->kind()), type);
   }
 
+  /// `Values` that emits every column of its underlying data, i.e. with
+  /// identity channels (see `Values::Key`). Pruning is done only in
+  /// PushdownAndPrunePass, which builds the narrowed channels directly.
+  const Values* makeValues(
+      const logical_plan::ValuesNode* source,
+      const velox::Variant* rows,
+      ColumnVector outputColumns) {
+    QGVector<velox::column_index_t> channels(outputColumns.size());
+    std::iota(channels.begin(), channels.end(), 0);
+    return make<Values>(
+        {source, rows, std::move(outputColumns), std::move(channels)});
+  }
+
   /// `Values` node carrying zero rows with the given output schema.
   /// Used to replace subtrees a rewrite proved produce no rows.
   const Values* makeEmptyValues(ColumnVector outputColumns) {
-    return make<Values>({/*source=*/nullptr,
-                         /*rows=*/nullptr,
-                         std::move(outputColumns)});
+    return makeValues(
+        /*source=*/nullptr, /*rows=*/nullptr, std::move(outputColumns));
   }
 
   /// Interned `Name`s for well-known functions, snapshotted from the

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -36,6 +36,36 @@ namespace facebook::axiom::optimizer::v2 {
 
 namespace {
 
+// True when `channels` selects every data column in order (no pruning).
+bool isIdentityChannels(
+    const QGVector<velox::column_index_t>& channels,
+    size_t dataSize) {
+  if (channels.size() != dataSize) {
+    return false;
+  }
+  for (size_t i = 0; i < channels.size(); ++i) {
+    if (channels[i] != i) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Wraps the `channels` children of `full` in a new RowVector of `rowType`,
+// so pruned data columns are never propagated downstream.
+velox::RowVectorPtr selectChannels(
+    const velox::RowVectorPtr& full,
+    const velox::RowTypePtr& rowType,
+    const QGVector<velox::column_index_t>& channels) {
+  std::vector<velox::VectorPtr> children;
+  children.reserve(channels.size());
+  for (auto channel : channels) {
+    children.push_back(full->childAt(channel));
+  }
+  return std::make_shared<velox::RowVector>(
+      full->pool(), rowType, full->nulls(), full->size(), std::move(children));
+}
+
 velox::core::FieldAccessTypedExprPtr toFieldAccess(ColumnCP column) {
   return std::make_shared<velox::core::FieldAccessTypedExpr>(
       toTypePtr(column->value().type), column->outputName());
@@ -1315,21 +1345,39 @@ velox::core::PlanNodePtr Emitter::emitLimit(const Limit& limit) {
 
 velox::core::PlanNodePtr Emitter::emitValues(const Values& values) {
   auto* pool = evaluator_.pool();
+  const auto& channels = values.channels();
+  const auto rowType = makeRowType(values.outputColumns());
   std::vector<velox::RowVectorPtr> rowVectors;
 
   if (values.rows() != nullptr) {
-    const auto rowType = makeRowType(values.outputColumns());
+    const auto& fullRows = values.rows()->array();
+    // Keep only the selected fields of each row variant, so a pruned data
+    // column is never built.
+    std::vector<velox::Variant> prunedRows;
+    const std::vector<velox::Variant>* rows = &fullRows;
+    if (!fullRows.empty() &&
+        !isIdentityChannels(channels, fullRows.front().row().size())) {
+      prunedRows.reserve(fullRows.size());
+      for (const auto& row : fullRows) {
+        const auto& fields = row.row();
+        std::vector<velox::Variant> kept;
+        kept.reserve(channels.size());
+        for (auto channel : channels) {
+          kept.push_back(fields[channel]);
+        }
+        prunedRows.push_back(velox::Variant::row(std::move(kept)));
+      }
+      rows = &prunedRows;
+    }
     rowVectors.emplace_back(
         std::static_pointer_cast<velox::RowVector>(
-            velox::BaseVector::createFromVariants(
-                rowType, values.rows()->array(), pool)));
+            velox::BaseVector::createFromVariants(rowType, *rows, pool)));
     return std::make_shared<velox::core::ValuesNode>(
         nextId(), std::move(rowVectors));
   }
 
   const auto* source = values.source();
   if (source == nullptr) {
-    const auto rowType = makeRowType(values.outputColumns());
     rowVectors.emplace_back(
         velox::BaseVector::create<velox::RowVector>(rowType, /*size=*/0, pool));
     return std::make_shared<velox::core::ValuesNode>(
@@ -1337,17 +1385,25 @@ velox::core::PlanNodePtr Emitter::emitValues(const Values& values) {
   }
 
   const auto& sourceRowType = source->outputType();
+  const bool identity = isIdentityChannels(channels, sourceRowType->size());
   const auto& data = source->data();
   if (const auto* variants =
           std::get_if<logical_plan::ValuesNode::Variants>(&data)) {
+    auto full = std::static_pointer_cast<velox::RowVector>(
+        velox::BaseVector::createFromVariants(sourceRowType, *variants, pool));
     rowVectors.emplace_back(
-        std::static_pointer_cast<velox::RowVector>(
-            velox::BaseVector::createFromVariants(
-                sourceRowType, *variants, pool)));
+        identity ? full : selectChannels(full, rowType, channels));
   } else if (
       const auto* vectors =
           std::get_if<logical_plan::ValuesNode::Vectors>(&data)) {
-    rowVectors = *vectors;
+    if (identity) {
+      rowVectors = *vectors;
+    } else {
+      rowVectors.reserve(vectors->size());
+      for (const auto& vector : *vectors) {
+        rowVectors.push_back(selectChannels(vector, rowType, channels));
+      }
+    }
   } else {
     VELOX_NYI(
         "ValuesNode::Exprs emit not yet supported (needs constant folding from normalize)");

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/v2/EstimateProvider.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "axiom/optimizer/EstimateMath.h"
 #include "axiom/optimizer/QueryGraph.h"
@@ -76,6 +77,13 @@ const Estimate& EstimateProvider::estimate(NodeCP node) {
     return it->second;
   }
   Estimate result = compute(node);
+  // A node's cardinality estimate should never be non-finite; estimate
+  // arithmetic saturates (see EstimateMath.h). Surface a violation here instead
+  // of letting infinity skew downstream cost comparisons.
+  VELOX_DCHECK(
+      !result.cardinality.has_value() || std::isfinite(*result.cardinality),
+      "Cardinality estimate is not finite. Node: {}",
+      node->nodeType());
   return byNode_.emplace(node, std::move(result)).first->second;
 }
 

--- a/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
+++ b/axiom/optimizer/v2/FoldMetadataAggregatePass.cpp
@@ -188,10 +188,10 @@ class Folder : public NodeRewriter<NoContext> {
       rows.push_back(velox::Variant::row(std::move(row)));
     }
 
-    return builder().make<Values>(Values::Key{
-        .source = nullptr,
-        .rows = registerVariant(velox::Variant::array(std::move(rows))),
-        .outputColumns = node->outputColumns()});
+    return builder().makeValues(
+        /*source=*/nullptr,
+        registerVariant(velox::Variant::array(std::move(rows))),
+        node->outputColumns());
   }
 
   static int64_t count(

--- a/axiom/optimizer/v2/LimitAndOrderPass.cpp
+++ b/axiom/optimizer/v2/LimitAndOrderPass.cpp
@@ -212,7 +212,9 @@ class LimitAndOrderRewriter : public NodeRewriter<LimitContext> {
   LIMIT_BARRIER(Filter, rewriteFilter, true)
   LIMIT_BARRIER(Aggregate, rewriteAggregate, false)
   LIMIT_BARRIER(GroupId, rewriteGroupId, false)
-  LIMIT_BARRIER(Unnest, rewriteUnnest, false)
+  // Unnest emits each input row's unnested rows in input order, so it passes
+  // its input's order through: a Sort below it stays observable.
+  LIMIT_BARRIER(Unnest, rewriteUnnest, true)
   LIMIT_BARRIER(Join, rewriteJoin, false)
   LIMIT_BARRIER(Window, rewriteWindow, false)
   LIMIT_BARRIER(Apply, rewriteApply, false)

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -576,6 +576,15 @@ Project::Project(Key key)
   VELOX_CHECK_EQ(this->outputColumns().size(), exprs_.size());
 }
 
+bool Project::isDeterministic() const {
+  for (ExprCP expr : exprs_) {
+    if (expr->containsNonDeterministic()) {
+      return false;
+    }
+  }
+  return true;
+}
+
 size_t Project::KeyHash::operator()(const Project* node) const {
   return hashOf(node->input(), node->outputColumns(), node->exprs());
 }
@@ -975,22 +984,25 @@ bool MarkDistinct::KeyEq::operator()(const MarkDistinct* node, const Key& key)
 Values::Values(Key key)
     : Node(NodeType::kValues, ColumnVector{key.outputColumns}, {}),
       source_(key.source),
-      rows_(key.rows) {
+      rows_(key.rows),
+      channels_(std::move(key.channels)) {
   VELOX_CHECK(
       source_ == nullptr || rows_ == nullptr,
       "Values cannot carry both a passthrough source and folded rows");
 
   const auto numColumns = this->outputColumns().size();
+  VELOX_CHECK_EQ(
+      channels_.size(),
+      numColumns,
+      "Values channels must have one entry per output column");
+
   if (source_ != nullptr) {
     const auto& rowType = source_->outputType();
-    VELOX_CHECK_EQ(
-        rowType->size(),
-        numColumns,
-        "Values source schema must match outputColumns count");
     for (size_t i = 0; i < numColumns; ++i) {
+      VELOX_CHECK_LT(channels_[i], rowType->size());
       VELOX_CHECK(
-          rowType->childAt(i)->equivalent(
-              *this->outputColumns()[i]->value().type),
+          rowType->childAt(channels_[i])
+              ->equivalent(*this->outputColumns()[i]->value().type),
           "Values source column {} type must match outputColumns",
           i);
     }
@@ -1004,30 +1016,32 @@ Values::Values(Key key)
           row.kind(),
           velox::TypeKind::ROW,
           "Values folded rows must be row variants");
-      VELOX_CHECK_EQ(
-          row.row().size(),
-          numColumns,
-          "Values folded row field count must match outputColumns");
+      for (auto channel : channels_) {
+        VELOX_CHECK_LT(channel, row.row().size());
+      }
     }
   }
 }
 
 size_t Values::KeyHash::operator()(const Values* node) const {
-  return hashOf(node->source(), node->rows(), node->outputColumns());
+  return hashOf(
+      node->source(), node->rows(), node->outputColumns(), node->channels());
 }
 
 size_t Values::KeyHash::operator()(const Key& key) const {
-  return hashOf(key.source, key.rows, key.outputColumns);
+  return hashOf(key.source, key.rows, key.outputColumns, key.channels);
 }
 
 bool Values::KeyEq::operator()(const Values* left, const Values* right) const {
   return left->source() == right->source() && left->rows() == right->rows() &&
-      left->outputColumns() == right->outputColumns();
+      left->outputColumns() == right->outputColumns() &&
+      left->channels() == right->channels();
 }
 
 bool Values::KeyEq::operator()(const Key& key, const Values* node) const {
   return key.source == node->source() && key.rows == node->rows() &&
-      key.outputColumns == node->outputColumns();
+      key.outputColumns == node->outputColumns() &&
+      key.channels == node->channels();
 }
 
 bool Values::KeyEq::operator()(const Values* node, const Key& key) const {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -308,6 +308,11 @@ class Project : public Node {
     return exprs_;
   }
 
+  /// True if no output expression contains a non-deterministic function, so an
+  /// output can be substituted (inlined) into a consumer without changing
+  /// semantics.
+  bool isDeterministic() const;
+
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }
@@ -827,6 +832,13 @@ class Values : public Node {
     const velox::Variant* rows;
     /// Output schema (defines the columns in all cases).
     ColumnVector outputColumns;
+    /// For each output column, its index into the underlying data (`source`
+    /// schema / `rows` fields). Identity `0..n-1` when the Values emits every
+    /// data column; pushdown pruning removes entries, leaving holes so a
+    /// dropped data column is never materialized. Must have one entry per
+    /// output column — Builder::makeValues fills identity for the emit-all
+    /// case.
+    QGVector<velox::column_index_t> channels;
   };
 
   /// Transparent hasher for interning `Values`s by identity.
@@ -854,6 +866,11 @@ class Values : public Node {
     return rows_;
   }
 
+  /// For each output column, its index into the underlying data. See Key.
+  const QGVector<velox::column_index_t>& channels() const {
+    return channels_;
+  }
+
   std::span<const NodeCP> inputs() const override {
     return {};
   }
@@ -864,6 +881,7 @@ class Values : public Node {
  private:
   const logical_plan::ValuesNode* const source_;
   const velox::Variant* const rows_;
+  const QGVector<velox::column_index_t> channels_;
 };
 
 using ValuesCP = const Values*;

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -44,6 +44,12 @@ namespace facebook::axiom::optimizer::v2 {
 /// `options.numWorkers` / `options.numDrivers` (each >= 1) are the target task
 /// and per-task driver counts; at `numWorkers > 1` the plan is distributed
 /// across fragments with remote exchanges.
+///
+/// Output column names are guaranteed to match the query only when `plan` is
+/// rooted in an `OutputNode`, whose field names pin the result names. For a
+/// bare plan (no OutputNode) the optimizer may elide pure-rename projections
+/// and carry a column under a source or disambiguated name, so the result
+/// column names are unspecified — do not depend on them.
 PlanAndStats optimize(
     const logical_plan::LogicalPlanNode& plan,
     const connector::SchemaResolver& schemaResolver,

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -19,6 +19,7 @@
 #include <folly/container/F14Map.h>
 #include "axiom/optimizer/PlanUtils.h"
 #include "axiom/optimizer/QueryGraph.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
 #include "axiom/optimizer/v2/NodeRewriter.h"
 
 namespace facebook::axiom::optimizer::v2 {
@@ -134,6 +135,23 @@ ExprCP PrecomputeProjections::toColumn(
 NodeCP PrecomputeProjections::node() && {
   if (!needsProject_) {
     return input_;
+  }
+
+  // Fold into a child Project rather than stacking a second one: substitute
+  // this project's expressions through the child's output->expression map.
+  // Skipped when the child has a non-deterministic expression, since a fold
+  // could evaluate such an output more than once.
+  //
+  // TODO: still inline the deterministic outputs when only some are
+  // non-deterministic — isolate the non-deterministic ones in a separate
+  // Project below and fold the rest.
+  if (input_->is(NodeType::kProject)) {
+    const auto* childProject = input_->as<Project>();
+    if (childProject->isDeterministic()) {
+      outExprs_ = ExprFactory(builder_).substitute(
+          outExprs_, childProject->outputColumns(), childProject->exprs());
+      input_ = childProject->input();
+    }
   }
   return builder_.make<Project>(
       {input_, std::move(outExprs_), std::move(outColumns_)});
@@ -407,14 +425,15 @@ NodeCP Rewriter::rewriteUnnest(const Unnest* unnest, NoContext& context) {
   // solely to feed a lifted unnest expression.
   PrecomputeProjections precompute{
       newInput, builder(), /*projectAllInputs=*/false};
+  // Keep the replicated (passthrough) columns first, before the lifted unnest
+  // expressions, so the project preserves input column order.
+  for (ColumnCP column : unnest->replicatedColumns()) {
+    precompute.toColumn(column);
+  }
   ExprVector newUnnestExprs;
   newUnnestExprs.reserve(unnest->unnestExpressions().size());
   for (ExprCP expr : unnest->unnestExpressions()) {
     newUnnestExprs.push_back(precompute.toColumn(expr));
-  }
-  // Keep the replicated (passthrough) columns in the project's output.
-  for (ColumnCP column : unnest->replicatedColumns()) {
-    precompute.toColumn(column);
   }
   newInput = std::move(precompute).node();
   // Structured fields (replicatedColumns / unnestColumns / ordinalityColumn)

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -578,6 +578,26 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     childContext.nonNullColumns = context.nonNullColumns;
     NodeCP newInput = rewrite(node->input(), childContext);
 
+    // Inline a child Project: a Project directly over another Project collapses
+    // into one by substituting this Project's expressions through the child's
+    // output->expression map. Skipped when the child has a non-deterministic
+    // expression, since a parent that references such an output more than once
+    // would evaluate it multiple times.
+    //
+    // TODO: still inline the deterministic outputs when only some are
+    // non-deterministic — isolate the non-deterministic ones in a separate
+    // Project below and fold the rest.
+    if (newInput->is(NodeType::kProject)) {
+      const auto* childProject = newInput->as<Project>();
+      if (childProject->isDeterministic()) {
+        survivingExprs = exprs_.substitute(
+            survivingExprs,
+            childProject->outputColumns(),
+            childProject->exprs());
+        newInput = childProject->input();
+      }
+    }
+
     // Drop the Project when its surviving outputs are a pure pass-through of
     // the (rewritten) input's output columns. Pushdown can make a Project
     // identity by pruning columns below it — e.g. a semi-project join fused
@@ -947,7 +967,29 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   }
 
   NodeCP rewriteValues(const Values* node, PushdownContext& context) override {
-    return maybeWrapFilter(node, std::move(context.pending));
+    // Keep every column the output needs (`required`), not just those demanded
+    // strictly above (`requiredAbove`): a pending conjunct wrapped as a Filter
+    // over this Values reads the Values' output, so its columns must survive.
+    ColumnVector survivingOutputs;
+    QGVector<velox::column_index_t> survivingChannels;
+    const auto& outputColumns = node->outputColumns();
+    const auto& channels = node->channels();
+    for (size_t i = 0; i < outputColumns.size(); ++i) {
+      if (context.required.contains(outputColumns[i])) {
+        survivingOutputs.push_back(outputColumns[i]);
+        survivingChannels.push_back(channels[i]);
+      }
+    }
+
+    NodeCP result = node;
+    if (survivingOutputs.size() != outputColumns.size()) {
+      result = builder().make<Values>(
+          {node->source(),
+           node->rows(),
+           std::move(survivingOutputs),
+           std::move(survivingChannels)});
+    }
+    return maybeWrapFilter(result, std::move(context.pending));
   }
 
   // Internal nodes — recurse with empty pending via `blockAt`:
@@ -1048,18 +1090,39 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       outputOnlyColumns.add(node->ordinalityColumn());
     }
     auto [pushable, blocked] = partition(context.pending, outputOnlyColumns);
+
+    // Columns this Unnest must still produce: those the consumer requires plus
+    // the columns read by conjuncts that stay above.
+    PlanObjectSet outputsKept = context.required;
+    outputsKept.unionColumns(blocked);
+
+    // Drop the replicated (pass-through) columns and ordinality column the
+    // consumer no longer needs. These must leave the replicated/ordinality
+    // fields and the output set together: Unnest requires both to appear in
+    // outputColumns. Columns still read by pushed-down conjuncts remain
+    // required of the input via 'pushable'.
+    ColumnVector survivingReplicated;
+    survivingReplicated.reserve(node->replicatedColumns().size());
+    for (ColumnCP column : node->replicatedColumns()) {
+      if (outputsKept.contains(column)) {
+        survivingReplicated.push_back(column);
+      }
+    }
+    ColumnCP survivingOrdinality = node->ordinalityColumn() != nullptr &&
+            outputsKept.contains(node->ordinalityColumn())
+        ? node->ordinalityColumn()
+        : nullptr;
+
     PushdownContext childContext =
         makeChildContext(std::move(pushable), context);
     childContext.required.unionColumns(node->unnestExpressions());
-    childContext.required.unionObjects(node->replicatedColumns());
+    childContext.required.unionObjects(survivingReplicated);
     childContext.required.unionColumns(blocked);
     childContext.requiredAbove = childContext.required;
     NodeCP newInput = rewrite(node->input(), childContext);
 
     // Unnest accepts a subset of structured-field outputs as
     // `outputColumns`; drop entries the consumer doesn't need.
-    PlanObjectSet outputsKept = context.required;
-    outputsKept.unionColumns(blocked);
     ColumnVector survivingOutputs;
     survivingOutputs.reserve(node->outputColumns().size());
     for (ColumnCP column : node->outputColumns()) {
@@ -1068,17 +1131,15 @@ class Pushdown : public NodeRewriter<PushdownContext> {
       }
     }
 
-    // TODO: Trim `replicatedColumns` against `outputsKept` to drop dead
-    // passthrough columns when the input carries more than the consumer needs.
     const bool unchanged = newInput == node->input() &&
         survivingOutputs.size() == node->outputColumns().size();
     NodeCP newNode = unchanged ? static_cast<NodeCP>(node)
                                : builder().make<Unnest>(
                                      {newInput,
                                       node->unnestExpressions(),
-                                      node->replicatedColumns(),
+                                      std::move(survivingReplicated),
                                       node->unnestColumns(),
-                                      node->ordinalityColumn(),
+                                      survivingOrdinality,
                                       std::move(survivingOutputs)});
     return maybeWrapFilter(newNode, std::move(blocked));
   }

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -384,7 +384,9 @@ class Translator {
       return {inner.node, std::move(outputColumns), std::move(outputNames)};
     }
     // Bare plan (no OutputNode): nothing has narrowed the required set, so
-    // request everything the root advertises.
+    // request everything the root advertises. Output names are best-effort here
+    // (the column's own name) and not guaranteed without an OutputNode to pin
+    // them -- see the optimize() contract in Optimize.h.
     Translated translated = translateNode(plan, allNames(*plan.outputType()));
     std::vector<std::string> outputNames;
     outputNames.reserve(translated.node->outputColumns().size());
@@ -1238,7 +1240,7 @@ Translated Translator::makeEmptyResult(const velox::RowType& outputType) {
   ColumnVector outputColumns =
       makeOutputColumns(outputType, /*cardinality=*/0, scope);
   ValuesCP valuesNode =
-      builder_.make<Values>({nullptr, nullptr, std::move(outputColumns)});
+      builder_.makeValues(nullptr, nullptr, std::move(outputColumns));
   return {valuesNode, std::move(scope)};
 }
 
@@ -1559,8 +1561,8 @@ Translated Translator::translateValues(
   }
 
   const lp::ValuesNode* passthrough = foldedRows == nullptr ? &values : nullptr;
-  ValuesCP valuesNode = builder_.make<Values>(
-      {passthrough, foldedRows, std::move(outputColumns)});
+  ValuesCP valuesNode =
+      builder_.makeValues(passthrough, foldedRows, std::move(outputColumns));
   return {valuesNode, std::move(scope)};
 }
 

--- a/axiom/optimizer/v2/tests/TpchPlanTest.cpp
+++ b/axiom/optimizer/v2/tests/TpchPlanTest.cpp
@@ -343,7 +343,6 @@ TEST_F(TpchPlanTest, q08) {
                   .build())
           .hashJoinInner(matchScan("nation").build())
           .project()
-          .project()
           .aggregation()
           .project()
           .orderBy()
@@ -688,7 +687,6 @@ TEST_F(TpchPlanTest, q17) {
                   .build())
           .filter()
           .project()
-          .project()
           .aggregation()
           .project()
           .build();
@@ -781,7 +779,6 @@ TEST_F(TpchPlanTest, q20) {
                              .build())
           // TODO Optimize if(true, sum * 0.5, null) to sum * 0.5.
           .filter("cast(ps_availqty as double) > if(true, sum * 0.5, null)")
-          .project()
           .project()
           .hashJoinRightSemiFilter(
               matchScan("supplier")


### PR DESCRIPTION
Summary:

Fixes several independent optimizer issues found while debugging query failures and expanding UnnestTest to run on both the v1 and v2 optimizers:

- Cardinality estimate arithmetic saturates to the finite float range. A long chain of cross joins or unnests overflowed the estimate to infinity and aborted planning; it now stays finite and plans. The v2 per-node estimate gains a matching finiteness check.
- Pushdown prunes a Values node's unused output columns. Each surviving column records its index into the source data (a new `channels` list), so a pruned column is never built at emit.
- Pushdown collapses a Project sitting directly on another Project, and precompute folds its lifted Project into a child Project, instead of stacking two. Both skip a child whose expression is non-deterministic.
- Precompute lists a Project's passthrough columns before the computed ones, matching v1's column order.
- Pushdown trims an Unnest's dead replicated and ordinality columns when the consumer no longer needs them.
- LimitAndOrder treats Unnest as order-preserving, so a Sort below it stays observable rather than being blocked.

UnnestTest now runs on both optimizers, and PlanMatcher gains `projectIf`/`filterIf` and parse-option overloads for the cases where v1 and v2 legitimately differ.

Differential Revision: D112523942


