### PR TITLE
fix(sql): Cap expression depth to avoid stack overflow (#1607)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -782,6 +782,17 @@ TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
 lp::ExprApi ExpressionPlanner::toExpr(
     const ExpressionPtr& node,
     ExprOptions options) {
+  AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+      exprDepth_,
+      options_.maxExpressionDepth,
+      node->location(),
+      /*token=*/std::nullopt,
+      "Expression exceeds maximum nesting depth");
+  ++exprDepth_;
+  SCOPE_EXIT {
+    --exprDepth_;
+  };
+
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -20,10 +20,9 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <folly/container/F14Map.h>
-
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/sql/presto/ParserOptions.h"
 #include "axiom/sql/presto/ast/AstNodesAll.h"
 
 namespace axiom::sql::presto {
@@ -108,13 +107,15 @@ class ExpressionPlanner {
       std::string user,
       SubqueryPlanner subqueryPlanner,
       SortingKeyResolver sortingKeyResolver,
+      const ParserOptions& options,
       ShouldDropQualifier shouldDropQualifier = nullptr,
       ColumnResolver columnResolver = nullptr)
       : user_{std::move(user)},
         subqueryPlanner_(std::move(subqueryPlanner)),
         sortingKeyResolver_(std::move(sortingKeyResolver)),
         shouldDropQualifier_(std::move(shouldDropQualifier)),
-        columnResolver_(std::move(columnResolver)) {}
+        columnResolver_(std::move(columnResolver)),
+        options_{options} {}
 
   /// Finds WindowCallExpr nodes nested inside non-window expressions.
   /// Skips top-level window projections (where the ExprApi itself is a
@@ -132,6 +133,7 @@ class ExpressionPlanner {
   /// Translates an AST expression into an ExprApi. Aggregate options
   /// (DISTINCT, FILTER, ORDER BY) are embedded in the returned ExprApi via
   /// AggregateCallExpr. Window functions are embedded via WindowCallExpr.
+  /// Rejects expressions nested deeper than the configured limit.
   lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {});
 
   /// Sets alias-to-expression mappings for lateral column alias resolution.
@@ -243,6 +245,8 @@ class ExpressionPlanner {
   ShouldDropQualifier shouldDropQualifier_;
   ColumnResolver columnResolver_;
 
+  ParserOptions options_;
+
   // Per-query cache for user-defined type lookups. Entries with nullptr values
   // represent negatively cached (not-found) types.
   folly::F14FastMap<std::string, facebook::velox::TypePtr> typeCache_;
@@ -265,6 +269,9 @@ class ExpressionPlanner {
   // the qualifier of 'x.field' when 'x' names a lambda parameter rather than
   // an outer table alias.
   std::vector<std::string> lambdaParamScope_;
+
+  // Current toExpr recursion depth, bounded by options_.maxExpressionDepth.
+  uint32_t exprDepth_{0};
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ParserOptions.cpp
+++ b/axiom/sql/presto/ParserOptions.cpp
@@ -17,6 +17,7 @@
 #include "axiom/sql/presto/ParserOptions.h"
 
 #include <fmt/format.h>
+#include <folly/Conv.h>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -43,6 +44,13 @@ std::vector<ConfigProperty> buildProperties(
           fmt::to_string(ParserOptions::kParseDecimalLiteralAsDoubleDefault),
           "Parse decimal literals (e.g. 1.5) as DOUBLE. When false, parse as "
           "DECIMAL with inferred precision and scale.",
+      },
+      {
+          std::string(ParserOptions::kMaxExpressionDepth),
+          ConfigPropertyType::kInteger,
+          fmt::to_string(ParserOptions::kMaxExpressionDepthDefault),
+          "Maximum expression nesting depth; deeper expressions are rejected "
+          "to avoid a stack overflow.",
       },
   };
 
@@ -88,10 +96,17 @@ ParserOptions ParserOptions::from(
       field = it->second == "true";
     }
   };
+  auto setUint32 = [&](std::string_view key, uint32_t& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = folly::to<uint32_t>(it->second);
+    }
+  };
 
   ParserOptions options;
   setBool(kFriendlySql, options.friendlySql);
   setBool(kParseDecimalLiteralAsDouble, options.parseDecimalLiteralAsDouble);
+  setUint32(kMaxExpressionDepth, options.maxExpressionDepth);
   return options;
 }
 

--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -31,9 +32,12 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   static constexpr std::string_view kFriendlySql = "friendly_sql";
   static constexpr std::string_view kParseDecimalLiteralAsDouble =
       "parse_decimal_literal_as_double";
+  static constexpr std::string_view kMaxExpressionDepth =
+      "max_expression_depth";
 
   static constexpr bool kFriendlySqlDefault = true;
   static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
+  static constexpr uint32_t kMaxExpressionDepthDefault = 256;
 
   ParserOptions();
 
@@ -50,6 +54,10 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   /// from the literal. Matches Presto's decimal_literal_result_type session
   /// property.
   bool parseDecimalLiteralAsDouble{kParseDecimalLiteralAsDoubleDefault};
+
+  /// Maximum expression nesting depth; deeper expressions are rejected to
+  /// avoid a stack overflow.
+  uint32_t maxExpressionDepth{kMaxExpressionDepthDefault};
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "friendly_sql").

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -30,6 +30,7 @@
 #include "axiom/sql/presto/DisplayNames.h"
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
+#include "axiom/sql/presto/ParserOptions.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/RecursiveCteValidator.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
@@ -256,7 +257,7 @@ class RelationPlanner : public AstVisitor {
       const std::string& defaultSchema,
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
           std::string_view /*sql*/)>& parseSql,
-      bool friendlySql = true)
+      const ParserOptions& options = {})
       : context_{makePrestoContext(
             user,
             defaultConnectorId,
@@ -266,7 +267,7 @@ class RelationPlanner : public AstVisitor {
         parseSql_{parseSql},
         user_{std::move(user)},
         builder_(newBuilder()),
-        friendlySql_{friendlySql} {}
+        options_{options} {}
 
   static lp::PlanBuilder::Context makePrestoContext(
       const std::string& user,
@@ -944,7 +945,7 @@ class RelationPlanner : public AstVisitor {
     // compatibility (e.g., SELECT a AS b, b FROM t — second b is column b).
     std::unordered_map<std::string, core::ExprPtr> aliasExprs;
     std::unordered_set<std::string> columnNames;
-    if (friendlySql_) {
+    if (options_.friendlySql) {
       for (const auto& name : builder_->outputNames()) {
         if (name.has_value()) {
           columnNames.insert(name.value());
@@ -1030,7 +1031,7 @@ class RelationPlanner : public AstVisitor {
         } else {
           // Normal SingleColumn handling.
           if (alias.has_value()) {
-            if (friendlySql_) {
+            if (options_.friendlySql) {
               aliasExprs[*alias] = expr.expr();
             }
             expr = expr.as(*alias);
@@ -1587,12 +1588,14 @@ class RelationPlanner : public AstVisitor {
       parseSql_;
   const std::string user_;
   std::shared_ptr<lp::PlanBuilder> builder_;
+  ParserOptions options_;
   ExpressionPlanner exprPlanner_{
       user_,
       [this](Query* query) { return planSubquery(query); },
       [this](const ExpressionPtr& expr, ExprOptions options) {
         return toSortingKey(expr, options);
       },
+      options_,
       [this](const std::string& qualifier, const std::string& name) {
         // Only canonicalize if the qualifier resolves as a table alias (not a
         // struct field dereference) and the unqualified name is unambiguous.
@@ -1606,7 +1609,6 @@ class RelationPlanner : public AstVisitor {
   CteScope ctes_;
   ViewMap views_;
   std::unordered_set<facebook::axiom::CatalogSchemaTableName> inputTables_;
-  bool friendlySql_;
 
   DisplayNames displayNames_;
 };
@@ -1774,7 +1776,10 @@ core::ExprPtr parseFunctionBody(
   VELOX_USER_CHECK_NOT_NULL(column, "SQL function body is not an expression");
 
   ExpressionPlanner exprPlanner{
-      user, /*subqueryPlanner=*/nullptr, /*sortingKeyResolver=*/nullptr};
+      user,
+      /*subqueryPlanner=*/nullptr,
+      /*sortingKeyResolver=*/nullptr,
+      ParserOptions{}};
   return exprPlanner.toExpr(column->expression()).expr();
 }
 
@@ -1895,7 +1900,10 @@ lp::ExprPtr resolveSqlExpression(
     const std::string& user,
     const ExpressionPtr& expr) {
   ExpressionPlanner exprPlanner{
-      user, /*subqueryPlanner=*/nullptr, /*sortingKeyResolver=*/nullptr};
+      user,
+      /*subqueryPlanner=*/nullptr,
+      /*sortingKeyResolver=*/nullptr,
+      ParserOptions{}};
 
   auto plan = lp::PlanBuilder()
                   .values(ROW({}), {Variant::row({})})
@@ -3092,7 +3100,7 @@ SqlStatementPtr doPlan(
         defaultConnectorId,
         defaultSchema,
         parseSql,
-        parserSession->options().friendlySql);
+        parserSession->options());
     query->accept(&planner);
     return std::make_shared<SelectStatement>(
         planner.plan(),

--- a/axiom/sql/presto/PrestoSqlError.h
+++ b/axiom/sql/presto/PrestoSqlError.h
@@ -258,6 +258,27 @@ PrestoErrorClassification classify(PrestoSqlErrorKind kind);
     }                                                                   \
   } while (0)
 
+/// Throws PrestoSqlError with kSemantic kind if val1 >= val2.
+/// Automatically appends ": {val1} vs {val2}" to the error message.
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
+#define AXIOM_PRESTO_SEMANTIC_CHECK_LT(                                 \
+    val1, val2, location, token, fmt_str, ...)                          \
+  do {                                                                  \
+    const auto _axiom_v1 = (val1);                                      \
+    const auto _axiom_v2 = (val2);                                      \
+    if (FOLLY_UNLIKELY(_axiom_v1 >= _axiom_v2)) {                       \
+      assert((location).line > 0 && "Location must have 1-based line"); \
+      throw ::axiom::sql::presto::PrestoSqlError(                       \
+          fmt::format(fmt_str, ##__VA_ARGS__) +                         \
+              fmt::format(": {} vs {}", _axiom_v1, _axiom_v2),          \
+          static_cast<size_t>((location).line - 1),                     \
+          static_cast<size_t>(std::max(0, (location).charPosition)),    \
+          (token),                                                      \
+          ::axiom::sql::presto::PrestoSqlErrorKind::kSemantic,          \
+          fmt_str);                                                     \
+    }                                                                   \
+  } while (0)
+
 /// Throws PrestoSqlError with kSemantic kind if val1 > val2.
 /// Automatically appends ": {val1} vs {val2}" to the error message.
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1100,5 +1100,20 @@ TEST_F(ExpressionParserTest, mixedCaseColumnName) {
       "SELECT ORDERINGID FROM mixedCase", matchScan().project().output()));
 }
 
+TEST_F(ExpressionParserTest, expressionDepthCapBoundary) {
+  auto chain = [](uint32_t terms) {
+    std::string expr = "1";
+    for (uint32_t i = 0; i < terms; ++i) {
+      expr += " + 0";
+    }
+    return expr;
+  };
+  EXPECT_NE(
+      nullptr, parseExpr(chain(ParserOptions::kMaxExpressionDepthDefault - 1)));
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr(chain(ParserOptions::kMaxExpressionDepthDefault)),
+      "Expression exceeds maximum nesting depth");
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

A deeply nested expression caused the coordinator to crash with a stack overflow. For example, a long chain like:

```sql
SELECT count(*) FROM t WHERE x = 0 OR x = 1 OR x = 2 OR ...
```

causes the planner to recurse once per operand, eventually exhausting the thread stack. Because C++ can't catch a stack overflow, the process dies with a SIGSEGV instead of returning an error.

This change adds a depth counter to `ExpressionPlanner::toExpr`: once the nesting exceeds the configured limit, the query fails with `Expression exceeds maximum nesting depth` rather than continuing to recurse until the stack is exhausted. The limit is a session config property, `max_expression_depth` (default 256), so it can be tuned without a code change. The guard applies only to `toExpr`; other recursive stages (AST construction, relational planning) will be handled in separate follow-ups.

Note: Although AST construction recurses first, the crash is in toExpr, not AST build. This is because toExpr does far more per level (type resolution, building expression objects), and its frames use more stack.

Reviewed By: mbasmanova

Differential Revision: D112548210


