### PR TITLE
fix(optimizer): Lower shared expression DAGs in linear time (#1603)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -826,25 +826,47 @@ velox::core::TypedExprPtr ToVelox::pathToGetter(
 
 std::vector<velox::core::TypedExprPtr> ToVelox::toTypedExprs(
     const ExprVector& exprs) {
+  // One cache across all expressions: they share conversion context and often
+  // share subexpressions (e.g. a Project's output columns).
+  ExprCache cache;
   std::vector<velox::core::TypedExprPtr> typedExprs;
   typedExprs.reserve(exprs.size());
   for (auto expr : exprs) {
-    typedExprs.emplace_back(toTypedExpr(expr));
+    typedExprs.emplace_back(toTypedExpr(expr, cache));
   }
   return typedExprs;
 }
 
 velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
-  auto it = projectedExprs_.find(expr);
-  if (it != projectedExprs_.end()) {
-    return it->second;
-  }
+  ExprCache cache;
+  return toTypedExpr(expr, cache);
+}
 
+velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr, ExprCache& cache) {
+  auto projected = projectedExprs_.find(expr);
+  if (projected != projectedExprs_.end()) {
+    return projected->second;
+  }
+  // Exprs form a DAG; memoize per conversion so a shared subexpression is
+  // lowered once. Without this a deeply shared expression lowers in exponential
+  // time. The conversion context (column naming, altered types, subfield
+  // getters) is fixed for one conversion, so an Expr* key is sufficient.
+  if (auto cached = cache.find(expr); cached != cache.end()) {
+    return cached->second;
+  }
+  auto result = toTypedExprUncached(expr, cache);
+  cache.emplace(expr, result);
+  return result;
+}
+
+velox::core::TypedExprPtr ToVelox::toTypedExprUncached(
+    ExprCP expr,
+    ExprCache& cache) {
   switch (expr->type()) {
     case PlanType::kColumnExpr: {
       auto column = expr->as<Column>();
       if (column->topColumn() && getterForPushdownSubfield_) {
-        auto field = toTypedExpr(column->topColumn());
+        auto field = toTypedExpr(column->topColumn(), cache);
         return pathToGetter(column->topColumn(), column->path(), field);
       }
       auto name = makeVeloxExprWithNoAlias_ ? std::string(column->name())
@@ -863,11 +885,11 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
       auto call = expr->as<Call>();
 
       if (auto inList = tryCreateConstantInList(*call)) {
-        inputs.push_back(toTypedExpr(call->args()[0]));
+        inputs.push_back(toTypedExpr(call->args()[0], cache));
         inputs.push_back(std::move(inList));
       } else {
         for (auto arg : call->args()) {
-          inputs.push_back(toTypedExpr(arg));
+          inputs.push_back(toTypedExpr(arg, cache));
         }
       }
 
@@ -904,12 +926,12 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
       if (field) {
         return std::make_shared<velox::core::FieldAccessTypedExpr>(
             toTypePtr(expr->value().type),
-            toTypedExpr(expr->as<Field>()->base()),
+            toTypedExpr(expr->as<Field>()->base(), cache),
             field);
       }
       return std::make_shared<velox::core::DereferenceTypedExpr>(
           toTypePtr(expr->value().type),
-          toTypedExpr(expr->as<Field>()->base()),
+          toTypedExpr(expr->as<Field>()->base(), cache),
           expr->as<Field>()->index());
     }
     case PlanType::kLiteralExpr: {
@@ -933,7 +955,8 @@ velox::core::TypedExprPtr ToVelox::toTypedExpr(ExprCP expr) {
         types.push_back(toTypePtr(c->value().type));
       }
       return std::make_shared<velox::core::LambdaTypedExpr>(
-          ROW(std::move(names), std::move(types)), toTypedExpr(lambda->body()));
+          ROW(std::move(names), std::move(types)),
+          toTypedExpr(lambda->body(), cache));
     }
     default:
       VELOX_FAIL("Cannot translate {} to TypeExpr", expr->toString());

--- a/axiom/optimizer/ToVelox.h
+++ b/axiom/optimizer/ToVelox.h
@@ -136,6 +136,17 @@ class ToVelox {
 
   std::vector<velox::core::TypedExprPtr> toTypedExprs(const ExprVector& exprs);
 
+  // Memoizes each Expr's lowered form for the duration of one conversion, so a
+  // shared subexpression DAG lowers in linear rather than exponential time.
+  using ExprCache = folly::F14FastMap<ExprCP, velox::core::TypedExprPtr>;
+
+  // Lowers 'expr', reusing 'cache' for already-lowered subexpressions.
+  velox::core::TypedExprPtr toTypedExpr(ExprCP expr, ExprCache& cache);
+
+  // Lowers 'expr' without consulting 'cache' (the caller memoizes the result);
+  // recurses into subexpressions through the caching toTypedExpr(expr, cache).
+  velox::core::TypedExprPtr toTypedExprUncached(ExprCP expr, ExprCache& cache);
+
   void setLeafData(
       int32_t id,
       std::vector<velox::core::TypedExprPtr> filterConjuncts,

--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -132,6 +132,24 @@ TEST_P(TestConnectorQueryTest, writeFiltered) {
   velox::test::assertEqualVectors(actual, expected);
 }
 
+// A chain of CTEs that each square the previous column inlines into a single
+// expression whose shared subexpressions form a DAG with 2^depth-way sharing.
+// Converting that expression to a Velox plan must reuse each shared node's
+// result rather than re-expanding it per reference, which would be exponential.
+TEST_P(TestConnectorQueryTest, sharedSubexpressionConversion) {
+  testConnector_->addTable("t", ROW({"x"}, {BIGINT()}));
+
+  constexpr int kDepth = 28;
+  std::string sql = "WITH t0 AS (SELECT x FROM t)";
+  for (int i = 1; i <= kDepth; ++i) {
+    sql += fmt::format(", t{0} AS (SELECT x * x AS x FROM t{1})", i, i - 1);
+  }
+  sql += fmt::format(" SELECT x FROM t{}", kDepth);
+
+  auto logicalPlan = parseSelect(sql, kTestConnectorId);
+  ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
+}
+
 AXIOM_INSTANTIATE_V1_V2(TestConnectorQueryTest);
 
 } // namespace

--- a/axiom/optimizer/v2/ExprEmitter.cpp
+++ b/axiom/optimizer/v2/ExprEmitter.cpp
@@ -168,36 +168,62 @@ velox::core::TypedExprPtr ExprEmitter::callToTypedExpr(
 velox::core::TypedExprPtr ExprEmitter::toTypedExpr(
     ExprCP expr,
     ColumnNaming naming) {
+  ExprCache cache;
+  return toTypedExpr(expr, naming, cache);
+}
+
+velox::core::TypedExprPtr
+ExprEmitter::toTypedExpr(ExprCP expr, ColumnNaming naming, ExprCache& cache) {
+  // Exprs form a DAG: a shared subexpression is one interned node reached from
+  // many parents. Memoize per conversion so each node is lowered once; without
+  // this, a deeply shared expression lowers in exponential time. 'naming' is
+  // fixed for the whole conversion, so a plain Expr* key is sufficient.
+  if (auto it = cache.find(expr); it != cache.end()) {
+    return it->second;
+  }
+
+  velox::core::TypedExprPtr result;
   switch (expr->type()) {
     case PlanType::kColumnExpr:
-      return columnToTypedExpr(expr->as<Column>(), naming);
+      result = columnToTypedExpr(expr->as<Column>(), naming);
+      break;
     case PlanType::kLiteralExpr:
-      return literalToTypedExpr(expr->as<Literal>());
+      result = literalToTypedExpr(expr->as<Literal>());
+      break;
     case PlanType::kCallExpr: {
       const auto* call = expr->as<Call>();
       std::vector<velox::core::TypedExprPtr> args;
       args.reserve(call->args().size());
       for (ExprCP arg : call->args()) {
-        args.push_back(toTypedExpr(arg, naming));
+        args.push_back(toTypedExpr(arg, naming, cache));
       }
-      return callToTypedExpr(call, std::move(args));
+      result = callToTypedExpr(call, std::move(args));
+      break;
     }
     case PlanType::kLambdaExpr: {
       const auto* lambda = expr->as<Lambda>();
-      return lambdaToTypedExpr(lambda, toTypedExpr(lambda->body(), naming));
+      result =
+          lambdaToTypedExpr(lambda, toTypedExpr(lambda->body(), naming, cache));
+      break;
     }
     default:
       VELOX_NYI("Unsupported expression type: {}", expr->typeName());
   }
+
+  cache.emplace(expr, result);
+  return result;
 }
 
 std::vector<velox::core::TypedExprPtr> ExprEmitter::toTypedExprs(
     const ExprVector& exprs,
     ColumnNaming naming) {
+  // One cache across all expressions: they share 'naming' and often share
+  // subexpressions (e.g. a Project's output columns).
+  ExprCache cache;
   std::vector<velox::core::TypedExprPtr> result;
   result.reserve(exprs.size());
   for (ExprCP expr : exprs) {
-    result.push_back(toTypedExpr(expr, naming));
+    result.push_back(toTypedExpr(expr, naming, cache));
   }
   return result;
 }

--- a/axiom/optimizer/v2/ExprEmitter.h
+++ b/axiom/optimizer/v2/ExprEmitter.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <folly/container/F14Map.h>
+
 #include "axiom/common/Enums.h"
 #include "axiom/optimizer/QueryGraph.h"
 #include "velox/core/Expressions.h"
@@ -64,6 +66,14 @@ class ExprEmitter {
       ColumnNaming naming = ColumnNaming::kOutputName);
 
  private:
+  // Memoizes each Expr's lowered form for the duration of one conversion, so a
+  // shared subexpression DAG lowers in linear rather than exponential time.
+  using ExprCache = folly::F14FastMap<ExprCP, velox::core::TypedExprPtr>;
+
+  // Lowers 'expr', reusing 'cache' for already-lowered subexpressions.
+  velox::core::TypedExprPtr
+  toTypedExpr(ExprCP expr, ColumnNaming naming, ExprCache& cache);
+
   // Lowers a `Call`. 'args' are the already-lowered arguments.
   velox::core::TypedExprPtr callToTypedExpr(
       const Call* call,


### PR DESCRIPTION
Summary:

The optimizer interns expressions, so a shared subexpression is a single node reached from several parents. An expression is therefore a DAG, not a tree. Lowering a plan to a Velox plan re-converted each shared node once per path through the DAG. For a deeply shared expression this took time exponential in its depth, so planning the query never finished.

Such an expression arises when projections that reuse a column are inlined. A chain where each step squares the previous column,

    x1 = x0 * x0, x2 = x1 * x1, ..., xN = x(N-1) * x(N-1)

collapses into one expression whose tree form has 2^N nodes but whose DAG has only N.

Both planners now memoize each expression's lowered form by identity for the duration of one conversion, so a shared subexpression is lowered once and the Velox plan reuses it.

Reviewed By: amitkdutta

Differential Revision: D112540506
