### PR TITLE
feat: Inline SQL-invoked functions (#1612)

### DIFF
--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(
   CatalogSchemaTableName.cpp
   ConfigRegistry.cpp
   QueryRuntimeStats.cpp
+  SchemaFunctionName.cpp
   SchemaTableName.cpp
   SchemaTypeName.cpp
   SessionConfig.cpp

--- a/axiom/common/SchemaFunctionName.cpp
+++ b/axiom/common/SchemaFunctionName.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/common/SchemaFunctionName.h"
+
+#include <fmt/core.h>
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::axiom {
+
+std::string SchemaFunctionName::toString() const {
+  return fmt::format("{}", *this);
+}
+
+} // namespace facebook::axiom
+
+size_t std::hash<facebook::axiom::SchemaFunctionName>::operator()(
+    const facebook::axiom::SchemaFunctionName& name) const {
+  auto hash = folly::hasher<std::string>{}(name.function);
+  hash = facebook::velox::bits::hashMix(
+      hash, folly::hasher<std::string>{}(name.schema));
+  return hash;
+}

--- a/axiom/common/SchemaFunctionName.h
+++ b/axiom/common/SchemaFunctionName.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include <fmt/format.h>
+#include <ostream>
+
+namespace facebook::axiom {
+
+/// Structured representation of a schema-qualified function name.
+/// Parallels SchemaTypeName for connector-provided SQL-invoked functions.
+struct SchemaFunctionName {
+  std::string schema;
+  std::string function;
+
+  /// Returns "schema.function" for display/logging only.
+  std::string toString() const;
+
+  bool operator==(const SchemaFunctionName&) const = default;
+};
+
+// Used by gtest to print values in assertion failures.
+inline std::ostream& operator<<(
+    std::ostream& os,
+    const SchemaFunctionName& name) {
+  return os << name.toString();
+}
+
+} // namespace facebook::axiom
+
+template <>
+struct std::hash<facebook::axiom::SchemaFunctionName> {
+  size_t operator()(const facebook::axiom::SchemaFunctionName& name) const;
+};
+
+template <>
+struct fmt::formatter<facebook::axiom::SchemaFunctionName>
+    : fmt::formatter<std::string_view> {
+  auto format(
+      const facebook::axiom::SchemaFunctionName& name,
+      format_context& ctx) const {
+    return fmt::format_to(ctx.out(), "{}.{}", name.schema, name.function);
+  }
+};

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -17,6 +17,7 @@
 
 #include <functional>
 #include "axiom/common/Enums.h"
+#include "axiom/common/SchemaFunctionName.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/common/SchemaTypeName.h"
 #include "axiom/connectors/ConnectorSession.h"
@@ -902,6 +903,39 @@ struct PushdownRoot {
   TablePtr table;
 };
 
+/// One overload of a SQL-invoked function resolved from a connector, e.g. a
+/// portable UDF from an external function registry. The caller inlines the body
+/// at the call site (the connector does not parse it), so the function leaves
+/// no call node in the plan.
+struct SqlFunctionDefinition {
+  /// Declared result type. Carried rather than derived from 'body' because it
+  /// may be wider than the body's inferred type: the caller casts (widens) the
+  /// resolved body to it. The defining connector guarantees the body type is
+  /// coercible to this type.
+  velox::TypePtr returnType;
+
+  /// Formal argument names, positionally aligned with 'argumentTypes'. Bind
+  /// the call's arguments to matching references inside 'body'.
+  std::vector<std::string> argumentNames;
+
+  /// Formal argument types. Used to select among overloads.
+  std::vector<velox::TypePtr> argumentTypes;
+
+  /// SQL expression over 'argumentNames', in the dialect of the defining
+  /// connector. Each connector documents the single SQL dialect it supports;
+  /// callers parse 'body' according to that documentation.
+  std::string body;
+
+  /// Whether a null in any argument forces a null result without evaluating the
+  /// body (Velox's defaultNullBehavior; SQL's RETURNS NULL ON NULL INPUT).
+  /// Carried explicitly because it cannot be recovered from 'body': it is a
+  /// property of the definition that dictates how the body is embedded. When
+  /// true, the caller guards the inlined body to yield null on a null argument.
+  bool defaultNullBehavior{true};
+};
+
+using SqlFunctionDefinitionPtr = std::shared_ptr<const SqlFunctionDefinition>;
+
 class ConnectorMetadata {
  public:
   /// Return the metadata for a given connector ID. Throws if not registered.
@@ -963,6 +997,17 @@ class ConnectorMetadata {
   /// @return nullptr if the type is not found.
   virtual velox::TypePtr findType(const SchemaTypeName& /*typeName*/) {
     return nullptr;
+  }
+
+  /// Finds all overloads of a SQL-invoked function by schema-qualified name.
+  /// Connectors that serve externally-defined SQL functions (e.g. portable
+  /// UDFs from a function registry) override this. Callers select among the
+  /// returned overloads by argument type and inline the chosen body.
+  ///
+  /// @return empty if the function is not found.
+  virtual std::vector<SqlFunctionDefinitionPtr> findFunction(
+      const SchemaFunctionName& /*functionName*/) {
+    return {};
   }
 
   /// EXPERIMENTAL. Opt-in gate for connector pushdown. Default false.

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -561,6 +561,28 @@ void TestConnectorMetadata::addType(
   VELOX_CHECK(inserted, "Type already registered: {}", typeName);
 }
 
+std::vector<SqlFunctionDefinitionPtr> TestConnectorMetadata::findFunction(
+    const SchemaFunctionName& functionName) {
+  auto it = functions_.find(functionName);
+  if (it == functions_.end()) {
+    return {};
+  }
+  return {it->second};
+}
+
+void TestConnectorMetadata::addFunction(
+    const SchemaFunctionName& functionName,
+    SqlFunctionDefinition definition) {
+  VELOX_CHECK(
+      schemas_.contains(functionName.schema),
+      "Schema not found: {}",
+      functionName.schema);
+  auto [_, inserted] = functions_.emplace(
+      functionName,
+      std::make_shared<const SqlFunctionDefinition>(std::move(definition)));
+  VELOX_CHECK(inserted, "Function already registered: {}", functionName);
+}
+
 ViewPtr TestConnectorMetadata::findView(const SchemaTableName& tableName) {
   auto it = views_.find(tableName);
   if (it == views_.end()) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -619,6 +619,15 @@ class TestConnectorMetadata : public ConnectorMetadata {
   /// with the same name is already registered.
   void addType(const SchemaTypeName& typeName, velox::TypePtr type);
 
+  std::vector<SqlFunctionDefinitionPtr> findFunction(
+      const SchemaFunctionName& functionName) override;
+
+  /// Registers a SQL-invoked function for findFunction() resolution. Throws if
+  /// a function with the same name is already registered.
+  void addFunction(
+      const SchemaFunctionName& functionName,
+      SqlFunctionDefinition definition);
+
   ViewPtr findView(const SchemaTableName& tableName) override;
 
   /// Register a view with the given name, output schema, and SQL text.
@@ -667,6 +676,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
 
   folly::F14FastSet<std::string> schemas_{"default"};
   folly::F14FastMap<SchemaTypeName, velox::TypePtr> types_;
+  folly::F14FastMap<SchemaFunctionName, SqlFunctionDefinitionPtr> functions_;
 };
 
 /// At DataSource creation time, the data contained in the corresponding Table

--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 #include "axiom/logical_plan/ExprResolver.h"
+
+#include <folly/ScopeGuard.h>
+#include <folly/container/F14Map.h>
+
 #include "axiom/logical_plan/ExprApi.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "velox/exec/Aggregate.h"
@@ -737,7 +741,139 @@ int32_t parseLegacyRowFieldOrdinal(
   return ordinal;
 }
 
+bool containsSubquery(const ExprPtr& expr) {
+  if (expr->isSubquery()) {
+    return true;
+  }
+  for (const auto& input : expr->inputs()) {
+    if (containsSubquery(input)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 } // namespace
+
+ExprPtr ExprResolver::resolveSqlFunction(
+    const std::string& name,
+    const std::vector<ExprPtr>& inputs) const {
+  if (sqlFunctionResolver_ == nullptr) {
+    return nullptr;
+  }
+
+  // Reject recursion before the potentially expensive resolver call: a name in
+  // 'inliningFunctions_' is a SQL function whose body is currently being
+  // resolved, so re-entry is a recursive reference.
+  VELOX_USER_CHECK(
+      !inliningFunctions_.contains(name),
+      "Recursive SQL function is not supported: {}",
+      name);
+
+  auto resolved = sqlFunctionResolver_(name, toTypes(inputs));
+  if (!resolved.has_value()) {
+    return nullptr;
+  }
+
+  // The resolver selects an overload matching the call's argument count, and
+  // returns names and types 1:1, so a mismatch is an internal contract
+  // violation, not a user error.
+  VELOX_CHECK_EQ(
+      resolved->argumentNames.size(),
+      inputs.size(),
+      "SQL function overload arity mismatch: {}",
+      name);
+  VELOX_CHECK_EQ(
+      resolved->argumentTypes.size(),
+      resolved->argumentNames.size(),
+      "SQL function has mismatched argument names and types: {}",
+      name);
+
+  inliningFunctions_.insert(name);
+  SCOPE_EXIT {
+    inliningFunctions_.erase(name);
+  };
+
+  // Bind each argument, casting it to its declared type so the body operates on
+  // the declared types (e.g. int -> bigint). The resolver already matched the
+  // call to the signature and verified coercibility, so this only applies the
+  // cast and cannot fail here.
+  std::vector<ExprPtr> args;
+  args.reserve(inputs.size());
+  folly::F14FastMap<std::string, ExprPtr> bindings;
+  for (size_t i = 0; i < inputs.size(); ++i) {
+    auto arg = inputs[i]->type()->equivalent(*resolved->argumentTypes[i])
+        ? inputs[i]
+        : std::make_shared<SpecialFormExpr>(
+              resolved->argumentTypes[i], SpecialForm::kCast, inputs[i]);
+    VELOX_USER_CHECK(
+        bindings.emplace(resolved->argumentNames[i], arg).second,
+        "Duplicate argument name in SQL function: {}: {}",
+        resolved->argumentNames[i],
+        name);
+    args.push_back(arg);
+  }
+
+  // A body identifier must be one of the function's arguments; nested
+  // SQL-invoked functions in the body recurse through resolveScalarTypes.
+  folly::F14FastSet<std::string> usedArguments;
+  auto argumentResolver = [&](const std::optional<std::string>& alias,
+                              const std::string& fieldName) -> ExprPtr {
+    // An alias-qualified reference is struct field access on an argument (a
+    // function body has no table aliases); returning nullptr lets
+    // resolveScalarTypes dereference the argument instead.
+    if (alias.has_value()) {
+      return nullptr;
+    }
+    auto it = bindings.find(fieldName);
+    VELOX_USER_CHECK(
+        it != bindings.end(),
+        "Unknown identifier in SQL function body: {}: {}",
+        fieldName,
+        name);
+    usedArguments.insert(fieldName);
+    return it->second;
+  };
+
+  auto body = resolveScalarTypes(resolved->body, argumentResolver);
+
+  // A subquery in the body would carry argument references that bypass
+  // 'argumentResolver' -- they would be neither substituted nor counted below.
+  VELOX_USER_CHECK(
+      !containsSubquery(body),
+      "Subqueries in SQL function bodies are not supported: {}",
+      name);
+
+  // Every argument must appear in the body; otherwise inlining would drop the
+  // corresponding argument's evaluation.
+  VELOX_USER_CHECK_EQ(
+      usedArguments.size(),
+      bindings.size(),
+      "SQL function does not use all of its arguments: {}",
+      name);
+
+  // Cast the body to the declared return type. The connector should guarantee
+  // coercibility; verify it so an inconsistent definition fails cleanly here
+  // instead of emitting an invalid cast.
+  if (!body->type()->equivalent(*resolved->returnType)) {
+    VELOX_USER_CHECK(
+        coercer_->coerce(body->type(), resolved->returnType).has_value(),
+        "SQL function body is not coercible to its declared return type: {} to {}: {}",
+        body->type()->toString(),
+        resolved->returnType->toString(),
+        name);
+    body = std::make_shared<SpecialFormExpr>(
+        resolved->returnType, SpecialForm::kCast, body);
+  }
+
+  // TODO: Skip the wrapper when the resolved body already propagates nulls from
+  // every argument (needs null-propagation analysis over the resolved body).
+  if (resolved->nullWrapper) {
+    body = resolved->nullWrapper(body, args);
+  }
+
+  return body;
+}
 
 ExprPtr ExprResolver::resolveScalarTypes(
     const velox::core::ExprPtr& expr,
@@ -832,6 +968,10 @@ ExprPtr ExprResolver::resolveScalarTypes(
         return folded;
       }
       return specialForm;
+    }
+
+    if (auto inlined = resolveSqlFunction(name, inputs)) {
+      return inlined;
     }
 
     auto type = resolveScalarFunction(name, inputs, coercer_);

--- a/axiom/logical_plan/ExprResolver.h
+++ b/axiom/logical_plan/ExprResolver.h
@@ -15,6 +15,10 @@
  */
 #pragma once
 
+#include <optional>
+
+#include <folly/container/F14Set.h>
+
 #include "axiom/logical_plan/Expr.h"
 #include "axiom/logical_plan/ExprApi.h"
 #include "velox/core/ITypedExpr.h"
@@ -47,6 +51,52 @@ class ExprResolver {
   using FunctionRewriteHook = std::function<
       ExprPtr(const std::string& name, const std::vector<ExprPtr>& args)>;
 
+  /// Wraps a resolved SQL-function body so a null in any argument yields null
+  /// without evaluating the body. Receives the resolved body (already coerced
+  /// to the result type) and the coerced argument expressions; returns the
+  /// wrapped body. The frontend supplies it so the dialect-specific null test
+  /// (e.g. is_null) stays out of this layer.
+  using NullWrapper = std::function<
+      ExprPtr(const ExprPtr& body, const std::vector<ExprPtr>& args)>;
+
+  /// A SQL-invoked function selected for a call, resolved into the untyped body
+  /// to inline plus the metadata needed to embed it. Produced by the frontend
+  /// that owns a SQL parser for the defining connector's dialect; consumed by
+  /// resolveScalarTypes, which coerces and binds the call's arguments and
+  /// resolves the body.
+  struct ResolvedSqlFunction {
+    /// Formal argument names, positionally aligned with 'argumentTypes'.
+    std::vector<std::string> argumentNames;
+
+    /// Formal argument types. The call's arguments are coerced to these before
+    /// binding, so the body sees the declared types (e.g. int -> bigint).
+    std::vector<velox::TypePtr> argumentTypes;
+
+    /// Untyped scalar body expression over 'argumentNames', parsed from the
+    /// connector's SQL by the frontend. Must not contain subqueries.
+    velox::core::ExprPtr body;
+
+    /// Declared result type; the resolved body is implicitly coerced to it.
+    velox::TypePtr returnType;
+
+    /// Wraps the resolved body for RETURNS NULL ON NULL INPUT, or null when the
+    /// function is called on null input (no wrapping). Applied after argument
+    /// binding and return-type coercion.
+    NullWrapper nullWrapper;
+  };
+
+  /// Resolves a call to a SQL-invoked (inlined) function by name and argument
+  /// types, or returns nullopt if 'name' is not a SQL-invoked function.
+  /// Argument types select among overloads. If 'name' is a SQL-invoked function
+  /// but no overload accepts 'argTypes', the resolver fails with a user error
+  /// rather than returning nullopt (which would surface as a misleading
+  /// function-not-found error). Installed by the frontend, which resolves the
+  /// function against connectors and parses its body in the appropriate
+  /// dialect.
+  using SqlFunctionResolver = std::function<std::optional<ResolvedSqlFunction>(
+      const std::string& name,
+      const std::vector<velox::TypePtr>& argTypes)>;
+
   /// @param queryCtx Query context for constant folding.
   /// @param coercer Coercion rule set used for implicit type conversions,
   /// or nullptr to disable implicit coercions.
@@ -54,18 +104,23 @@ class ExprResolver {
   /// @param pool Memory pool for constant folding evaluation.
   /// @param planNodeIdGenerator Plan node ID generator for subquery
   /// expressions.
+  /// @param sqlFunctionResolver Optional resolver for SQL-invoked functions
+  /// inlined from connectors. Requires a non-null 'coercer', since inlining
+  /// coerces the arguments and body to their declared types.
   ExprResolver(
       std::shared_ptr<velox::core::QueryCtx> queryCtx,
       const velox::TypeCoercer* coercer,
       FunctionRewriteHook hook = nullptr,
       std::shared_ptr<velox::memory::MemoryPool> pool = nullptr,
       std::shared_ptr<velox::core::PlanNodeIdGenerator> planNodeIdGenerator =
-          nullptr)
+          nullptr,
+      SqlFunctionResolver sqlFunctionResolver = nullptr)
       : queryCtx_(std::move(queryCtx)),
         coercer_{coercer},
         hook_(std::move(hook)),
         pool_(std::move(pool)),
-        planNodeIdGenerator_{std::move(planNodeIdGenerator)} {}
+        planNodeIdGenerator_{std::move(planNodeIdGenerator)},
+        sqlFunctionResolver_{std::move(sqlFunctionResolver)} {}
 
   /// Resolves an untyped scalar expression into a typed expression. Handles
   /// column references, function calls, casts, literals, lambdas, and
@@ -148,6 +203,14 @@ class ExprResolver {
       const std::shared_ptr<const velox::core::CallExpr>& callExpr,
       const InputNameResolver& inputNameResolver) const;
 
+  // Resolves 'name'(inputs) as a SQL-invoked function inlined from a connector,
+  // or returns nullptr if 'name' is not such a function. Binds the argument
+  // names to 'inputs', resolves the body, and coerces it to the declared return
+  // type.
+  ExprPtr resolveSqlFunction(
+      const std::string& name,
+      const std::vector<ExprPtr>& inputs) const;
+
   // Resolves lambda arguments using already resolved non-lambda arguments.
   // Populates 'resolvedInputs' entries that correspond to lambda arguments.
   //
@@ -187,5 +250,14 @@ class ExprResolver {
   FunctionRewriteHook hook_;
   std::shared_ptr<velox::memory::MemoryPool> pool_;
   std::shared_ptr<velox::core::PlanNodeIdGenerator> planNodeIdGenerator_;
+  SqlFunctionResolver sqlFunctionResolver_;
+
+  // Names of SQL-invoked functions currently being inlined on the active
+  // resolveScalarTypes recursion, used to reject recursive definitions. This
+  // guard only catches recursion routed back through this same ExprResolver: it
+  // relies on sqlFunctionResolver_ returning an unresolved body that this
+  // instance resolves (nested SQL functions must not be resolved by a different
+  // ExprResolver). Resolution through a single ExprResolver is single-threaded.
+  mutable folly::F14FastSet<std::string> inliningFunctions_;
 };
 } // namespace facebook::axiom::logical_plan

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -137,6 +137,10 @@ class PlanBuilder {
     /// SQL function names to Velox runtime functions.
     ExprResolver::FunctionRewriteHook hook;
 
+    /// Resolves SQL-invoked (inlined) functions from connectors during
+    /// expression resolution. Optional; SQL frontends install it.
+    ExprResolver::SqlFunctionResolver sqlFunctionResolver;
+
     /// Provides memory for allocating literal values during constant folding.
     /// Automatically derived from queryCtx.
     std::shared_ptr<velox::memory::MemoryPool> pool;
@@ -223,7 +227,8 @@ class PlanBuilder {
             context.coercer,
             context.hook,
             context.pool,
-            context.planNodeIdGenerator} {
+            context.planNodeIdGenerator,
+            context.sqlFunctionResolver} {
     VELOX_CHECK_NOT_NULL(planNodeIdGenerator_);
     VELOX_CHECK_NOT_NULL(nameAllocator_);
   }

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1228,7 +1228,14 @@ lp::ExprApi ExpressionPlanner::toExpr(
         return toAggregateCallExpr(call, funcName, args, options);
       }
 
-      auto callExpr = lp::Call(funcName, args);
+      // A qualified (multi-part) name denotes a connector-defined SQL-invoked
+      // function. Encode it with a leading '.' so downstream resolution can
+      // distinguish it from a builtin; a plain builtin keeps its bare name.
+      auto callExpr = lp::Call(
+          call->name()->parts().size() > 1
+              ? "." + call->name()->fullyQualifiedName()
+              : funcName,
+          args);
 
       if (call->window() != nullptr) {
         auto windowSpec = convertWindow(call->window(), options);

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -17,6 +17,7 @@
 #include "axiom/sql/presto/PrestoParser.h"
 #include <folly/ScopeGuard.h>
 #include <folly/container/F14Map.h>
+#include <folly/container/small_vector.h>
 #include <folly/hash/Hash.h>
 #include <cctype>
 #include <unordered_set>
@@ -242,6 +243,11 @@ core::ExprPtr replaceInputs(
   return changed ? expr->replaceInputs(std::move(newInputs)) : expr;
 }
 
+lp::ExprResolver::SqlFunctionResolver makeSqlFunctionResolver(
+    std::string user,
+    std::function<std::shared_ptr<Statement>(std::string_view)> parseSql,
+    const TypeCoercer* coercer);
+
 class RelationPlanner : public AstVisitor {
  public:
   RelationPlanner(
@@ -251,7 +257,11 @@ class RelationPlanner : public AstVisitor {
       const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
           std::string_view /*sql*/)>& parseSql,
       bool friendlySql = true)
-      : context_{makePrestoContext(defaultConnectorId, defaultSchema)},
+      : context_{makePrestoContext(
+            user,
+            defaultConnectorId,
+            defaultSchema,
+            parseSql)},
         defaultSchema_{defaultSchema},
         parseSql_{parseSql},
         user_{std::move(user)},
@@ -259,8 +269,11 @@ class RelationPlanner : public AstVisitor {
         friendlySql_{friendlySql} {}
 
   static lp::PlanBuilder::Context makePrestoContext(
+      const std::string& user,
       const std::string& defaultConnectorId,
-      const std::string& defaultSchema) {
+      const std::string& defaultSchema,
+      const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
+          std::string_view /*sql*/)>& parseSql) {
     lp::PlanBuilder::Context ctx{
         defaultConnectorId,
         defaultSchema,
@@ -269,6 +282,8 @@ class RelationPlanner : public AstVisitor {
         std::make_shared<lp::ThrowingSqlExpressionsParser>(),
         &::facebook::velox::functions::prestosql::typeCoercer()};
     ctx.identifierCanonicalizer = &canonicalizeName;
+    ctx.sqlFunctionResolver =
+        makeSqlFunctionResolver(user, parseSql, ctx.coercer);
     return ctx;
   }
 
@@ -1738,6 +1753,144 @@ lp::ExprPtr PrestoParser::parseExpression(
 }
 
 namespace {
+
+// Parses a scalar SQL-function body into an untyped expression (a
+// velox::core::IExpr, not yet type-resolved) via 'parseSql' to reach the AST
+// and ExpressionPlanner to translate it. Argument binding and type resolution
+// happen later, when the enclosing call is resolved.
+core::ExprPtr parseFunctionBody(
+    const std::string& user,
+    const std::function<std::shared_ptr<Statement>(std::string_view)>& parseSql,
+    const std::string& body) {
+  auto statement = parseSql(fmt::format("SELECT {}", body));
+  auto* query = statement->as<Query>();
+  VELOX_USER_CHECK_NOT_NULL(query, "SQL function body is not an expression");
+  auto* spec = query->queryBody()->as<QuerySpecification>();
+  VELOX_USER_CHECK_NOT_NULL(spec, "SQL function body is not an expression");
+  const auto& items = spec->select()->selectItems();
+  VELOX_USER_CHECK_EQ(
+      items.size(), 1, "SQL function body is not a single expression");
+  auto* column = items[0]->as<SingleColumn>();
+  VELOX_USER_CHECK_NOT_NULL(column, "SQL function body is not an expression");
+
+  ExpressionPlanner exprPlanner{
+      user, /*subqueryPlanner=*/nullptr, /*sortingKeyResolver=*/nullptr};
+  return exprPlanner.toExpr(column->expression()).expr();
+}
+
+// Wraps a resolved SQL-function body for RETURNS NULL ON NULL INPUT as
+// IF(is_null(arg0) OR ... OR is_null(argN), NULL, body). Returns 'body'
+// unchanged for a zero-argument function. Installed as ResolvedSqlFunction's
+// nullWrapper so the dialect-specific is_null stays in the frontend.
+lp::ExprPtr wrapWithNullGuard(
+    const lp::ExprPtr& body,
+    const std::vector<lp::ExprPtr>& args) {
+  if (args.empty()) {
+    return body;
+  }
+
+  std::vector<lp::ExprPtr> anyNull;
+  anyNull.reserve(args.size());
+  for (const auto& arg : args) {
+    anyNull.push_back(
+        std::make_shared<lp::CallExpr>(BOOLEAN(), "is_null", arg));
+  }
+
+  lp::ExprPtr condition = anyNull.size() == 1
+      ? std::move(anyNull.front())
+      : std::make_shared<lp::SpecialFormExpr>(
+            BOOLEAN(), lp::SpecialForm::kOr, std::move(anyNull));
+
+  auto nullLiteral = std::make_shared<lp::ConstantExpr>(
+      body->type(),
+      std::make_shared<Variant>(Variant::null(body->type()->kind())));
+
+  return std::make_shared<lp::SpecialFormExpr>(
+      body->type(),
+      lp::SpecialForm::kIf,
+      std::move(condition),
+      std::move(nullLiteral),
+      body);
+}
+
+// Builds the resolver that inlines connector-defined SQL-invoked functions.
+// Only names that the frontend marked with a leading '.' are treated as
+// qualified function references; everything else returns nullopt so builtin
+// resolution proceeds.
+lp::ExprResolver::SqlFunctionResolver makeSqlFunctionResolver(
+    std::string user,
+    std::function<std::shared_ptr<Statement>(std::string_view)> parseSql,
+    const TypeCoercer* coercer) {
+  VELOX_CHECK_NOT_NULL(
+      coercer, "A coercer is required to inline SQL functions");
+  return [user = std::move(user), parseSql = std::move(parseSql), coercer](
+             const std::string& name, const std::vector<TypePtr>& argTypes)
+             -> std::optional<lp::ExprResolver::ResolvedSqlFunction> {
+    VELOX_CHECK(!name.empty(), "Function call has an empty name");
+    if (name.front() != '.') {
+      return std::nullopt;
+    }
+
+    folly::small_vector<std::string, 3> parts;
+    folly::split('.', std::string_view{name}.substr(1), parts);
+    VELOX_USER_CHECK_EQ(
+        parts.size(),
+        3,
+        "Qualified function name must be catalog.schema.function: {}",
+        name.substr(1));
+
+    auto metadata =
+        facebook::axiom::connector::ConnectorMetadataRegistry::tryGet(parts[0]);
+    VELOX_USER_CHECK_NOT_NULL(metadata, "Catalog not found: {}", parts[0]);
+
+    auto overloads =
+        metadata->findFunction({/*schema=*/parts[1], /*function=*/parts[2]});
+    VELOX_USER_CHECK(
+        !overloads.empty(), "SQL function not found: {}", name.substr(1));
+
+    // Multiple signatures for one name are not supported yet.
+    VELOX_USER_CHECK_EQ(
+        overloads.size(),
+        1,
+        "Overloaded SQL functions are not supported: {}",
+        name.substr(1));
+    const auto& definition = *overloads.front();
+
+    // Match the call to the signature: argument count, then each argument type
+    // coercible to its declared type. The resolver owns this matching, so the
+    // expression resolver only applies the coercion later, never re-checks it.
+    VELOX_USER_CHECK_EQ(
+        argTypes.size(),
+        definition.argumentTypes.size(),
+        "SQL function called with wrong number of arguments: {}",
+        name.substr(1));
+    for (size_t i = 0; i < argTypes.size(); ++i) {
+      const auto& declaredType = definition.argumentTypes[i];
+      if (argTypes[i]->equivalent(*declaredType)) {
+        continue;
+      }
+
+      VELOX_USER_CHECK(
+          coercer->coerce(argTypes[i], declaredType).has_value(),
+          "Cannot coerce SQL function argument {} to its declared type: {} to {}: {}",
+          i,
+          argTypes[i]->toString(),
+          declaredType->toString(),
+          name.substr(1));
+    }
+
+    lp::ExprResolver::ResolvedSqlFunction resolved;
+    resolved.argumentNames = definition.argumentNames;
+    resolved.argumentTypes = definition.argumentTypes;
+    resolved.returnType = definition.returnType;
+    resolved.body = parseFunctionBody(user, parseSql, definition.body);
+    if (definition.defaultNullBehavior) {
+      resolved.nullWrapper = wrapWithNullGuard;
+    }
+    return resolved;
+  };
+}
+
 lp::ExprPtr parseSqlExpression(
     const std::string& user,
     const ExpressionPtr& expr) {

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(
   ReferencedTablesTest.cpp
   SortParserTest.cpp
   SplitStatementsTest.cpp
+  SqlFunctionTest.cpp
   WithRecursiveTest.cpp
 )
 

--- a/axiom/sql/presto/tests/SqlFunctionTest.cpp
+++ b/axiom/sql/presto/tests/SqlFunctionTest.cpp
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace connector = facebook::axiom::connector;
+
+namespace {
+
+class SqlFunctionTest : public PrestoParserTestBase {
+ protected:
+  void SetUp() override {
+    PrestoParserTestBase::SetUp();
+    metadata_ = std::make_shared<connector::TestConnectorMetadata>(nullptr);
+    connector::ConnectorMetadataRegistry::global().insert("tc", metadata_);
+  }
+
+  void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase("tc");
+    metadata_.reset();
+    PrestoParserTestBase::TearDown();
+  }
+
+  std::shared_ptr<connector::TestConnectorMetadata> metadata_;
+};
+
+// A qualified call is replaced in place by its body, with each argument bound
+// to the call-site expression, in projections and predicates alike.
+TEST_F(SqlFunctionTest, inlines) {
+  // f(x) := x
+  metadata_->addFunction(
+      {"default", "identity"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x",
+          .defaultNullBehavior = false,
+      });
+  testSelect(
+      "SELECT tc.default.identity(n_nationkey) FROM nation",
+      matchScan("nation").project({"n_nationkey"}).output());
+
+  testSelect(
+      "SELECT tc.default.identity(123) FROM nation",
+      matchScan("nation").project({"123::bigint"}).output());
+
+  testSelect(
+      "SELECT tc.default.identity(n_nationkey + 123) FROM nation",
+      matchScan("nation").project({"n_nationkey + 123::bigint"}).output());
+
+  // f(a, b) := a + b
+  metadata_->addFunction(
+      {"default", "combine"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"a", "b"},
+          .argumentTypes = {BIGINT(), BIGINT()},
+          .body = "a + b",
+          .defaultNullBehavior = false,
+      });
+  testSelect(
+      "SELECT tc.default.combine(10, tc.default.combine(n_nationkey, n_regionkey)) "
+      "FROM nation",
+      matchScan("nation")
+          .project({"10::bigint + (n_nationkey + n_regionkey)"})
+          .output());
+
+  // f(x) := x * x references its argument more than once; each occurrence is
+  // bound to the call-site expression.
+  metadata_->addFunction(
+      {"default", "square"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x * x",
+          .defaultNullBehavior = false,
+      });
+  testSelect(
+      "SELECT tc.default.square(n_nationkey + n_regionkey) FROM nation",
+      matchScan("nation")
+          .project(
+              {"(n_nationkey + n_regionkey) * (n_nationkey + n_regionkey)"})
+          .output());
+
+  // f(x) := case when x < 10 then 1 when x < 20 then 2 else 3 end
+  metadata_->addFunction(
+      {"default", "bucket"},
+      {
+          .returnType = INTEGER(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "case when x < 10 then 1 when x < 20 then 2 else 3 end",
+          .defaultNullBehavior = false,
+      });
+  testSelect(
+      "SELECT tc.default.bucket(n_nationkey) FROM nation",
+      matchScan("nation")
+          .project({"case when n_nationkey < 10::bigint then 1 "
+                    "     when n_nationkey < 20::bigint then 2 "
+                    "     else 3 end"})
+          .output());
+  testSelect(
+      "SELECT * FROM nation "
+      "WHERE tc.default.bucket(n_nationkey + n_regionkey) = 2",
+      matchScan("nation")
+          .filter(
+              "(case when n_nationkey + n_regionkey < 10::bigint then 1 "
+              "      when n_nationkey + n_regionkey < 20::bigint then 2 "
+              "      else 3 end) "
+              " = 2")
+          .output());
+
+  // Constant. f(x) := array['red', 'green', 'blue']
+  metadata_->addFunction(
+      {"default", "colors"},
+      {
+          .returnType = ARRAY(VARCHAR()),
+          .body = "array['red', 'green', 'blue']",
+          .defaultNullBehavior = false,
+      });
+  testSelect(
+      "SELECT tc.default.colors()[n_nationkey % 3 + 1] FROM nation",
+      matchScan("nation")
+          .project({"array_constructor('red', 'green', 'blue')"
+                    "   [(n_nationkey % 3::bigint) + 1::bigint]"})
+          .output());
+}
+
+// Each argument is cast to its declared type, and the body is cast to the
+// declared return type.
+TEST_F(SqlFunctionTest, coercion) {
+  metadata_->addFunction(
+      {"default", "identity"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x",
+          .defaultNullBehavior = false,
+      });
+  // The INTEGER argument is coerced to the declared BIGINT.
+  testSelect(
+      "SELECT tc.default.identity(CAST(n_nationkey AS INTEGER)) FROM nation",
+      matchScan("nation")
+          .project({"cast(cast(n_nationkey as integer) as bigint)"})
+          .output());
+
+  metadata_->addFunction(
+      {"default", "narrow"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "cast(x as smallint)",
+          .defaultNullBehavior = false,
+      });
+  // The SMALLINT body is coerced to the declared BIGINT return type.
+  testSelect(
+      "SELECT tc.default.narrow(n_nationkey) FROM nation",
+      matchScan("nation")
+          .project({"cast(cast(n_nationkey as smallint) as bigint)"})
+          .output());
+}
+
+// A RETURNS NULL ON NULL INPUT function has its body wrapped so a null in any
+// argument yields null without evaluating the body.
+TEST_F(SqlFunctionTest, nullOnNullInput) {
+  metadata_->addFunction(
+      {"default", "guarded_one"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x",
+          .defaultNullBehavior = true,
+      });
+  testSelect(
+      "SELECT tc.default.guarded_one(n_nationkey) FROM nation",
+      matchScan("nation")
+          .project({"if(is_null(n_nationkey), null, n_nationkey)"})
+          .output());
+
+  metadata_->addFunction(
+      {"default", "guarded_two"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"a", "b"},
+          .argumentTypes = {BIGINT(), BIGINT()},
+          .body = "a + b",
+          .defaultNullBehavior = true,
+      });
+  testSelect(
+      "SELECT tc.default.guarded_two(n_nationkey, n_regionkey) FROM nation",
+      matchScan("nation")
+          .project({"if(is_null(n_nationkey) or is_null(n_regionkey), "
+                    "null, n_nationkey + n_regionkey)"})
+          .output());
+
+  // A zero-argument function has no argument to be null, so no guard is added.
+  metadata_->addFunction(
+      {"default", "answer"},
+      {
+          .returnType = BIGINT(),
+          .body = "42",
+          .defaultNullBehavior = true,
+      });
+  testSelect(
+      "SELECT tc.default.answer() FROM nation",
+      matchScan("nation").project({"42::bigint"}).output());
+}
+
+// Malformed calls and definitions fail with clear user errors.
+TEST_F(SqlFunctionTest, resolutionErrors) {
+  // A well-formed function; the call site, not the definition, is at fault in
+  // the first four cases below.
+  metadata_->addFunction(
+      {"default", "identity"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x",
+      });
+
+  // Unregistered catalog.
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT nope.default.identity(n_nationkey) FROM nation"),
+      "Catalog not found");
+
+  // No such function.
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT tc.default.missing(n_nationkey) FROM nation"),
+      "SQL function not found");
+
+  // Wrong number of arguments.
+  VELOX_ASSERT_THROW(
+      parseSelect(
+          "SELECT tc.default.identity(n_nationkey, n_regionkey) FROM nation"),
+      "SQL function called with wrong number of arguments");
+
+  // Argument not coercible to the declared type.
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT tc.default.identity(n_name) FROM nation"),
+      "Cannot coerce SQL function argument");
+
+  // Body does not use every argument.
+  metadata_->addFunction(
+      {"default", "unused"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x", "y"},
+          .argumentTypes = {BIGINT(), BIGINT()},
+          .body = "x",
+      });
+  VELOX_ASSERT_THROW(
+      parseSelect(
+          "SELECT tc.default.unused(n_nationkey, n_regionkey) FROM nation"),
+      "SQL function does not use all of its arguments");
+
+  // Body references an identifier that is not an argument.
+  metadata_->addFunction(
+      {"default", "unknown_identifier"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "y",
+      });
+  VELOX_ASSERT_THROW(
+      parseSelect(
+          "SELECT tc.default.unknown_identifier(n_nationkey) FROM nation"),
+      "Unknown identifier in SQL function body");
+
+  // Body calls itself.
+  metadata_->addFunction(
+      {"default", "recurse"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "tc.default.recurse(x)",
+      });
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT tc.default.recurse(n_nationkey) FROM nation"),
+      "Recursive SQL function is not supported");
+
+  // Body type is not coercible to the declared return type.
+  metadata_->addFunction(
+      {"default", "bad_return"},
+      {
+          .returnType = BIGINT(),
+          .body = "array[1, 2, 3]",
+      });
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT tc.default.bad_return() FROM nation"),
+      "SQL function body is not coercible to its declared return type");
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

Calling a SQL-invoked function by its qualified name — for example:

    SELECT catalog.schema.fn(x) FROM t

failed in Axiom with `Scalar function doesn't exist`. These functions are defined as a SQL body in a connector's metastore rather than registered in Velox's function registry, so name resolution never found them. Axiom now resolves such a call by fetching its definition from the connector and inlining the body in place of the call, so the plan contains the body expression and no call node remains.

The connector exposes definitions through a new `ConnectorMetadata::findFunction`, which returns the return type, argument names and types, the SQL body, and whether the function returns null on null input. `ExprResolver` gains an optional resolver seam: for a qualified call it binds each argument to the call-site expression, casts the argument to its declared type, inlines the resolved body, casts the body to the declared return type, and — for a RETURNS NULL ON NULL INPUT function — wraps the body so a null in any argument yields null without evaluating it. The Presto frontend supplies this seam: it recognizes qualified calls, selects the connector's single signature, and verifies each argument is coercible before inlining. The connector and `ExprResolver` layers stay dialect-agnostic; each connector documents the one SQL dialect its bodies use.

Not yet supported, each failing with a user error: a name bound to more than one signature, a subquery in the body, and a recursive definition.

Differential Revision: D112659169


