### PR TITLE
refactor(runner): Typed query cancellation, drop co_drain (#1604)

### DIFF
--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/runner/LocalRunner.h"
 #include <folly/CancellationToken.h>
+#include <folly/OperationCancelled.h>
 #include <folly/coro/AsyncGenerator.h>
 #include <folly/coro/AsyncScope.h>
 #include <folly/coro/BlockingWait.h>
@@ -313,6 +314,22 @@ folly::coro::Task<velox::RowVectorPtr> LocalRunner::co_pull() {
     start();
   }
 
+  // start() can return without a cursor if the run was cancelled or errored
+  // before starting. There is no cursor to surface the reason, so do it here: a
+  // genuine error as itself, a pure cancel as cooperative cancellation. Once a
+  // cursor exists, moveNext() itself surfaces a cancelled task as
+  // folly::OperationCancelled (translated in TaskCursor) and a genuine error as
+  // itself.
+  if (!cursor_) {
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      if (error_) {
+        std::rethrow_exception(error_);
+      }
+    }
+    throw folly::OperationCancelled{};
+  }
+
   velox::ContinueFuture future = velox::ContinueFuture::makeEmpty();
   // The parallel TaskQueue wakes the consumer only when a batch is queued or
   // all producers are finished/drained, so a resolved wait-future implies the
@@ -444,11 +461,14 @@ velox::RowVectorPtr LocalRunner::makeWriteResult(int64_t rows) {
 void LocalRunner::start() {
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    // A cancel (or error) that landed before start() leaves the runner terminal
-    // with no cursor; surface that error rather than starting and tripping the
-    // state precondition below.
+    // A cancel or error that landed before start() leaves the runner terminal
+    // with no cursor. Surface a genuine error here; for a pure cancel, return
+    // without starting so the read path surfaces cooperative cancellation.
     if (error_) {
       std::rethrow_exception(error_);
+    }
+    if (state_ == State::kCancelled) {
+      return;
     }
     VELOX_CHECK_EQ(state_, State::kInitialized);
   }
@@ -467,16 +487,21 @@ void LocalRunner::start() {
 
   {
     std::lock_guard<std::mutex> lock(mutex_);
-    if (!error_) {
+    // Do not adopt the cursor if a cancel or error landed while starting; that
+    // would clobber the terminal state a concurrent cancelTasks()/onError set.
+    if (!error_ && state_ != State::kCancelled) {
       cursor_ = std::move(cursor);
       state_ = State::kRunning;
     }
   }
 
   if (!cursor_) {
-    // The cursor was not set because previous fragments had an error.
+    // A cancel or error landed while starting, so the cursor was not adopted.
+    // Cancel the just-built tasks; co_pull() then surfaces the cause under
+    // 'mutex_' (a genuine error as itself, a pure cancel as cooperative
+    // cancellation). Do not read error_ here: it is written by onError() under
+    // the lock from a stage-task thread, so an unlocked read would race.
     cancelTasks();
-    std::rethrow_exception(error_);
   }
 }
 
@@ -494,6 +519,7 @@ void LocalRunner::cancelTasks() {
   // so serialize the error/state mutation under 'mutex_' against start() (which
   // reads error_ under the same lock) and a second concurrent cancelTasks().
   std::vector<std::shared_ptr<velox::exec::Task>> tasks;
+  std::exception_ptr error;
   {
     std::lock_guard<std::mutex> lock(mutex_);
     // A completed query stays finished: the cancel callback can fire after
@@ -502,33 +528,38 @@ void LocalRunner::cancelTasks() {
     if (state_ == State::kFinished) {
       return;
     }
-    // If called without a previous error, set the error to cancellation.
-    // onError records its own error before calling cancelTasks() to propagate
-    // it, so it must not be overwritten here.
+    // A pure cancel records kCancelled but does NOT fabricate an error_:
+    // error_ is reserved for genuine failures, so onError() (guarded by 'if
+    // (error_)') can still record a real error that co-occurs with a cancel,
+    // and the read path can tell cancellation apart from failure by type
+    // (co_pull() surfaces OperationCancelled when cancelled-without-error).
     if (!error_) {
-      try {
-        state_ = State::kCancelled;
-        VELOX_FAIL("Query cancelled");
-      } catch (const std::exception&) {
-        error_ = std::current_exception();
-      }
+      state_ = State::kCancelled;
     }
     // Copy tasks under the lock to prevent use-after-free if reap() clears
-    // stages_ concurrently. Propagate to the cursor here too, under the lock
-    // that guards cursor_.
+    // stages_ concurrently. Snapshot error_ (may be null) and propagate a
+    // genuine error to the cursor under the lock that guards cursor_.
     for (auto& stage : stages_) {
       for (auto& task : stage) {
         tasks.push_back(task);
       }
     }
-    if (cursor_) {
-      cursor_->setError(error_);
+    error = error_;
+    if (cursor_ && error) {
+      cursor_->setError(error);
     }
   }
   VELOX_CHECK(state_ != State::kInitialized);
 
   for (auto& task : tasks) {
-    task->setError(error_);
+    if (error) {
+      task->setError(error);
+    } else {
+      // Clean cancel: stop the task without a caller error. terminate() still
+      // marks it kCanceled with its own "Cancelled" exception, which the read
+      // path translates to OperationCancelled rather than surfacing verbatim.
+      (void)task->requestCancel();
+    }
   }
 }
 

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -169,8 +169,8 @@ class LocalRunner : public Runner,
   // Best-effort attempt to cancel the execution. May be invoked from any
   // thread (via the cancellation callback), without serialization, and is
   // idempotent. A no-op once execution has finished (state() == kFinished).
-  // Otherwise state() becomes kCancelled and the in-flight or next pull
-  // surfaces the cancellation error.
+  // Otherwise state() becomes kCancelled (without fabricating an error_) and
+  // the in-flight or next pull surfaces cooperative cancellation.
   void cancelTasks();
 
   // Awaited reap shared by co_close() and the co_runWrite() error path. Joins

--- a/axiom/runner/Runner.cpp
+++ b/axiom/runner/Runner.cpp
@@ -16,12 +16,12 @@
 
 #include "axiom/runner/Runner.h"
 
-#include <folly/CancellationToken.h>
 #include <folly/container/F14Map.h>
 #include <folly/coro/BlockingWait.h>
+#include <folly/coro/Invoke.h>
 #include <folly/coro/Task.h>
 #include <folly/coro/Timeout.h>
-#include <folly/coro/WithCancellation.h>
+#include <glog/logging.h>
 #include "velox/common/base/Exceptions.h"
 
 namespace facebook::axiom::runner {
@@ -45,44 +45,55 @@ AXIOM_DEFINE_EMBEDDED_ENUM_NAME(Runner, State, stateNames);
 void Runner::drain(
     const std::function<void(velox::RowVectorPtr)>& onBatch,
     int64_t timeoutMicros) {
-  // Hold the generator as a local; drain() co_closes the runner below (on this
-  // calling, non-executor thread) so the run is always reaped before return.
-  auto generator = execute();
-  std::atomic<bool> timedOut{false};
-  auto loop = [&]() -> folly::coro::Task<void> {
-    const auto token = co_await folly::coro::co_current_cancellation_token;
-    folly::CancellationCallback onTimeout{token, [&] { timedOut.store(true); }};
-    while (auto batch = co_await generator.next()) {
-      onBatch(std::move(*batch));
-    }
-  };
-
-  std::exception_ptr error;
-  try {
-    if (timeoutMicros > 0) {
-      folly::coro::blockingWait(
-          folly::coro::timeout(
-              loop(), std::chrono::microseconds(timeoutMicros)));
-    } else {
-      folly::coro::blockingWait(loop());
-    }
-  } catch (const std::exception&) {
-    error = std::current_exception();
-  }
-
-  // Reap whether the drain succeeded, timed out, or failed, before surfacing
-  // any error. On a deadline this reaps the cancelled run; VELOX_USER_FAIL is
-  // thrown only after the reap completes.
-  folly::coro::blockingWait(co_close());
-
-  if (error) {
-    if (timedOut.load()) {
-      VELOX_USER_FAIL(
-          "Query exceeded maximum time limit of {:.2f}s",
-          timeoutMicros / 1'000'000.0);
-    }
-    std::rethrow_exception(error);
-  }
+  folly::coro::blockingWait(
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto generator = execute();
+        auto loop = [&]() -> folly::coro::Task<void> {
+          while (auto batch = co_await generator.next()) {
+            onBatch(std::move(*batch));
+          }
+        };
+        // co_invoke the loop: folly::coro::timeout() takes the awaitable by
+        // value and does not immediately co_await it, so invoking the lambda
+        // bare would leave the returned Task holding a dangling reference.
+        std::exception_ptr error;
+        bool timedOut = false;
+        try {
+          if (timeoutMicros > 0) {
+            co_await folly::coro::timeout(
+                folly::coro::co_invoke(loop),
+                std::chrono::microseconds(timeoutMicros));
+          } else {
+            co_await folly::coro::co_invoke(loop);
+          }
+        } catch (const folly::FutureTimeout&) {
+          timedOut = true;
+        } catch (const std::exception&) {
+          error = std::current_exception();
+        }
+        // Reap regardless, before surfacing any error or the deadline failure.
+        // A reap failure must not mask the original stop reason: if the drain
+        // already failed or timed out, keep that and let the reap error be
+        // secondary.
+        try {
+          co_await co_close();
+        } catch (const std::exception& e) {
+          if (!timedOut && !error) {
+            throw;
+          }
+          LOG(WARNING) << "co_close() failed during reap, surfacing the "
+                          "original stop reason instead: "
+                       << e.what();
+        }
+        if (timedOut) {
+          VELOX_USER_FAIL(
+              "Query exceeded maximum time limit of {:.2f}s",
+              timeoutMicros / 1'000'000.0);
+        }
+        if (error) {
+          std::rethrow_exception(error);
+        }
+      }));
 }
 
 } // namespace facebook::axiom::runner

--- a/axiom/runner/Runner.h
+++ b/axiom/runner/Runner.h
@@ -94,16 +94,18 @@ class Runner {
   /// Returns the state of execution.
   virtual State state() const = 0;
 
-  /// Convenience that synchronously drives execute() to completion, invoking
-  /// 'onBatch' for each result batch, then co_closes the runner before
-  /// returning. For callers that are not themselves coroutines — synchronous
-  /// entry points such as the CLI, FFI boundaries, and tests. A coroutine
-  /// caller should await execute() (and co_close()) directly instead. Blocks
-  /// the calling thread, so it must NOT be called from a Velox executor thread
-  /// (blocking there starves the executor).
+  /// Synchronous convenience that drives execute() to completion (or the
+  /// deadline), invokes 'onBatch' for each result batch, then reaps via
+  /// co_close() before returning. For non-coroutine callers that do not need
+  /// external cancellation — simple entry points, tests, benchmarks. Blocks the
+  /// calling thread, so it must NOT be called from a Velox executor thread.
   ///
-  /// When 'timeoutMicros' > 0, enforces a wall-clock deadline via cooperative
-  /// cancellation; on the deadline the drain fails with VELOX_USER_FAIL.
+  /// When 'timeoutMicros' > 0, enforces a cooperative deadline over execution
+  /// only (not the parse/permission/optimize phases nor a write commit; a
+  /// non-yielding operator can overrun it), failing with VELOX_USER_FAIL on the
+  /// deadline. A caller that needs external cancellation does not use drain():
+  /// it drives execute()/co_close() under its own co_withCancellation scope and
+  /// catches folly::OperationCancelled (see SqlQueryRunner::run).
   void drain(
       const std::function<void(velox::RowVectorPtr)>& onBatch,
       int64_t timeoutMicros = 0);

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/runner/LocalRunner.h"
 #include <folly/CancellationToken.h>
+#include <folly/OperationCancelled.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Task.h>
 #include <folly/coro/WithCancellation.h>
@@ -148,10 +149,10 @@ class LocalRunnerTest : public test::LocalRunnerTestBase {
         axiom::connector::ConnectorProperties{});
   }
 
-  std::shared_ptr<LocalRunner> makeRunner(
-      optimizer::MultiFragmentPlanPtr plan) {
+  template <typename RunnerT = LocalRunner>
+  std::shared_ptr<RunnerT> makeRunner(optimizer::MultiFragmentPlanPtr plan) {
     const auto queryId = plan->options().queryId;
-    return std::make_shared<LocalRunner>(
+    return std::make_shared<RunnerT>(
         makeRunnerSession(queryId),
         std::move(plan),
         optimizer::FinishWrite{},
@@ -175,6 +176,18 @@ int64_t extractSingleInt64(const std::vector<velox::RowVectorPtr>& vectors) {
   return vectors.at(0)->childAt(0)->as<velox::FlatVector<int64_t>>()->valueAt(
       0);
 }
+
+// A LocalRunner whose co_close() throws after the real reap, to exercise
+// drain()'s policy that a reap failure must not mask the original stop reason.
+class ReapFailingLocalRunner : public LocalRunner {
+ public:
+  using LocalRunner::LocalRunner;
+
+  folly::coro::Task<void> co_close() override {
+    co_await LocalRunner::co_close();
+    VELOX_FAIL("injected reap failure");
+  }
+};
 
 TEST_F(LocalRunnerTest, count) {
   auto join = makeJoinPlan();
@@ -227,10 +240,13 @@ TEST_F(LocalRunnerTest, executeCancellation) {
     while (co_await generator.next()) {
     }
   };
-  VELOX_ASSERT_THROW(
+  // Cancellation surfaces as cooperative cancellation
+  // (folly::OperationCancelled), not a VeloxRuntimeError shaped like a genuine
+  // failure.
+  EXPECT_THROW(
       folly::coro::blockingWait(
           folly::coro::co_withCancellation(source.getToken(), drainLoop())),
-      "cancel");
+      folly::OperationCancelled);
   folly::coro::blockingWait(localRunner->co_close());
 
   EXPECT_EQ(Runner::State::kCancelled, localRunner->state());
@@ -267,10 +283,10 @@ TEST_F(LocalRunnerTest, executeCancellationFromAnotherThread) {
     while (co_await generator.next()) {
     }
   };
-  VELOX_ASSERT_THROW(
+  EXPECT_THROW(
       folly::coro::blockingWait(
           folly::coro::co_withCancellation(source.getToken(), drainLoop())),
-      "cancel");
+      folly::OperationCancelled);
   canceller.join();
   folly::coro::blockingWait(localRunner->co_close());
 
@@ -307,6 +323,31 @@ TEST_F(LocalRunnerTest, error) {
         results.push_back(std::move(batch));
       }),
       "division by zero");
+  EXPECT_EQ(Runner::State::kError, localRunner->state());
+}
+
+// drain(..., timeoutMicros) fails with a user error when execution overruns the
+// cooperative deadline.
+TEST_F(LocalRunnerTest, drainTimeout) {
+  auto join = makeJoinPlan();
+  auto localRunner = makeRunner(join);
+
+  // A 1us deadline is far shorter than the join over kNumRows can complete in,
+  // so the run is still executing when the deadline elapses.
+  VELOX_ASSERT_THROW(
+      localRunner->drain([](velox::RowVectorPtr) {}, /*timeoutMicros=*/1),
+      "exceeded maximum time limit");
+}
+
+// A reap (co_close) failure must not mask the original stop reason: the genuine
+// execution error surfaces from drain() while the secondary reap failure is
+// logged, not thrown.
+TEST_F(LocalRunnerTest, drainReapFailureDoesNotMaskError) {
+  auto join = makeJoinPlan("if (c0 = 111, c0 / 0, c0 + 1) as c0");
+  auto localRunner = makeRunner<ReapFailingLocalRunner>(join);
+
+  VELOX_ASSERT_THROW(
+      localRunner->drain([](velox::RowVectorPtr) {}), "division by zero");
   EXPECT_EQ(Runner::State::kError, localRunner->state());
 }
 


### PR DESCRIPTION
Summary:

Surfaces query cancellation as a typed exception at the source instead of
reconstructing the stop cause downstream. Previously a cancel was recorded as a
fabricated `VeloxRuntimeError` shaped like a genuine failure, and a `co_drain()`
helper reconstructed the reason from a callback plus the caller's token.

- `cancelTasks()` no longer fabricates an `error_` for a pure cancel: it records
  `kCancelled` and requests task cancellation, reserving `error_` for genuine
  failures. This also fixes an error-masking race -- a genuine error that
  co-occurs with a cancel is no longer blocked by a fabricated cancel error
  (`onError()`'s `if (error_)` guard now lets the real error win).
- The read path surfaces cooperative cancellation as `folly::OperationCancelled`
  through Velox's `TaskCursor` (changed separately, now landed). `co_pull()` also
  surfaces it directly for a cancel that lands before a cursor exists, and
  rethrows a genuine startup error rather than dereferencing a missing cursor.
- `co_drain()` and `DrainOutcome` are removed. The caller composes external
  cancellation and the deadline with plain structured concurrency (see the CLI
  diff), so the `Runner` virtual surface is unchanged. `drain()` remains a
  synchronous convenience for non-cancelling callers (tests, benchmarks),
  preserving the deadline `VELOX_USER_FAIL` contract; a reap failure no longer
  masks the original stop reason.

Relies on Velox's `TaskCursor` surfacing a requested cancel as
`folly::OperationCancelled`, which landed separately.

Reviewed By: xiaoxmeng

Differential Revision: D112582002


