### PR TITLE
fix(parser): Keep lateral aliases out of subqueries (#1613)

### DIFF
--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -30,6 +30,11 @@ GROUP BY COALESCE(t.a, (SELECT max(a) FROM u))
 -- distinct columns (a scalar value vs a boolean).
 SELECT (SELECT max(a) FROM u), EXISTS (SELECT max(a) FROM u) FROM t
 ----
+-- `k` inside the subquery binds to the subquery's own column, not to the
+-- same-named alias in the outer SELECT.
+SELECT a AS k, (SELECT max(k) FROM (VALUES (10), (20)) AS _(k))
+FROM (VALUES (1), (2)) AS _(a)
+----
 -- Case-insensitive CTE alias resolution.
 WITH a AS (SELECT * FROM (VALUES (1)) t(a)) SELECT A.a FROM A
 ----

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -1486,6 +1486,20 @@ lp::ExprApi ExpressionPlanner::planSubquery(
   if (auto it = subqueryCache_.find(query); it != subqueryCache_.end()) {
     return it->second;
   }
+
+  // Lateral column aliases belong to the enclosing SELECT block only. Clear
+  // them while the subquery is planned so a bare column reference inside the
+  // subquery resolves against the subquery's own FROM (and then the outer
+  // scope's columns for correlation), not an outer SELECT alias.
+  const auto* savedAliasExprs = aliasExprs_;
+  const auto* savedColumnNames = columnNames_;
+  aliasExprs_ = nullptr;
+  columnNames_ = nullptr;
+  SCOPE_EXIT {
+    aliasExprs_ = savedAliasExprs;
+    columnNames_ = savedColumnNames;
+  };
+
   auto result = subqueryPlanner_(query->as<Query>());
 
   if (scalar) {

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -906,6 +906,34 @@ TEST_F(ExpressionParserTest, lateralColumnAliasErrors) {
       "Cannot resolve column: j");
 }
 
+TEST_F(ExpressionParserTest, lateralColumnAliasNotVisibleInSubquery) {
+  // A lateral column alias belongs to its own SELECT block, so it must not be
+  // visible inside a subquery. Here the outer alias `r_regionkey` collides with
+  // region.r_regionkey; the subquery's bare `r_regionkey` must bind to
+  // region.r_regionkey.
+  auto subqueryMatcher =
+      matchScan("region").aggregate({}, {"max(r_regionkey)"}).build();
+
+  testSelect(
+      "SELECT n_regionkey AS r_regionkey, "
+      "       (SELECT max(r_regionkey) FROM region) "
+      "FROM nation",
+      matchScan("nation")
+          .project([&](const lp::LogicalPlanNodePtr& node) {
+            auto& project = *node->as<lp::ProjectNode>();
+            ASSERT_EQ(2, project.expressions().size());
+
+            const auto& subqueryExpr = project.expressionAt(1);
+            ASSERT_EQ(lp::ExprKind::kSubquery, subqueryExpr->kind());
+
+            const auto& subquery =
+                subqueryExpr->as<lp::SubqueryExpr>()->subquery();
+            ASSERT_TRUE(subqueryMatcher->match(subquery))
+                << subquery->toString();
+          })
+          .output());
+}
+
 TEST_F(ExpressionParserTest, row) {
   testNationExpr(
       "row(n_regionkey, n_name)", "row_constructor(n_regionkey, n_name)");

--- a/axiom/sql/presto/tests/PrestoParserTestBase.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.cpp
@@ -17,7 +17,6 @@
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/ExprPrinter.h"
-#include "axiom/logical_plan/PlanPrinter.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/aggregates/RegisterAggregateFunctions.h"
 #include "velox/functions/prestosql/registration/RegistrationFunctions.h"
@@ -83,15 +82,13 @@ void PrestoParserTestBase::testExplain(
         explainStatement->statement()->as<SelectStatement>();
 
     auto logicalPlan = selectStatement->plan();
-    ASSERT_TRUE(matcher.build()->match(logicalPlan))
-        << lp::PlanPrinter::toText(*logicalPlan);
+    ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
   } else if (explainStatement->statement()->isInsert()) {
     auto* insertStatement =
         explainStatement->statement()->as<InsertStatement>();
 
     auto logicalPlan = insertStatement->plan();
-    ASSERT_TRUE(matcher.build()->match(logicalPlan))
-        << lp::PlanPrinter::toText(*logicalPlan);
+    ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
   } else {
     FAIL() << "Unexpected statement: "
            << explainStatement->statement()->kindName();
@@ -124,8 +121,7 @@ void PrestoParserTestBase::testSelect(
   auto* selectStatement = statement->as<SelectStatement>();
 
   auto logicalPlan = selectStatement->plan();
-  ASSERT_TRUE(matcher.build()->match(logicalPlan))
-      << lp::PlanPrinter::toText(*logicalPlan);
+  ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
 
   ASSERT_EQ(views.size(), selectStatement->views().size());
 
@@ -148,8 +144,7 @@ void PrestoParserTestBase::testInsert(
   auto insertStatement = statement->as<InsertStatement>();
 
   auto logicalPlan = insertStatement->plan();
-  ASSERT_TRUE(matcher.build()->match(logicalPlan))
-      << lp::PlanPrinter::toText(*logicalPlan);
+  ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
 }
 
 void PrestoParserTestBase::testCtas(
@@ -170,8 +165,7 @@ void PrestoParserTestBase::testCtas(
   ASSERT_TRUE(*ctasStatement->tableSchema() == *tableSchema);
 
   auto logicalPlan = ctasStatement->plan();
-  ASSERT_TRUE(matcher.build()->match(logicalPlan))
-      << lp::PlanPrinter::toText(*logicalPlan);
+  ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
 
   const auto& actualProperties = ctasStatement->properties();
   ASSERT_EQ(properties.size(), actualProperties.size());


### PR DESCRIPTION
Summary:

A scalar subquery in the SELECT list that referenced a column whose name matched an outer SELECT alias failed to plan. For example:

    SELECT
      max_by(a, b) AS k,
      max_by(coalesce(a, (SELECT max(k) FROM dim)), b) AS s
    FROM t
    GROUP BY g

failed with:

    Scalar function doesn't exist: max_by

The subquery's `k` resolved to the outer alias `k` — whose expression is `max_by(a, b)` — instead of `dim.k`. Resolving that aggregate as an input to the subquery's `max(...)` then looked up `max_by` as a scalar and failed.

Lateral column aliases let a later SELECT item reference an earlier item's alias (friendly SQL). They are tracked on the shared expression planner while the SELECT list is built. That state was not cleared when planning a subquery, so the subquery saw the enclosing block's aliases. A lateral alias belongs to its own SELECT block, not a nested one. `planSubquery` now clears the alias state while the subquery is planned; a bare column there resolves against the subquery's own FROM, then the outer scope for correlation.

bypass-github-export-checks

Differential Revision: D112686591


