### PR TITLE
fix(optimizer): Honor remoteOutput for TableWrite in v2

### DIFF
--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -496,8 +496,21 @@ class PlanMatcherBuilder {
   /// Cannot be used with match(PlanNodePtr) - use match(MultiFragmentPlan).
   PlanMatcherBuilder& shuffle();
 
+  /// Marks a shuffle boundary (see shuffle()) only when 'condition' is true;
+  /// otherwise a no-op.
+  PlanMatcherBuilder& shuffleIf(bool condition) {
+    return condition ? shuffle() : *this;
+  }
+
   /// Matches a PartitionedOutput node with a single partition.
   PlanMatcherBuilder& partitionedOutputSingle();
+
+  /// Adds a single-partition PartitionedOutput matcher (see
+  /// partitionedOutputSingle()) only when 'condition' is true; otherwise a
+  /// no-op.
+  PlanMatcherBuilder& partitionedOutputSingleIf(bool condition) {
+    return condition ? partitionedOutputSingle() : *this;
+  }
 
   /// Marks a shuffle boundary with verification of partition keys.
   /// @param keys Expected partition key column names. Supports symbol rewriting
@@ -507,6 +520,15 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& shuffle(
       const std::vector<std::string>& keys,
       bool replicateNullsAndAny = false);
+
+  /// Marks a shuffle boundary with partition keys (see shuffle(keys,
+  /// replicateNullsAndAny)) only when 'condition' is true; otherwise a no-op.
+  PlanMatcherBuilder& shuffleIf(
+      bool condition,
+      const std::vector<std::string>& keys,
+      bool replicateNullsAndAny = false) {
+    return condition ? shuffle(keys, replicateNullsAndAny) : *this;
+  }
 
   /// Marks an ordered shuffle boundary (uses MergeExchange instead of
   /// Exchange). In a distributed plan:

--- a/axiom/optimizer/tests/RemoteOutputTest.cpp
+++ b/axiom/optimizer/tests/RemoteOutputTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "axiom/logical_plan/PlanBuilder.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 
@@ -86,9 +87,7 @@ TEST_P(RemoteOutputTest, globalAggregation) {
         {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
 
     auto builder = matchScan("t").distributedAggregation({}, {"sum(b)"});
-    if (remoteOutput) {
-      builder.partitionedOutputSingle();
-    }
+    builder.partitionedOutputSingleIf(remoteOutput);
 
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, builder.build());
   }
@@ -174,6 +173,39 @@ TEST_P(RemoteOutputTest, sameColumnTwice) {
         builder.project().gather().project();
       }
     }
+
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, builder.build());
+  }
+}
+
+TEST_P(RemoteOutputTest, tableWrite) {
+  testConnector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+  testConnector_->addTable("w", ROW({"a", "b"}, BIGINT()));
+
+  auto logicalPlan =
+      lp::PlanBuilder(lp::PlanBuilder::Context(kTestConnectorId, "default"))
+          .tableScan("t")
+          .tableWrite("w", lp::WriteKind::kInsert, {"a", "b"})
+          .build();
+
+  for (bool remoteOutput : {false, true}) {
+    SCOPED_TRACE(remoteOutput ? "remoteOutput=true" : "remoteOutput=false");
+    auto plan = planVelox(
+        logicalPlan,
+        {.numWorkers = 2, .numDrivers = 2, .remoteOutput = remoteOutput});
+
+    auto builder = matchScan("t").tableWrite().localGather().tableWriteMerge();
+    // v2 always runs the final TableWriteMerge on a separate coordinator
+    // fragment fed by a shuffle. v1 does the same unless it collocates the
+    // whole write in a single fragment, which it does when remote output caps
+    // that fragment with a PartitionedOutput.
+    builder.shuffleIf(useV2_ || !remoteOutput).tableWriteMerge();
+
+    // With remote output the output fragment's root is capped by a single
+    // PartitionedOutputNode so the written-row count can be consumed remotely.
+    // Without this cap the streaming scheduler rejects the plan (the output
+    // fragment must be rooted at a PartitionedOutputNode).
+    builder.partitionedOutputSingleIf(remoteOutput);
 
     AXIOM_ASSERT_DISTRIBUTED_PLAN(plan.plan, builder.build());
   }

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -2051,12 +2051,22 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
   velox::core::PlanNodePtr outputProjection;
 
   if (root->is(NodeType::kTableWrite)) {
-    // A table write is a root sink: emit it (and its gathered input) directly
-    // as the single root fragment. Its output is the write-stats row the runner
+    // A table write is a root sink: emit it (and its gathered input) as the
+    // single root fragment. Its output is the write-stats row the runner
     // interprets via FinishWrite, not a user column layout, so it takes no
-    // output-rename projection.
+    // output-rename projection. Like the other roots, cap the output fragment
+    // with a single PartitionedOutput when results are consumed remotely, so
+    // the runner reads the stats rows from a PartitionedOutput as it does for
+    // every other fragment; otherwise emit the write directly.
     currentFragment_ = &top;
-    top.fragment.planNode = emit(root);
+    velox::core::PlanNodePtr writePlan = emit(root);
+    if (options_.remoteOutput) {
+      outputProjection = writePlan;
+      top.fragment.planNode =
+          makeSingleOutput(writePlan->outputType(), writePlan);
+    } else {
+      top.fragment.planNode = writePlan;
+    }
   } else {
     // A root whose subtree already runs on one task (e.g. below a global ORDER
     // BY or aggregate) needs no output gather and is emitted directly, like the


### PR DESCRIPTION
Summary: A distributed plan rooted at a `TableWrite` was rejected by the streaming scheduler when its results are consumed remotely. The scheduler requires the output fragment to be rooted at a `PartitionedOutputNode`, but the write was emitted without one. The v2 optimizer now caps the write's output fragment with a single-partition `PartitionedOutput` when `remoteOutput` is set. The runner then reads the write-stats rows from it, just as it does for every other root fragment.

Reviewed By: mbasmanova

Differential Revision: D112653383


