### PR TITLE
feat: Select output transport per PartitionedOutput node via a pluggable registry (#1616)

### DIFF
--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -600,7 +600,11 @@ PlanAndStats ToVelox::toVeloxPlan(
 
   if (options.remoteOutput) {
     rootPlanNode = velox::core::PartitionedOutputNode::single(
-        nextId(), rootPlanNode->outputType(), exchangeSerdeKind_, rootPlanNode);
+        nextId(),
+        rootPlanNode->outputType(),
+        exchangeSerdeKind_,
+        std::string{velox::core::TransportKind::kInMemory},
+        rootPlanNode);
   }
 
   auto finishWrite = std::move(finishWrite_);
@@ -1153,7 +1157,11 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   }
 
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
-      nextId(), node->outputType(), exchangeSerdeKind_, node);
+      nextId(),
+      node->outputType(),
+      exchangeSerdeKind_,
+      std::string{velox::core::TransportKind::kInMemory},
+      node);
   makePredictionAndHistory(source.fragment.planNode->id(), &op);
 
   applyGroupedLeaves(source, groupedLeaves_->root);
@@ -1184,7 +1192,11 @@ velox::core::PlanNodePtr ToVelox::makeOffset(
   auto input = makeFragment(op.input(), source, stages);
 
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
-      nextId(), input->outputType(), exchangeSerdeKind_, input);
+      nextId(),
+      input->outputType(),
+      exchangeSerdeKind_,
+      std::string{velox::core::TransportKind::kInMemory},
+      input);
   makePredictionAndHistory(source.fragment.planNode->id(), &op);
 
   applyGroupedLeaves(source, groupedLeaves_->root);
@@ -1235,7 +1247,11 @@ velox::core::PlanNodePtr ToVelox::makeLimit(
   }
 
   source.fragment.planNode = velox::core::PartitionedOutputNode::single(
-      nextId(), node->outputType(), exchangeSerdeKind_, node);
+      nextId(),
+      node->outputType(),
+      exchangeSerdeKind_,
+      std::string{velox::core::TransportKind::kInMemory},
+      node);
   makePredictionAndHistory(source.fragment.planNode->id(), &op);
 
   applyGroupedLeaves(source, groupedLeaves_->root);
@@ -1958,22 +1974,39 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
   if (distribution.isArbitrary()) {
     VELOX_CHECK_EQ(0, keys.size());
     source.fragment.planNode = velox::core::PartitionedOutputNode::arbitrary(
-        nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+        nextId(),
+        outputType,
+        exchangeSerdeKind_,
+        std::string{velox::core::TransportKind::kInMemory},
+        sourcePlan);
   } else if (distribution.isBroadcast()) {
     VELOX_CHECK_EQ(0, keys.size());
     source.fragment.planNode = velox::core::PartitionedOutputNode::broadcast(
-        nextId(), 1, outputType, exchangeSerdeKind_, sourcePlan);
+        nextId(),
+        1,
+        outputType,
+        exchangeSerdeKind_,
+        std::string{velox::core::TransportKind::kInMemory},
+        sourcePlan);
   } else if (distribution.isGather()) {
     VELOX_CHECK_EQ(0, keys.size());
     source.fragment.planNode = velox::core::PartitionedOutputNode::single(
-        nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+        nextId(),
+        outputType,
+        exchangeSerdeKind_,
+        std::string{velox::core::TransportKind::kInMemory},
+        sourcePlan);
   } else {
     VELOX_CHECK_NE(0, keys.size());
     const auto numPartitions =
         groupedLeavesWidth(*outerConsumerGroupedLeaves, options_.numWorkers);
     if (numPartitions == 1) {
       source.fragment.planNode = velox::core::PartitionedOutputNode::single(
-          nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+          nextId(),
+          outputType,
+          exchangeSerdeKind_,
+          std::string{velox::core::TransportKind::kInMemory},
+          sourcePlan);
     } else {
       auto partitionFunctionFactory = createPartitionFunctionSpec(
           sourcePlan->outputType(), keys, distribution);
@@ -1987,6 +2020,7 @@ velox::core::PlanNodePtr ToVelox::makeRepartition(
               std::move(partitionFunctionFactory),
               outputType,
               exchangeSerdeKind_,
+              std::string{velox::core::TransportKind::kInMemory},
               sourcePlan);
     }
   }

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -392,7 +392,11 @@ class Emitter {
       const velox::RowTypePtr& outputType,
       const velox::core::PlanNodePtr& sourcePlan) {
     return velox::core::PartitionedOutputNode::single(
-        nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+        nextId(),
+        outputType,
+        exchangeSerdeKind_,
+        std::string{velox::core::TransportKind::kInMemory},
+        sourcePlan);
   }
 
   // Builds the consumer-side exchange node for 'partitioning' — a
@@ -1775,12 +1779,17 @@ velox::core::PlanNodePtr Emitter::makeExchangeProducer(
           /*numPartitions=*/1,
           outputType,
           exchangeSerdeKind_,
+          std::string{velox::core::TransportKind::kInMemory},
           sourcePlan);
     case PartitionKind::kGather:
       return makeSingleOutput(outputType, sourcePlan);
     case PartitionKind::kArbitrary:
       return velox::core::PartitionedOutputNode::arbitrary(
-          nextId(), outputType, exchangeSerdeKind_, sourcePlan);
+          nextId(),
+          outputType,
+          exchangeSerdeKind_,
+          std::string{velox::core::TransportKind::kInMemory},
+          sourcePlan);
     case PartitionKind::kPartitioned: {
       auto fields =
           toFieldAccessList(partitioning.keys, "Exchange partition key");
@@ -1818,6 +1827,7 @@ velox::core::PlanNodePtr Emitter::makeExchangeProducer(
           std::move(spec),
           outputType,
           exchangeSerdeKind_,
+          std::string{velox::core::TransportKind::kInMemory},
           sourcePlan);
     }
     case PartitionKind::kUnspecified:


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/148



Makes the output transport pluggable and a **plan property**. Adds an abstract `OutputBufferManager` interface and a query-scoped `OutputTransportRegistry` (same pattern as `ConnectorRegistry`), keyed by transport id, where each entry pairs a manager with the factory that builds its matching output operator. `PartitionedOutputNode` names the transport its output is sent over — the way `TableScanNode` names its connector — so `Task` resolves the paired manager and `createDriver` builds the matching operator from the same registry entry. This is groundwork for alternative transports (e.g. a GPU/UCX output queue) selected per plan, with no conditional compilation; the UCX consumer lands in stacked https://github.com/facebookincubator/velox/issues/17730. (cf. https://github.com/facebookincubator/velox/issues/16993)

## How it works

`PartitionedOutputNode.transportKind` → `OutputTransportRegistry::tryGet(queryCtx, transport)` (per-query override → global fallback) → `Task` holds the resolved manager → `createDriver` builds the operator from that same entry's factory → `PartitionedOutput` receives its concrete manager in its constructor.

Selection is simply the transport the plan named. A named transport with no registered entry **fails fast** rather than silently running over a different transport. The built-in **in-memory** transport is seeded as a real entry when the global registry is created (and restored by `unregisterAll()`), so it is always available with no explicit registration and every lookup/enumeration is a plain registry read. Existing queries carry no annotation, default to in-memory, and are unchanged.

## Key changes

| Component | Change |
| --- | --- |
| OutputBufferManager.h _(new interface)_ | Pure-virtual interface: control plane (task lifecycle) + observability only. The data plane (enqueue / getData / acknowledge / delete) stays on the concrete managers, since payloads are transport-specific (serialized pages vs. GPU buffers). Documents the thread-safety and lifetime contract implementations must honor. |
| OutputTransportRegistry _(new)_ | Thread-safe registry keyed by transport id: per-query overrides + global fallback (`ScopedRegistry` + `QueryCtx`), mirroring `ConnectorRegistry`. Each entry pairs a manager with the factory that builds its operator, so the two can't diverge (enforced in the entry ctor). Seeds the built-in in-memory default as a real root entry at creation, so lookup and enumeration are plain reads; isolation scopes (`create(nullptr)`) intentionally exclude it. |
| DefaultOutputBufferManager _(the in-memory implementation, renamed from OutputBufferManager in https://github.com/facebookincubator/velox/issues/18034)_ | Provides `makeDefaultTransportEntry()` (manager + `PartitionedOutput` operator) that the registry seeds under the in-memory transport. |
| PartitionedOutputNode | Carries a `transportKind` (next to `serdeKind`, serialized with the node). No default on the ctor — callers pass it; the previous signature is kept behind `VELOX_ENABLE_BACKWARD_COMPATIBILITY`. |
| Task | Resolves the entry from the node's transport and fails fast if none is registered; holds the manager weakly (to break the Task↔OutputBuffer cycle) and passes the operator factory to `createDriver`. No default/registry knowledge of its own. |
| PartitionedOutput | Receives its concrete manager in the constructor — the operator/manager pairing lives in the type system, not a runtime cast. |
| LocalPlanner (createDriver) | Builds the output operator from the resolved transport's registry entry, read straight from the node. |
| PlanFragment | Removes the per-node transport side map (reverts https://github.com/facebookincubator/velox/issues/17567) now that the node carries the transport; `TransportKind` moves to `PlanNode.h`. |

One producer per task → one live manager per task (no multi-manager aggregation).

## Commits

1. **feat(core):** move the output transport from the `PlanFragment` side map onto `PartitionedOutputNode` — add `transportKind` + threading/serde and revert https://github.com/facebookincubator/velox/issues/17567 in one change. Inert until the runtime resolves it.
2. **feat(exec):** the pluggable `OutputBufferManager` interface + `OutputTransportRegistry` + per-transport resolution in `Task` / `createDriver`.

_The mechanical `OutputBufferManager` → `DefaultOutputBufferManager` rename landed separately in https://github.com/facebookincubator/velox/issues/18034 (merged); this PR is rebased on top of it._

## Tests

* `OutputTransportRegistryTest`: registration/lookup, per-query override vs. global fallback, `getAll` enumeration, the always-available in-memory default, and isolation scopes excluding the default.
* `TaskTest.partitionedOutputSelectsOperatorByTransportKind`: `createDriver` builds the operator from the resolved transport's entry, verified with a CPU test transport (no UCX needed).
* `TaskTest.partitionedOutputEntryRequiresOperatorFactory`: an entry paired with a null operator factory is rejected at construction — the manager/operator pairing can't diverge.
* `TaskTest.partitionedOutputErrorsWhenTransportUnregistered`: a node naming an unregistered transport fails fast.
* `TaskTest.taskUsesDefaultOutputBufferManagerAfterRegistryClear`: `unregisterAll()` resets to the built-in baseline, so a default task still runs after a clear.
* `TaskTest.taskStatsPreserveFinalOutputBufferStats`: final output buffer stats survive task termination.
* `PlanNodeSerdeTest.partitionedOutput`: the transport annotation (incl. a non-default `kUcx`) round-trips through serde.
* `PlanNodeSerdeTest.partitionedOutputTransportKindDefaultsWhenMissing`: a plan serialized before `transportKind` existed deserializes to the in-memory default (backward compatible).

X-link: https://github.com/facebookincubator/velox/pull/16980

Reviewed By: apurva-meta

Differential Revision: D107557292

Pulled By: pedroerp


