### PR TITLE
feat(sql): Flatten OR/AND chains into one n-ary call (#1608)

### DIFF
--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -892,16 +892,32 @@ lp::ExprApi ExpressionPlanner::toExpr(
 
     case NodeType::kLogicalBinaryExpression: {
       auto* logical = node->as<LogicalBinaryExpression>();
-      auto left = toExpr(logical->left(), options);
-      auto right = toExpr(logical->right(), options);
+      const auto op = logical->op();
 
-      switch (logical->op()) {
-        case LogicalBinaryExpression::Operator::kAnd:
-          return left && right;
-
-        case LogicalBinaryExpression::Operator::kOr:
-          return left || right;
+      // Flatten a same-operator left-deep chain into one n-ary call. AND/OR
+      // parse left-associatively, so same-op chains nest on the left spine.
+      std::vector<const LogicalBinaryExpression*> chain{logical};
+      while (auto* leftBinary =
+                 chain.back()->left()->as<LogicalBinaryExpression>()) {
+        if (leftBinary->op() != op) {
+          break;
+        }
+        chain.push_back(leftBinary);
       }
+
+      std::vector<lp::ExprApi> operands;
+      operands.reserve(chain.size() + 1);
+      operands.push_back(toExpr(chain.back()->left(), options));
+      for (auto it = chain.rbegin(); it != chain.rend(); ++it) {
+        operands.push_back(toExpr((*it)->right(), options));
+      }
+      switch (op) {
+        case LogicalBinaryExpression::Operator::kAnd:
+          return lp::Call("and", std::move(operands));
+        case LogicalBinaryExpression::Operator::kOr:
+          return lp::Call("or", std::move(operands));
+      }
+      VELOX_UNREACHABLE();
     }
 
     case NodeType::kArithmeticUnaryExpression: {

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -782,6 +782,16 @@ TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
 lp::ExprApi ExpressionPlanner::toExpr(
     const ExpressionPtr& node,
     ExprOptions options) {
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      exprDepth_ < maxExpressionDepth_,
+      node->location(),
+      /*token=*/std::nullopt,
+      "statement is too large");
+  ++exprDepth_;
+  SCOPE_EXIT {
+    --exprDepth_;
+  };
+
   switch (node->type()) {
     case NodeType::kIdentifier: {
       auto name = canonicalizeIdentifier(*node->as<Identifier>());

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -20,10 +20,9 @@
 #include <unordered_map>
 #include <unordered_set>
 
-#include <folly/container/F14Map.h>
-
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/sql/presto/ParserOptions.h"
 #include "axiom/sql/presto/ast/AstNodesAll.h"
 
 namespace axiom::sql::presto {
@@ -109,12 +108,14 @@ class ExpressionPlanner {
       SubqueryPlanner subqueryPlanner,
       SortingKeyResolver sortingKeyResolver,
       ShouldDropQualifier shouldDropQualifier = nullptr,
-      ColumnResolver columnResolver = nullptr)
+      ColumnResolver columnResolver = nullptr,
+      uint32_t maxExpressionDepth = ParserOptions::kMaxExpressionDepthDefault)
       : user_{std::move(user)},
         subqueryPlanner_(std::move(subqueryPlanner)),
         sortingKeyResolver_(std::move(sortingKeyResolver)),
         shouldDropQualifier_(std::move(shouldDropQualifier)),
-        columnResolver_(std::move(columnResolver)) {}
+        columnResolver_(std::move(columnResolver)),
+        maxExpressionDepth_{maxExpressionDepth} {}
 
   /// Finds WindowCallExpr nodes nested inside non-window expressions.
   /// Skips top-level window projections (where the ExprApi itself is a
@@ -132,6 +133,7 @@ class ExpressionPlanner {
   /// Translates an AST expression into an ExprApi. Aggregate options
   /// (DISTINCT, FILTER, ORDER BY) are embedded in the returned ExprApi via
   /// AggregateCallExpr. Window functions are embedded via WindowCallExpr.
+  /// Fails with "statement is too large" when the expression nests too deeply.
   lp::ExprApi toExpr(const ExpressionPtr& node, ExprOptions options = {});
 
   /// Sets alias-to-expression mappings for lateral column alias resolution.
@@ -243,6 +245,9 @@ class ExpressionPlanner {
   ShouldDropQualifier shouldDropQualifier_;
   ColumnResolver columnResolver_;
 
+  // Cap on toExpr recursion depth.
+  const uint32_t maxExpressionDepth_;
+
   // Per-query cache for user-defined type lookups. Entries with nullptr values
   // represent negatively cached (not-found) types.
   folly::F14FastMap<std::string, facebook::velox::TypePtr> typeCache_;
@@ -265,6 +270,9 @@ class ExpressionPlanner {
   // the qualifier of 'x.field' when 'x' names a lambda parameter rather than
   // an outer table alias.
   std::vector<std::string> lambdaParamScope_;
+
+  // Current toExpr recursion depth, bounded by maxExpressionDepth_.
+  uint32_t exprDepth_{0};
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/ParserOptions.cpp
+++ b/axiom/sql/presto/ParserOptions.cpp
@@ -17,6 +17,7 @@
 #include "axiom/sql/presto/ParserOptions.h"
 
 #include <fmt/format.h>
+#include <folly/Conv.h>
 
 #include "velox/common/base/Exceptions.h"
 
@@ -43,6 +44,13 @@ std::vector<ConfigProperty> buildProperties(
           fmt::to_string(ParserOptions::kParseDecimalLiteralAsDoubleDefault),
           "Parse decimal literals (e.g. 1.5) as DOUBLE. When false, parse as "
           "DECIMAL with inferred precision and scale.",
+      },
+      {
+          std::string(ParserOptions::kMaxExpressionDepth),
+          ConfigPropertyType::kInteger,
+          fmt::to_string(ParserOptions::kMaxExpressionDepthDefault),
+          "Maximum expression nesting depth before parsing fails with "
+          "\"statement is too large\", to avoid a stack overflow.",
       },
   };
 
@@ -88,10 +96,17 @@ ParserOptions ParserOptions::from(
       field = it->second == "true";
     }
   };
+  auto setUint32 = [&](std::string_view key, uint32_t& field) {
+    auto it = properties.find(key);
+    if (it != properties.end()) {
+      field = folly::to<uint32_t>(it->second);
+    }
+  };
 
   ParserOptions options;
   setBool(kFriendlySql, options.friendlySql);
   setBool(kParseDecimalLiteralAsDouble, options.parseDecimalLiteralAsDouble);
+  setUint32(kMaxExpressionDepth, options.maxExpressionDepth);
   return options;
 }
 

--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -31,9 +32,12 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   static constexpr std::string_view kFriendlySql = "friendly_sql";
   static constexpr std::string_view kParseDecimalLiteralAsDouble =
       "parse_decimal_literal_as_double";
+  static constexpr std::string_view kMaxExpressionDepth =
+      "max_expression_depth";
 
   static constexpr bool kFriendlySqlDefault = true;
   static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
+  static constexpr uint32_t kMaxExpressionDepthDefault = 256;
 
   ParserOptions();
 
@@ -50,6 +54,10 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   /// from the literal. Matches Presto's decimal_literal_result_type session
   /// property.
   bool parseDecimalLiteralAsDouble{kParseDecimalLiteralAsDoubleDefault};
+
+  /// Maximum expression nesting depth; deeper expressions fail with
+  /// "statement is too large" to avoid a stack overflow.
+  uint32_t maxExpressionDepth{kMaxExpressionDepthDefault};
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "friendly_sql").

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -30,6 +30,7 @@
 #include "axiom/sql/presto/DisplayNames.h"
 #include "axiom/sql/presto/ExpressionPlanner.h"
 #include "axiom/sql/presto/GroupByPlanner.h"
+#include "axiom/sql/presto/ParserOptions.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/RecursiveCteValidator.h"
 #include "axiom/sql/presto/ShowStatsBuilder.h"
@@ -256,7 +257,8 @@ class RelationPlanner : public AstVisitor {
       const std::string& defaultSchema,
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
           std::string_view /*sql*/)>& parseSql,
-      bool friendlySql = true)
+      bool friendlySql = true,
+      uint32_t maxExpressionDepth = ParserOptions::kMaxExpressionDepthDefault)
       : context_{makePrestoContext(
             user,
             defaultConnectorId,
@@ -266,6 +268,7 @@ class RelationPlanner : public AstVisitor {
         parseSql_{parseSql},
         user_{std::move(user)},
         builder_(newBuilder()),
+        maxExpressionDepth_{maxExpressionDepth},
         friendlySql_{friendlySql} {}
 
   static lp::PlanBuilder::Context makePrestoContext(
@@ -1587,6 +1590,7 @@ class RelationPlanner : public AstVisitor {
       parseSql_;
   const std::string user_;
   std::shared_ptr<lp::PlanBuilder> builder_;
+  uint32_t maxExpressionDepth_;
   ExpressionPlanner exprPlanner_{
       user_,
       [this](Query* query) { return planSubquery(query); },
@@ -1602,7 +1606,8 @@ class RelationPlanner : public AstVisitor {
       [this](const std::string& first, const std::string& second) {
         return builder_->hasColumn(first) ||
             builder_->hasQualifiedColumn(first, second);
-      }};
+      },
+      maxExpressionDepth_};
   CteScope ctes_;
   ViewMap views_;
   std::unordered_set<facebook::axiom::CatalogSchemaTableName> inputTables_;
@@ -3092,7 +3097,8 @@ SqlStatementPtr doPlan(
         defaultConnectorId,
         defaultSchema,
         parseSql,
-        parserSession->options().friendlySql);
+        parserSession->options().friendlySql,
+        parserSession->options().maxExpressionDepth);
     query->accept(&planner);
     return std::make_shared<SelectStatement>(
         planner.plan(),

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1113,5 +1113,55 @@ TEST_F(ExpressionParserTest, expressionDepthCapBoundary) {
       parseExpr(chain(256)), "statement is too large");
 }
 
+// A chain past the expression-depth cap flattens to one n-ary call and plans;
+// unflattened it would recurse over the cap.
+TEST_F(ExpressionParserTest, deepOrChainFlattensToNaryCall) {
+  const uint32_t termCount = ParserOptions::kMaxExpressionDepthDefault + 1;
+  std::string sql = "1 = 0";
+  for (uint32_t i = 1; i < termCount; ++i) {
+    sql += " OR 1 = " + std::to_string(i);
+  }
+  auto expr = parseExpr(sql);
+  ASSERT_TRUE(expr->isSpecialForm());
+  auto* orExpr = expr->as<lp::SpecialFormExpr>();
+  EXPECT_EQ(lp::SpecialForm::kOr, orExpr->form());
+  EXPECT_EQ(termCount, orExpr->inputs().size());
+}
+
+// AND flattens like OR into one n-ary call.
+TEST_F(ExpressionParserTest, andChainFlattensToNaryCall) {
+  auto expr = parseExpr("1 = 0 AND 2 = 0 AND 3 = 0");
+  ASSERT_TRUE(expr->isSpecialForm());
+  auto* andExpr = expr->as<lp::SpecialFormExpr>();
+  EXPECT_EQ(lp::SpecialForm::kAnd, andExpr->form());
+  EXPECT_EQ(3, andExpr->inputs().size());
+}
+
+// Regression guard: a different operator on the chain's left child stops the
+// flatten, so the nested AND stays nested instead of merging into the OR.
+TEST_F(ExpressionParserTest, mixedOperatorsNotFlattenedTogether) {
+  auto expr = parseExpr("1 = 0 AND 2 = 0 OR 3 = 0");
+  ASSERT_TRUE(expr->isSpecialForm());
+  auto* orExpr = expr->as<lp::SpecialFormExpr>();
+  EXPECT_EQ(lp::SpecialForm::kOr, orExpr->form());
+  ASSERT_EQ(2, orExpr->inputs().size());
+  ASSERT_TRUE(orExpr->inputAt(0)->isSpecialForm());
+  EXPECT_EQ(
+      lp::SpecialForm::kAnd,
+      orExpr->inputAt(0)->as<lp::SpecialFormExpr>()->form());
+}
+
+// Flattening preserves the operands' original left-to-right order.
+TEST_F(ExpressionParserTest, flattenPreservesOperandOrder) {
+  auto expr = parseExpr("1 = 2 OR 3 = 4 OR 5 = 6");
+  ASSERT_TRUE(expr->isSpecialForm());
+  auto* orExpr = expr->as<lp::SpecialFormExpr>();
+  EXPECT_EQ(lp::SpecialForm::kOr, orExpr->form());
+  ASSERT_EQ(3, orExpr->inputs().size());
+  EXPECT_EQ("eq(1, 2)", orExpr->inputAt(0)->toString());
+  EXPECT_EQ("eq(3, 4)", orExpr->inputAt(1)->toString());
+  EXPECT_EQ("eq(5, 6)", orExpr->inputAt(2)->toString());
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1100,5 +1100,18 @@ TEST_F(ExpressionParserTest, mixedCaseColumnName) {
       "SELECT ORDERINGID FROM mixedCase", matchScan().project().output()));
 }
 
+TEST_F(ExpressionParserTest, expressionDepthCapBoundary) {
+  auto chain = [](int terms) {
+    std::string expr = "1";
+    for (int i = 0; i < terms; ++i) {
+      expr += " + 0";
+    }
+    return expr;
+  };
+  EXPECT_NE(nullptr, parseExpr(chain(255)));
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr(chain(256)), "statement is too large");
+}
+
 } // namespace
 } // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

A long same-operator boolean chain like

    SELECT * FROM t WHERE x = 0 OR x = 1 OR x = 2 OR ...

failed at the parent diff's depth cap, because `ExpressionPlanner::toExpr` recursed once per term. This flattens a same-operator left-deep OR/AND chain into a single n-ary `and`/`or` call — collected iteratively, each operand translated once — so it costs no recursion frame per term and now plans. Only left-deep chains flatten; `a OR (b OR c)` still recurses per term, and the chain's depth is then bounded by the AST-walk (`AstBuilder`), a separate follow-up.

Differential Revision: D112591812


