### PR TITLE
feat(sql): Support CALL statements for stored procedures (#1615)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <fmt/ranges.h>
 #include <folly/CancellationToken.h>
 #include <folly/container/F14Map.h>
 #include <folly/coro/BlockingWait.h>
@@ -410,6 +411,22 @@ std::string SqlQueryRunner::dropTable(
   }
 }
 
+std::string SqlQueryRunner::call(
+    std::string_view queryId,
+    const presto::CallStatement& statement) {
+  // Fold each bound argument expression to a value.
+  std::vector<velox::Variant> arguments;
+  arguments.reserve(statement.arguments().size());
+  for (const auto& argument : statement.arguments()) {
+    arguments.push_back(
+        optimizer::ConstantExprEvaluator::evaluateConstantExpr(*argument));
+  }
+
+  folly::coro::blockingWait(statement.procedure()->execute(
+      makeConnectorSession(queryId, statement.connectorId()), arguments));
+  return "CALL";
+}
+
 std::string SqlQueryRunner::addColumn(
     std::string_view queryId,
     const presto::AddColumnStatement& statement,
@@ -760,6 +777,25 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
               add->ifNotExists() ? "IF NOT EXISTS " : "",
               add->columnName(),
               add->columnType()->toString())};
+    } else if (statement->isCall()) {
+      // EXPLAIN must be side-effect-free: echo the resolved call without
+      // invoking the procedure.
+      const auto* call = statement->as<presto::CallStatement>();
+
+      std::vector<std::string> arguments;
+      arguments.reserve(call->arguments().size());
+      for (const auto& argument : call->arguments()) {
+        // TODO: render arguments as Presto SQL (add Expr::toSql); toString()
+        // emits debug form (e.g. array_constructor(...)), not valid SQL.
+        arguments.push_back(argument->toString());
+      }
+
+      return {
+          .message = fmt::format(
+              "CALL {}.{}({})",
+              call->connectorId(),
+              call->procedureName(),
+              fmt::join(arguments, ", "))};
     } else {
       VELOX_NYI("Unsupported EXPLAIN query: {}", statement->kindName());
     }
@@ -871,6 +907,11 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
   if (sqlStatement.isDropSchema()) {
     const auto* drop = sqlStatement.as<presto::DropSchemaStatement>();
     return {.message = dropSchema(queryId, *drop)};
+  }
+
+  if (sqlStatement.isCall()) {
+    const auto* call = sqlStatement.as<presto::CallStatement>();
+    return {.message = this->call(queryId, *call)};
   }
 
   if (sqlStatement.isShowStatsForQuery()) {

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -357,6 +357,10 @@ class SqlQueryRunner {
       std::string_view queryId,
       const presto::DropSchemaStatement& statement);
 
+  std::string call(
+      std::string_view queryId,
+      const presto::CallStatement& statement);
+
   /// Returns the default connector ID set during initialization.
   const std::string& defaultConnectorId() const {
     return defaultConnectorId_;

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <folly/coro/Task.h>
 #include <folly/dynamic.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/init/Init.h>
@@ -1732,6 +1733,63 @@ TEST_F(SqlQueryRunnerTest, explainAddColumn) {
       findTable()->type(), ROW({"x", "dup"}, {BIGINT(), VARCHAR()}));
 
   run("DROP TABLE t");
+}
+
+TEST_F(SqlQueryRunnerTest, call) {
+  // increment(name, step = 1) adds 'step' to the named counter, exercising the
+  // full CALL path: parse, bind, constant-fold arguments, and execute.
+  auto counters = std::make_shared<std::unordered_map<std::string, int64_t>>();
+  testConnector_->metadata()->addProcedure(
+      {kDefaultSchema, "increment"},
+      facebook::axiom::connector::Procedure{
+          .parameters =
+              {{"name", VARCHAR(), std::nullopt},
+               {"step", BIGINT(), Variant(static_cast<int64_t>(1))}},
+          .execute = [counters](
+                         const facebook::axiom::connector::ConnectorSessionPtr&,
+                         const std::vector<Variant>& arguments)
+              -> folly::coro::Task<void> {
+            (*counters)[arguments[0].value<std::string>()] +=
+                arguments[1].value<int64_t>();
+            co_return;
+          }});
+
+  // Omitted 'step' defaults to 1.
+  auto result = run("CALL increment('foo')");
+  EXPECT_EQ(result.message, "CALL");
+  EXPECT_EQ((*counters)["foo"], 1);
+
+  run("CALL increment('bar')");
+  EXPECT_EQ((*counters)["bar"], 1);
+
+  // Explicit 'step' is coerced to BIGINT and applied.
+  run("CALL increment('foo', 10)");
+  EXPECT_EQ((*counters)["foo"], 11);
+
+  run("CALL increment('foo', 1 + 2)");
+  EXPECT_EQ((*counters)["foo"], 14);
+
+  // A constant-expression argument that fails to fold surfaces the error.
+  VELOX_ASSERT_THROW(run("CALL increment('foo', 1 / 0)"), "division by zero");
+
+  {
+    // EXPLAIN describes the CALL without invoking it: the counter is unchanged.
+    auto explained = run("EXPLAIN CALL increment('foo', 100)");
+    EXPECT_EQ(
+        explained.message,
+        "CALL test.default.increment(foo, CAST(100 AS BIGINT))");
+    EXPECT_EQ((*counters)["foo"], 14);
+  }
+
+  {
+    auto explained = run("EXPLAIN CALL increment('foo')");
+    EXPECT_EQ(explained.message, "CALL test.default.increment(foo, 1)");
+    EXPECT_EQ((*counters)["foo"], 14);
+  }
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      run("EXPLAIN CALL increment('foo', 'bar')"),
+      "Cannot coerce procedure argument from VARCHAR to BIGINT");
 }
 
 } // namespace

--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(
   ConfigRegistry.cpp
   QueryRuntimeStats.cpp
   SchemaFunctionName.cpp
+  SchemaProcedureName.cpp
   SchemaTableName.cpp
   SchemaTypeName.cpp
   SessionConfig.cpp

--- a/axiom/common/SchemaProcedureName.cpp
+++ b/axiom/common/SchemaProcedureName.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/common/SchemaProcedureName.h"
+
+#include <fmt/core.h>
+#include "velox/common/base/BitUtil.h"
+
+namespace facebook::axiom {
+
+std::string SchemaProcedureName::toString() const {
+  return fmt::format("{}", *this);
+}
+
+} // namespace facebook::axiom
+
+size_t std::hash<facebook::axiom::SchemaProcedureName>::operator()(
+    const facebook::axiom::SchemaProcedureName& name) const {
+  auto hash = folly::hasher<std::string>{}(name.procedure);
+  hash = facebook::velox::bits::hashMix(
+      hash, folly::hasher<std::string>{}(name.schema));
+  return hash;
+}

--- a/axiom/common/SchemaProcedureName.h
+++ b/axiom/common/SchemaProcedureName.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+#include <fmt/format.h>
+#include <ostream>
+
+namespace facebook::axiom {
+
+/// Structured representation of a schema-qualified stored-procedure name.
+/// Procedures and functions live in separate namespaces: a procedure is a
+/// named, side-effecting operation, not an expression.
+struct SchemaProcedureName {
+  std::string schema;
+  std::string procedure;
+
+  /// Returns "schema.procedure" for display/logging only.
+  std::string toString() const;
+
+  bool operator==(const SchemaProcedureName&) const = default;
+};
+
+// Used by gtest to print values in assertion failures.
+inline std::ostream& operator<<(
+    std::ostream& os,
+    const SchemaProcedureName& name) {
+  return os << name.toString();
+}
+
+} // namespace facebook::axiom
+
+template <>
+struct std::hash<facebook::axiom::SchemaProcedureName> {
+  size_t operator()(const facebook::axiom::SchemaProcedureName& name) const;
+};
+
+template <>
+struct fmt::formatter<facebook::axiom::SchemaProcedureName>
+    : fmt::formatter<std::string_view> {
+  auto format(
+      const facebook::axiom::SchemaProcedureName& name,
+      format_context& ctx) const {
+    return fmt::format_to(ctx.out(), "{}.{}", name.schema, name.procedure);
+  }
+};

--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -43,6 +43,26 @@ void MetadataCountGroup::checkConsistency() const {
   }
 }
 
+void Procedure::checkConsistency() const {
+  folly::F14FastSet<std::string> names;
+  bool seenOptional = false;
+  for (const auto& parameter : parameters) {
+    VELOX_CHECK(!parameter.name.empty(), "Procedure parameter name is empty");
+    VELOX_CHECK(
+        names.insert(parameter.name).second,
+        "Duplicate procedure parameter name: {}",
+        parameter.name);
+    if (parameter.defaultValue.has_value()) {
+      seenOptional = true;
+    } else {
+      VELOX_CHECK(
+          !seenOptional,
+          "Required procedure parameter must not follow an optional one: {}",
+          parameter.name);
+    }
+  }
+}
+
 namespace {
 
 // @return RowType that represents a subset of 'columns' which are not hidden.

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include "axiom/common/Enums.h"
 #include "axiom/common/SchemaFunctionName.h"
+#include "axiom/common/SchemaProcedureName.h"
 #include "axiom/common/SchemaTableName.h"
 #include "axiom/common/SchemaTypeName.h"
 #include "axiom/connectors/ConnectorSession.h"
@@ -936,6 +937,52 @@ struct SqlFunctionDefinition {
 
 using SqlFunctionDefinitionPtr = std::shared_ptr<const SqlFunctionDefinition>;
 
+/// One parameter of a stored procedure.
+struct ProcedureParameter {
+  /// Parameter name, used to match named arguments at the call site.
+  std::string name;
+
+  /// Declared parameter type; supplied arguments are coerced to it.
+  velox::TypePtr type;
+
+  /// Default value for an optional parameter, substituted when its argument is
+  /// omitted at the call site. Empty for a required parameter, which must be
+  /// supplied. A parameter is optional iff it has a default; optional
+  /// parameters must follow the required ones.
+  std::optional<velox::Variant> defaultValue;
+};
+
+/// A stored procedure a connector exposes: a named, side-effecting operation.
+/// Unlike a function, a procedure is not compiled into a plan and returns no
+/// rows: the engine binds the call's arguments to the parameters and invokes
+/// 'execute', which performs the connector-side side effect and either succeeds
+/// or throws.
+///
+/// A procedure name is not overloaded: a connector exposes at most one
+/// procedure per schema-qualified name. Parameter names must be unique and
+/// non-empty.
+struct Procedure {
+  /// Formal parameters, in declared (positional) order.
+  std::vector<ProcedureParameter> parameters;
+
+  /// Runs the procedure. 'arguments' are the actual values in declared
+  /// parameter order, coerced to the declared parameter types, with defaults
+  /// filled in for omitted optional parameters. Async so the implementation can
+  /// await connector I/O; the caller awaits (or blocks on) the returned task.
+  std::function<folly::coro::Task<void>(
+      const ConnectorSessionPtr& session,
+      const std::vector<velox::Variant>& arguments)>
+      execute;
+
+  /// Validates the parameter list: names are non-empty and unique, and optional
+  /// parameters (those with a default) follow all required ones. Names are
+  /// compared as-is; dialect-specific matching (e.g. case-insensitivity) is the
+  /// parser's concern. Throws on violation.
+  void checkConsistency() const;
+};
+
+using ProcedurePtr = std::shared_ptr<const Procedure>;
+
 class ConnectorMetadata {
  public:
   /// Return the metadata for a given connector ID. Throws if not registered.
@@ -1008,6 +1055,15 @@ class ConnectorMetadata {
   virtual std::vector<SqlFunctionDefinitionPtr> findFunction(
       const SchemaFunctionName& /*functionName*/) {
     return {};
+  }
+
+  /// Resolves the stored procedure named by 'name'. Connectors that expose
+  /// procedures override this. Procedure names are not overloaded, so at most
+  /// one procedure is returned.
+  ///
+  /// @return nullptr if the procedure is not found.
+  virtual ProcedurePtr findProcedure(const SchemaProcedureName& /*name*/) {
+    return nullptr;
   }
 
   /// EXPERIMENTAL. Opt-in gate for connector pushdown. Default false.

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -583,6 +583,23 @@ void TestConnectorMetadata::addFunction(
   VELOX_CHECK(inserted, "Function already registered: {}", functionName);
 }
 
+ProcedurePtr TestConnectorMetadata::findProcedure(
+    const SchemaProcedureName& name) {
+  auto it = procedures_.find(name);
+  if (it == procedures_.end()) {
+    return nullptr;
+  }
+  return it->second;
+}
+
+void TestConnectorMetadata::addProcedure(
+    const SchemaProcedureName& name,
+    Procedure procedure) {
+  auto [_, inserted] = procedures_.emplace(
+      name, std::make_shared<const Procedure>(std::move(procedure)));
+  VELOX_CHECK(inserted, "Procedure already registered: {}", name);
+}
+
 ViewPtr TestConnectorMetadata::findView(const SchemaTableName& tableName) {
   auto it = views_.find(tableName);
   if (it == views_.end()) {

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -628,6 +628,12 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const SchemaFunctionName& functionName,
       SqlFunctionDefinition definition);
 
+  ProcedurePtr findProcedure(const SchemaProcedureName& name) override;
+
+  /// Registers a stored procedure for findProcedure() resolution. Throws if a
+  /// procedure with the same name is already registered.
+  void addProcedure(const SchemaProcedureName& name, Procedure procedure);
+
   ViewPtr findView(const SchemaTableName& tableName) override;
 
   /// Register a view with the given name, output schema, and SQL text.
@@ -677,6 +683,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
   folly::F14FastSet<std::string> schemas_{"default"};
   folly::F14FastMap<SchemaTypeName, velox::TypePtr> types_;
   folly::F14FastMap<SchemaFunctionName, SqlFunctionDefinitionPtr> functions_;
+  folly::F14FastMap<SchemaProcedureName, ProcedurePtr> procedures_;
 };
 
 /// At DataSource creation time, the data contained in the corresponding Table

--- a/axiom/optimizer/ConstantExprEvaluator.cpp
+++ b/axiom/optimizer/ConstantExprEvaluator.cpp
@@ -57,7 +57,27 @@ class ExprTranslator : public lp::ExprVisitor {
 
   void visit(const lp::SpecialFormExpr& expr, lp::ExprVisitorContext& context)
       const {
-    VELOX_NYI();
+    auto& myCtx = static_cast<ExprTranslatorContext&>(context);
+
+    std::vector<velox::core::TypedExprPtr> inputs;
+    inputs.reserve(expr.inputs().size());
+    for (const auto& input : expr.inputs()) {
+      input->accept(*this, context);
+      inputs.push_back(myCtx.veloxExpr);
+    }
+
+    switch (expr.form()) {
+      case lp::SpecialForm::kCast:
+        myCtx.veloxExpr = std::make_shared<velox::core::CastTypedExpr>(
+            expr.type(), inputs, /*isTryCast=*/false);
+        break;
+      case lp::SpecialForm::kTryCast:
+        myCtx.veloxExpr = std::make_shared<velox::core::CastTypedExpr>(
+            expr.type(), inputs, /*isTryCast=*/true);
+        break;
+      default:
+        VELOX_NYI();
+    }
   }
 
   void visit(const lp::AggregateExpr& expr, lp::ExprVisitorContext& context)

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -802,7 +802,7 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* dereference = node->as<DereferenceExpression>();
 
       // Try to resolve as an enum literal (e.g., catalog.schema.Type.VALUE).
-      // When columnResolver_ is nullptr (e.g., parseSqlExpression for CREATE
+      // When columnResolver_ is nullptr (e.g., resolveSqlExpression for CREATE
       // TABLE property values), there is no column scope to compete with — a
       // 4-part dotted name can only be an enum literal.
       std::vector<std::string> parts;

--- a/axiom/sql/presto/ExpressionPlanner.h
+++ b/axiom/sql/presto/ExpressionPlanner.h
@@ -59,7 +59,7 @@ struct ExprOptions {
 /// function calls, casts, subqueries, etc.).
 ///
 /// Can be used standalone for translating simple expressions (e.g. in
-/// parseSqlExpression) by passing nullptr for both callbacks. When used
+/// resolveSqlExpression) by passing nullptr for both callbacks. When used
 /// within RelationPlanner to translate full queries, callbacks must be
 /// provided to handle subqueries and ordinal sort keys in aggregates.
 class ExpressionPlanner {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1891,7 +1891,7 @@ lp::ExprResolver::SqlFunctionResolver makeSqlFunctionResolver(
   };
 }
 
-lp::ExprPtr parseSqlExpression(
+lp::ExprPtr resolveSqlExpression(
     const std::string& user,
     const ExpressionPtr& expr) {
   ExpressionPlanner exprPlanner{
@@ -2430,7 +2430,7 @@ std::unordered_map<std::string, lp::ExprPtr> parseTableProperties(
   std::unordered_map<std::string, lp::ExprPtr> properties;
   for (const auto& p : props) {
     const auto& name = p->name()->value();
-    auto expr = parseSqlExpression(user, p->value());
+    auto expr = resolveSqlExpression(user, p->value());
     AXIOM_PRESTO_SEMANTIC_CHECK(
         expr->looksConstant(),
         p->location(),
@@ -2809,6 +2809,174 @@ SqlStatementPtr parseSetSession(const SetSession* setSession) {
       std::move(name), std::move(valueString));
 }
 
+// Resolves a procedure's qualified name into a connector id and
+// schema-qualified procedure name.
+std::pair<std::string, facebook::axiom::SchemaProcedureName>
+toConnectorProcedure(
+    const QualifiedName& name,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  const auto& parts = name.parts();
+  VELOX_CHECK(!parts.empty(), "Procedure name cannot be empty");
+
+  if (parts.size() == 1) {
+    // name
+    return {defaultConnectorId, {defaultSchema, parts[0]}};
+  }
+
+  if (parts.size() == 2) {
+    // schema.name
+    return {defaultConnectorId, {parts[0], parts[1]}};
+  }
+
+  // connector.schema.name
+  VELOX_CHECK_EQ(3, parts.size());
+  return {parts[0], {parts[1], parts[2]}};
+}
+
+// Resolves a single CALL argument to a constant expression coerced to the
+// procedure parameter's declared type. The value is folded later, by the
+// runner.
+lp::ExprPtr bindProcedureArgument(
+    const std::string& user,
+    const ExpressionPtr& valueExpr,
+    const TypePtr& declaredType,
+    const std::string& token) {
+  auto expr = resolveSqlExpression(user, valueExpr);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      expr->looksConstant(),
+      valueExpr->location(),
+      token,
+      "Procedure argument must be a constant: {}",
+      expr->toString());
+
+  if (expr->type()->equivalent(*declaredType)) {
+    return expr;
+  }
+
+  const auto& coercer = facebook::velox::functions::prestosql::typeCoercer();
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      coercer.coerce(expr->type(), declaredType).has_value(),
+      valueExpr->location(),
+      token,
+      "Cannot coerce procedure argument from {} to {}",
+      expr->type()->toString(),
+      declaredType->toString());
+  return std::make_shared<lp::SpecialFormExpr>(
+      declaredType, lp::SpecialForm::kCast, expr);
+}
+
+SqlStatementPtr parseCall(
+    const std::string& user,
+    const Call& call,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema) {
+  auto [connectorId, procedureName] =
+      toConnectorProcedure(*call.name(), defaultConnectorId, defaultSchema);
+
+  auto metadata = facebook::axiom::connector::ConnectorMetadataRegistry::tryGet(
+      connectorId);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      metadata != nullptr,
+      call.location(),
+      connectorId,
+      "Catalog not found: {}",
+      connectorId);
+
+  auto procedure = metadata->findProcedure(procedureName);
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      procedure != nullptr,
+      call.location(),
+      procedureName.procedure,
+      "Procedure not found: {}",
+      procedureName.toString());
+  procedure->checkConsistency();
+
+  const auto& parameters = procedure->parameters;
+  const auto& args = call.arguments();
+
+  bool anyNamed = false;
+  bool anyPositional = false;
+  for (const auto& arg : args) {
+    (arg->name() != nullptr ? anyNamed : anyPositional) = true;
+  }
+  AXIOM_PRESTO_SEMANTIC_CHECK(
+      !(anyNamed && anyPositional),
+      call.location(),
+      procedureName.procedure,
+      "Named and positional procedure arguments cannot be mixed");
+
+  // Map each parameter position to the argument supplied for it, if any.
+  // Named arguments are matched to parameters case-insensitively, using the
+  // same identifier canonicalization as the rest of the parser.
+  std::vector<const CallArgument*> supplied(parameters.size(), nullptr);
+  if (anyNamed) {
+    std::unordered_map<std::string, size_t> nameToIndex;
+    for (size_t i = 0; i < parameters.size(); ++i) {
+      VELOX_CHECK(
+          nameToIndex.emplace(canonicalizeName(parameters[i].name), i).second,
+          "Duplicate parameter name in procedure {}: {}",
+          procedureName.toString(),
+          parameters[i].name);
+    }
+    for (const auto& arg : args) {
+      const auto& argName = arg->name()->value();
+      auto it = nameToIndex.find(canonicalizeName(argName));
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          it != nameToIndex.end(),
+          call.location(),
+          argName,
+          "Unknown argument name for procedure {}: {}",
+          procedureName.toString(),
+          argName);
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          supplied[it->second] == nullptr,
+          call.location(),
+          argName,
+          "Duplicate argument for procedure {}: {}",
+          procedureName.toString(),
+          argName);
+      supplied[it->second] = arg.get();
+    }
+  } else {
+    AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+        args.size(),
+        parameters.size(),
+        call.location(),
+        procedureName.procedure,
+        "Too many arguments for procedure {}",
+        procedureName.toString());
+    for (size_t i = 0; i < args.size(); ++i) {
+      supplied[i] = args[i].get();
+    }
+  }
+
+  std::vector<lp::ExprPtr> arguments;
+  arguments.reserve(parameters.size());
+  for (size_t i = 0; i < parameters.size(); ++i) {
+    const auto& parameter = parameters[i];
+    if (supplied[i] != nullptr) {
+      arguments.push_back(bindProcedureArgument(
+          user, supplied[i]->value(), parameter.type, parameter.name));
+    } else {
+      AXIOM_PRESTO_SEMANTIC_CHECK(
+          parameter.defaultValue.has_value(),
+          call.location(),
+          parameter.name,
+          "Missing required procedure argument: {}",
+          parameter.name);
+      arguments.push_back(
+          lp::ConstantExpr::fromVariant(*parameter.defaultValue));
+    }
+  }
+
+  return std::make_shared<CallStatement>(
+      std::move(connectorId),
+      std::move(procedureName),
+      std::move(procedure),
+      std::move(arguments));
+}
+
 SqlStatementPtr doPlan(
     const std::shared_ptr<Statement>& query,
     const std::string& defaultConnectorId,
@@ -2858,6 +3026,11 @@ SqlStatementPtr doPlan(
 
   if (query->is(NodeType::kDropSchema)) {
     return parseDropSchema(*query->as<DropSchema>(), defaultConnectorId);
+  }
+
+  if (query->is(NodeType::kCall)) {
+    return parseCall(
+        user, *query->as<Call>(), defaultConnectorId, defaultSchema);
   }
 
   if (query->is(NodeType::kShowSchemas)) {

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -41,6 +41,7 @@ const auto& statementKindNames() {
       {SqlStatementKind::kResetSession, "RESET SESSION"},
       {SqlStatementKind::kUse, "USE"},
       {SqlStatementKind::kAddColumn, "ALTER TABLE ADD COLUMN"},
+      {SqlStatementKind::kCall, "CALL"},
   };
 
   return kNames;

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -18,7 +18,14 @@
 
 #include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/common/Enums.h"
+#include "axiom/common/SchemaProcedureName.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
+#include "velox/type/Variant.h"
+
+namespace facebook::axiom::connector {
+struct Procedure;
+using ProcedurePtr = std::shared_ptr<const Procedure>;
+} // namespace facebook::axiom::connector
 
 namespace axiom::sql::presto {
 
@@ -41,6 +48,7 @@ enum class SqlStatementKind {
   kResetSession,
   kUse,
   kAddColumn,
+  kCall,
 };
 
 AXIOM_DECLARE_ENUM_NAME(SqlStatementKind);
@@ -127,6 +135,10 @@ class SqlStatement {
 
   bool isAddColumn() const {
     return kind_ == SqlStatementKind::kAddColumn;
+  }
+
+  bool isCall() const {
+    return kind_ == SqlStatementKind::kCall;
   }
 
   template <typename T>
@@ -419,6 +431,49 @@ class AddColumnStatement : public SqlStatement {
   const facebook::velox::TypePtr columnType_;
   const bool ifTableExists_;
   const bool ifNotExists_;
+};
+
+/// A stored-procedure invocation. Resolved at parse time: the procedure is
+/// looked up on its connector and the call's arguments are bound to its
+/// parameters (matched positionally or by name, coerced to the declared
+/// parameter types, defaults filled) in declared parameter order, as constant
+/// expressions. The runner folds them to values; the connector then executes
+/// the procedure directly. Produces no rows.
+class CallStatement : public SqlStatement {
+ public:
+  CallStatement(
+      std::string connectorId,
+      facebook::axiom::SchemaProcedureName procedureName,
+      facebook::axiom::connector::ProcedurePtr procedure,
+      std::vector<facebook::axiom::logical_plan::ExprPtr> arguments)
+      : SqlStatement(SqlStatementKind::kCall),
+        connectorId_{std::move(connectorId)},
+        procedureName_{std::move(procedureName)},
+        procedure_{std::move(procedure)},
+        arguments_{std::move(arguments)} {}
+
+  const std::string& connectorId() const {
+    return connectorId_;
+  }
+
+  const facebook::axiom::SchemaProcedureName& procedureName() const {
+    return procedureName_;
+  }
+
+  /// Bound arguments as constant expressions, in declared parameter order.
+  const std::vector<facebook::axiom::logical_plan::ExprPtr>& arguments() const {
+    return arguments_;
+  }
+
+  const facebook::axiom::connector::ProcedurePtr& procedure() const {
+    return procedure_;
+  }
+
+ private:
+  const std::string connectorId_;
+  const facebook::axiom::SchemaProcedureName procedureName_;
+  const facebook::axiom::connector::ProcedurePtr procedure_;
+  const std::vector<facebook::axiom::logical_plan::ExprPtr> arguments_;
 };
 
 class CreateSchemaStatement : public SqlStatement {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -927,7 +927,11 @@ std::any AstBuilder::visitDropFunction(
 
 std::any AstBuilder::visitCall(PrestoSqlParser::CallContext* ctx) {
   trace("visitCall");
-  return visitChildren("visitCall", ctx);
+  auto arguments = visitTyped<CallArgument>(ctx->callArgument());
+  return std::static_pointer_cast<Statement>(std::make_shared<Call>(
+      getLocation(ctx),
+      getQualifiedName(ctx->qualifiedName()),
+      std::move(arguments)));
 }
 
 std::any AstBuilder::visitCreateRole(PrestoSqlParser::CreateRoleContext* ctx) {
@@ -2883,13 +2887,19 @@ std::any AstBuilder::visitSerializable(
 std::any AstBuilder::visitPositionalArgument(
     PrestoSqlParser::PositionalArgumentContext* ctx) {
   trace("visitPositionalArgument");
-  return visitChildren("visitPositionalArgument", ctx);
+  return std::make_shared<CallArgument>(
+      getLocation(ctx),
+      /*name=*/nullptr,
+      visitTyped<Expression>(ctx->expression()));
 }
 
 std::any AstBuilder::visitNamedArgument(
     PrestoSqlParser::NamedArgumentContext* ctx) {
   trace("visitNamedArgument");
-  return visitChildren("visitNamedArgument", ctx);
+  return std::make_shared<CallArgument>(
+      getLocation(ctx),
+      visitTyped<Identifier>(ctx->identifier()),
+      visitTyped<Expression>(ctx->expression()));
 }
 
 std::any AstBuilder::visitPrivilege(PrestoSqlParser::PrivilegeContext* ctx) {

--- a/axiom/sql/presto/tests/CMakeLists.txt
+++ b/axiom/sql/presto/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ target_link_libraries(axiom_logical_plan_matcher axiom_logical_plan GTest::gtest
 add_executable(
   axiom_sql_presto_test
   AggregationParserTest.cpp
+  CallParserTest.cpp
   ColumnFilteringTest.cpp
   DdlParserTest.cpp
   EnumLiteralTest.cpp

--- a/axiom/sql/presto/tests/CallParserTest.cpp
+++ b/axiom/sql/presto/tests/CallParserTest.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/coro/Task.h>
+#include "axiom/logical_plan/Expr.h"
+#include "axiom/sql/presto/tests/ExprMatcher.h"
+#include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include "velox/parse/ExpressionsParser.h"
+
+namespace axiom::sql::presto::test {
+
+using namespace facebook::velox;
+namespace lp = facebook::axiom::logical_plan;
+using facebook::axiom::connector::Procedure;
+using facebook::axiom::connector::ProcedureParameter;
+using facebook::axiom::logical_plan::test::ExprMatcher;
+
+namespace {
+
+// The parser only binds arguments; it never executes the procedure. 'execute'
+// throws so that any accidental execution fails the test loudly.
+Procedure makeProcedure(std::vector<ProcedureParameter> parameters) {
+  Procedure procedure;
+  procedure.parameters = std::move(parameters);
+  procedure.execute =
+      [](const facebook::axiom::connector::ConnectorSessionPtr&,
+         const std::vector<Variant>&) -> folly::coro::Task<void> {
+    VELOX_FAIL("Procedure must not be executed during parsing");
+  };
+  return procedure;
+}
+
+class CallParserTest : public PrestoParserTestBase {
+ protected:
+  void SetUp() override {
+    PrestoParserTestBase::SetUp();
+    // increment(Name VARCHAR, Step BIGINT = 1): a required VARCHAR and an
+    // optional BIGINT that defaults to 1. Parameters are declared in mixed case
+    // to exercise case-insensitive argument matching.
+    connector_->metadata()->addProcedure(
+        {std::string(kDefaultSchema), "increment"},
+        makeProcedure({
+            {"Name", VARCHAR(), std::nullopt},
+            {"Step", BIGINT(), Variant(static_cast<int64_t>(1))},
+        }));
+  }
+
+  // Parses 'sql' and asserts it is a CALL.
+  std::shared_ptr<const CallStatement> parseCall(std::string_view sql) {
+    auto call = std::dynamic_pointer_cast<const CallStatement>(parseSql(sql));
+    EXPECT_NE(call, nullptr);
+    return call;
+  }
+
+  facebook::velox::core::ExprPtr parseExpr(const std::string& expr) {
+    return exprParser_.parseExpr(expr);
+  }
+
+  // Parses a CALL and verifies its procedure name and bound arguments. Each
+  // expected argument is matched structurally against the parsed expression.
+  void verifyCall(
+      std::string_view sql,
+      const std::string& procedure,
+      const std::vector<std::string>& expectedArguments) {
+    auto call = parseCall(sql);
+
+    EXPECT_EQ(call->connectorId(), kConnectorId);
+    EXPECT_EQ(call->procedureName().schema, kDefaultSchema);
+    EXPECT_EQ(call->procedureName().procedure, procedure);
+
+    ASSERT_EQ(call->arguments().size(), expectedArguments.size());
+    for (size_t i = 0; i < expectedArguments.size(); ++i) {
+      ExprMatcher::match(call->arguments()[i], parseExpr(expectedArguments[i]));
+    }
+  }
+
+  facebook::velox::parse::DuckSqlExpressionsParser exprParser_;
+};
+
+TEST_F(CallParserTest, positional) {
+  // Positional arguments bind in order; 'step' (INTEGER literal) is coerced to
+  // the declared BIGINT parameter type.
+  verifyCall(
+      "CALL increment('counter', 5)",
+      "increment",
+      {"'counter'", "cast(5 as bigint)"});
+
+  // A schema-qualified name resolves the same procedure.
+  verifyCall(
+      "CALL default.increment('counter', 5)",
+      "increment",
+      {"'counter'", "cast(5 as bigint)"});
+
+  // The omitted optional 'step' is filled from its default of 1.
+  verifyCall("CALL increment('counter')", "increment", {"'counter'", "1"});
+
+  // A constant expression argument is bound unevaluated (folded by the runner)
+  // and coerced to the parameter type.
+  verifyCall(
+      "CALL increment('counter', 1 + 2)",
+      "increment",
+      {"'counter'", "cast(1 + 2 as bigint)"});
+
+  verifyCall(
+      "CALL increment('counter', 1 / 0)",
+      "increment",
+      {"'counter'", "cast(1 / 0 as bigint)"});
+
+  // An argument whose type cannot be coerced to the parameter type is rejected.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment('counter', rand())"),
+      "Cannot coerce procedure argument from DOUBLE to BIGINT");
+}
+
+TEST_F(CallParserTest, named) {
+  // Named arguments bind by name and are reordered to declared order. Checking
+  // 'step's value distinguishes it from the default, so dropping it would fail.
+  verifyCall(
+      "CALL increment(name => 'counter')", "increment", {"'counter'", "1"});
+
+  verifyCall(
+      "CALL increment(step => 5, name => 'counter')",
+      "increment",
+      {"'counter'", "cast(5 as bigint)"});
+
+  verifyCall(
+      "CALL increment(step => 1 + 2, name => 'counter')",
+      "increment",
+      {"'counter'", "cast(1 + 2 as bigint)"});
+
+  // Argument names are matched case-insensitively: lowercase 'name'/'step' and
+  // uppercase NAME/STEP both bind to the declared 'Name'/'Step' parameters.
+  verifyCall(
+      "CALL increment(STEP => 5, NAME => 'counter')",
+      "increment",
+      {"'counter'", "cast(5 as bigint)"});
+}
+
+TEST_F(CallParserTest, unknownProcedure) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL no_such_proc('counter')"),
+      "Procedure not found: default.no_such_proc");
+}
+
+TEST_F(CallParserTest, invalidArguments) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment('counter', 'five')"),
+      "Cannot coerce procedure argument from VARCHAR to BIGINT");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment('counter', 5, 'extra')"),
+      "Too many arguments for procedure default.increment");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment()"),
+      "Missing required procedure argument: Name");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment(name => 'counter', bogus => 'counter')"),
+      "Unknown argument name for procedure default.increment: bogus");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment(name => 'a', name => 'b')"),
+      "Duplicate argument for procedure default.increment: name");
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("CALL increment('counter', step => 5)"),
+      "Named and positional procedure arguments cannot be mixed");
+}
+
+} // namespace
+} // namespace axiom::sql::presto::test


### PR DESCRIPTION
Summary:

Axiom now parses and runs `CALL`, letting a connector expose a named, side-effecting operation callable from SQL:

    CALL system.my_procedure('orders', 5)

A connector exposes procedures through `ConnectorMetadata::findProcedure`, which returns a `Procedure` describing its parameters and an `execute` callback. The parser resolves the procedure and binds its arguments — positional or named, with defaults filled for omitted optional parameters and each argument coerced to its parameter type. Named arguments match parameters case-insensitively. The runner folds the bound arguments and calls `execute`; a procedure returns no rows. `EXPLAIN CALL` validates the call without running it.

Coercing an argument inserts a `CAST`, so `ConstantExprEvaluator` now lowers a `CAST`/`TRY_CAST` special form to a Velox expression instead of throwing NYI.

`EXPLAIN CALL` echoes its arguments in debug form (`Expr::toString`), not valid SQL. A TODO tracks adding `Expr::toSql`.

Reviewed By: xiaoxmeng

Differential Revision: D112810205


