### PR TITLE
fix: EXPLAIN (TYPE IO) under-reporting for repeated table scans

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -169,6 +169,59 @@ std::string getLocalTimezone() {
   return "UTC";
 }
 
+// Owns the optimizer QueryGraphContext for its lifetime and installs it as the
+// thread-local queryCtx(), clearing it on destruction.
+class OptimizerContext {
+ public:
+  explicit OptimizerContext(velox::memory::MemoryPool* pool)
+      : allocator_(std::make_unique<velox::HashStringAllocator>(pool)),
+        context_(std::make_unique<optimizer::QueryGraphContext>(*allocator_)) {
+    optimizer::queryCtx() = context_.get();
+  }
+
+  ~OptimizerContext() {
+    optimizer::queryCtx() = nullptr;
+  }
+
+  OptimizerContext(const OptimizerContext&) = delete;
+  OptimizerContext& operator=(const OptimizerContext&) = delete;
+
+ private:
+  std::unique_ptr<velox::HashStringAllocator> allocator_;
+  std::unique_ptr<optimizer::QueryGraphContext> context_;
+};
+
+// Returns 'schemaResolver' if non-null, else a default resolver over the global
+// connector metadata registry.
+std::shared_ptr<connector::SchemaResolver> orDefaultSchemaResolver(
+    std::shared_ptr<connector::SchemaResolver> schemaResolver) {
+  if (schemaResolver != nullptr) {
+    return schemaResolver;
+  }
+  return std::make_shared<connector::SchemaResolver>(
+      connector::ConnectorMetadataRegistry::global());
+}
+
+// Returns the destination table for an EXPLAIN (TYPE IO) over an INSERT or
+// CTAS, or nullopt for a plain SELECT.
+std::optional<CatalogSchemaTableName> explainIoOutputTable(
+    const axiom::sql::presto::SqlStatement& statement,
+    const logical_plan::LogicalPlanNode& plan) {
+  if (statement.isCreateTableAsSelect()) {
+    const auto* ctas =
+        statement.as<axiom::sql::presto::CreateTableAsSelectStatement>();
+    return CatalogSchemaTableName{ctas->connectorId(), ctas->tableName()};
+  }
+
+  if (statement.isInsert()) {
+    const auto* writeNode = plan.as<logical_plan::TableWriteNode>();
+    return CatalogSchemaTableName{
+        writeNode->connectorId(), writeNode->tableName()};
+  }
+
+  return std::nullopt;
+}
+
 } // namespace
 
 namespace axiom::sql {
@@ -801,28 +854,26 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     }
 
     if (explain->type() == presto::ExplainStatement::Type::kIo) {
-      VELOX_USER_CHECK(
-          !useOptimizerV2_, "EXPLAIN TYPE IO is not supported with --v2");
-      std::optional<CatalogSchemaTableName> outputTable;
-      if (statement->isCreateTableAsSelect()) {
-        const auto* ctas =
-            statement->as<presto::CreateTableAsSelectStatement>();
-        outputTable =
-            CatalogSchemaTableName{ctas->connectorId(), ctas->tableName()};
-      } else if (statement->isInsert()) {
-        const auto* writeNode = logicalPlan->as<logical_plan::TableWriteNode>();
-        outputTable = CatalogSchemaTableName{
-            writeNode->connectorId(), writeNode->tableName()};
-      }
+      std::optional<CatalogSchemaTableName> outputTable =
+          explainIoOutputTable(*statement, *logicalPlan);
 
-      std::string text;
       auto queryCtx = newQuery(options);
-      {
-        PhaseTimer phaseTimer(
-            timing.optimize,
-            runtimeStats.get(),
-            QueryRuntimeStats::kOptimizeWallNanos,
-            QueryRuntimeStats::kOptimizeCpuNanos);
+      PhaseTimer phaseTimer(
+          timing.optimize,
+          runtimeStats.get(),
+          QueryRuntimeStats::kOptimizeWallNanos,
+          QueryRuntimeStats::kOptimizeCpuNanos);
+
+      if (useOptimizerV2_) {
+        auto resolver = orDefaultSchemaResolver(schemaResolver);
+        OptimizerContext optimizerContext(optimizerPool_.get());
+        velox::exec::SimpleExpressionEvaluator evaluator(
+            queryCtx.get(), optimizerPool_.get());
+        return {
+            .message = optimizer::v2::explainIo(
+                *logicalPlan, *resolver, evaluator, std::move(outputTable))};
+      } else {
+        std::string text;
         optimize(
             logicalPlan,
             queryCtx,
@@ -835,8 +886,8 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
             schemaResolver,
             /*explain=*/true,
             runtimeStats);
+        return {.message = std::move(text)};
       }
-      return {.message = std::move(text)};
     }
 
     if (explain->isAnalyze()) {
@@ -1276,23 +1327,13 @@ optimizer::PlanAndStats SqlQueryRunner::optimize(
   optimizer::MultiFragmentPlan::Options opts;
   opts.numWorkers = options.numWorkers;
   opts.numDrivers = options.numDrivers;
-  auto allocator =
-      std::make_unique<velox::HashStringAllocator>(optimizerPool_.get());
-  auto context = std::make_unique<optimizer::QueryGraphContext>(*allocator);
-
-  optimizer::queryCtx() = context.get();
-  SCOPE_EXIT {
-    optimizer::queryCtx() = nullptr;
-  };
+  OptimizerContext optimizerContext(optimizerPool_.get());
 
   velox::exec::SimpleExpressionEvaluator evaluator(
       queryCtx.get(), optimizerPool_.get());
 
   auto history = std::make_unique<optimizer::VeloxHistory>();
-  if (schemaResolver == nullptr) {
-    schemaResolver = std::make_shared<connector::SchemaResolver>(
-        connector::ConnectorMetadataRegistry::global());
-  }
+  schemaResolver = orDefaultSchemaResolver(std::move(schemaResolver));
 
   auto connectorProperties = collectConnectorProperties(*sessionConfig_);
   auto optimizerOptions = optimizer::OptimizerOptions::from(

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -165,7 +165,7 @@ class SqlQueryRunner {
   /// polling for queries that set RunOptions::onProgress. If null, such a query
   /// fails loudly rather than running without the progress it asked for.
   /// @param useOptimizerV2 When true, all queries route through the v2
-  /// optimizer. EXPLAIN (type graph|optimized|io) and SHOW STATS FOR (<query>)
+  /// optimizer. EXPLAIN (type graph|optimized) and SHOW STATS FOR (<query>)
   /// fail with a user error under v2, because they inspect optimizer internals
   /// the v2 pipeline does not expose.
   explicit SqlQueryRunner(

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -15,7 +15,9 @@
 add_executable(
   axiom_cli_test
   CatalogPropertiesTest.cpp
+  ExplainIoTest.cpp
   SqlQueryRunnerTest.cpp
+  SqlQueryRunnerTestBase.cpp
   StdinReaderTest.cpp
   ConsoleTest.cpp
   LiveProgressDisplayTest.cpp

--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -59,12 +59,17 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
 
   // SELECT with no table scans.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT 1"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT 1"),
       normalizeJson(R"({"inputTableColumnInfos": []})"));
 
   // SELECT with table scan.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM nation"), normalizeJson(R"({
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM nation"),
+      normalizeJson(R"({
         "inputTableColumnInfos": [{
           "table": {
             "catalog": "test",
@@ -76,7 +81,9 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
 
   // CTAS with output table.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) CREATE TABLE t AS SELECT * FROM nation"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "CREATE TABLE t AS SELECT * FROM nation"),
       normalizeJson(R"({
         "inputTableColumnInfos": [{
           "table": {
@@ -95,7 +102,8 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
   testConnector_->addTable("t", ROW({"key", "name"}, {BIGINT(), VARCHAR()}));
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) INSERT INTO t(key, name) "
+          "EXPLAIN (TYPE IO) "
+          "INSERT INTO t(key, name) "
           "SELECT r_regionkey, r_name FROM region"),
       normalizeJson(R"({
         "inputTableColumnInfos": [{
@@ -114,7 +122,9 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
   // JOIN: multiple input tables sorted by name.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM nation, region WHERE n_regionkey = r_regionkey"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM nation, region "
+          "   WHERE n_regionkey = r_regionkey"),
       normalizeJson(R"({
         "inputTableColumnInfos": [
           {
@@ -183,92 +193,160 @@ TEST_P(ExplainIoTest, columnConstraints) {
 
   // Equality constraint.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds = '2026-03-17'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds = '2026-03-17'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // IN constraint.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds IN ('2026-03-17', '2026-03-18')"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds IN ('2026-03-17', '2026-03-18')"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
-            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // Range constraint.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds >= '2026-03-01' AND ds <= '2026-03-31'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds >= '2026-03-01' AND ds <= '2026-03-31'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-31", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // BETWEEN maps to a closed range, inclusive on both ends.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-31", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // BETWEEN on an integer column produces the same closed range.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE n BETWEEN 1 AND 10"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE n BETWEEN 1 AND 10"),
       makeTable(makeConstraint(
           "n",
           "BIGINT",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": 1, "bound": "EXACTLY"},
-             "high": {"value": 10, "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": 1, "bound": "EXACTLY"},
+                "high": {"value": 10, "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // LIKE with a literal prefix maps to a half-open range [prefix, prefix++),
   // where the upper bound increments the last byte of the prefix.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05%'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05%'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05", "bound": "EXACTLY"},
-             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-05", "bound": "EXACTLY"},
+                "high": {"value": "2026-06", "bound": "BELOW"}
+              }
+            ]
+          })")));
 
   // The '_' single-character wildcard also terminates the prefix.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05_'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05_'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05", "bound": "EXACTLY"},
-             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-05", "bound": "EXACTLY"},
+                "high": {"value": "2026-06", "bound": "BELOW"}
+              }
+            ]
+          })")));
 
   // LIKE with no wildcards degenerates to equality.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05-01'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05-01'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-05-01", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-05-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-05-01", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   auto noConstraints = normalizeJson(R"({
     "inputTableColumnInfos": [{
@@ -282,81 +360,110 @@ TEST_P(ExplainIoTest, columnConstraints) {
 
   // No constraint on explain_io column (filter on non-explain_io column only).
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE x = 1"), noConstraints);
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE x = 1"),
+      noConstraints);
 
   // Unconvertible filter on explain_io column drops the column entirely.
   // NOT is not supported, so ds <> 'foo' (which becomes NOT(eq(ds, 'foo')))
   // causes the column to be dropped.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds <> 'foo'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds <> 'foo'"),
       noConstraints);
 
   // NOT BETWEEN (parsed as not(between(...))) is unconvertible and drops the
   // column, same as other negations.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
       noConstraints);
 
   // BETWEEN with low > high is an empty range, so the whole table is excluded.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
       normalizeJson(R"({"inputTableColumnInfos": []})"));
 
   // LIKE with a leading wildcard has no usable prefix, so it is dropped.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '%05'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '%05'"),
       noConstraints);
 
   // LIKE with an ESCAPE clause is not converted (escape semantics are not
   // interpreted), so the column is dropped.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds LIKE '2026-05%' ESCAPE '#'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05%' ESCAPE '#'"),
       noConstraints);
 
   // Mix of convertible and unconvertible filters: unconvertible conjunct is
   // skipped (broader is safe), convertible conjunct is shown.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds >= '2026-03-01' AND ds <> 'foo'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds >= '2026-03-01' AND ds <> 'foo'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // IS NULL OR equality: nullsAllowed is true.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds IS NULL OR ds = '2026-03-17'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds IS NULL OR ds = '2026-03-17'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": true, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": true,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // OR with unconvertible disjunct: the entire OR expression cannot be
   // converted (dropping a disjunct would narrow the result, which is unsafe).
   // The unconvertible OR is skipped as a conjunct (broader is safe).
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds = '2026-03-17' OR length(ds) > 3"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds = '2026-03-17' OR length(ds) > 3"),
       noConstraints);
 
   // Constraints on both explain_io columns.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds = '2026-03-17' AND region = 'us'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds = '2026-03-17' AND region = 'us'"),
       normalizeJson(R"({
         "inputTableColumnInfos": [{
           "table": {
@@ -392,12 +499,21 @@ TEST_P(ExplainIoTest, columnConstraints) {
 
   // Greater-than (exclusive low bound).
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds > '2026-03-01'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds > '2026-03-01'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "ABOVE"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "ABOVE"}
+              }
+            ]
+          })")));
 
   // Subquery: constraints are extracted from the inner table scan.
   ASSERT_EQ(
@@ -407,9 +523,15 @@ TEST_P(ExplainIoTest, columnConstraints) {
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // UNION ALL: same table scanned twice, merged into one entry with
   // united constraints.
@@ -422,11 +544,19 @@ TEST_P(ExplainIoTest, columnConstraints) {
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
-            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // UNION (distinct): domains from both branches are united.
   // (2026-03-17, +inf) ∪ (2026-03-18, +inf) = (2026-03-17, +inf).
@@ -439,15 +569,78 @@ TEST_P(ExplainIoTest, columnConstraints) {
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "ABOVE"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "ABOVE"}
+              }
+            ]
+          })")));
 
   // ds <= x OR ds >= x covers all values — constraint is omitted.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds <= '2026-03-17' OR ds >= '2026-03-17'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds <= '2026-03-17' OR ds >= '2026-03-17'"),
       noConstraints);
+
+  // Same table scanned twice with filters on different columns: neither column
+  // is constrained in both scans, so the whole table may be read.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT a.x FROM t a, t b "
+          "   WHERE a.ds = '2026-03-17' AND b.region = 'us'"),
+      noConstraints);
+
+  // Same table scanned twice: ds is constrained in both (values unioned), but
+  // region only in one, so region is dropped (the other scan reads all
+  // regions).
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT a.x FROM t a, t b "
+          "   WHERE a.ds = '2026-03-17' "
+          "     AND b.ds = '2026-03-18' AND b.region = 'us'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // Same table scanned twice with overlapping ds ranges: the union coalesces
+  // them into a single range spanning both.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT a.x FROM t a, t b "
+          "   WHERE a.ds BETWEEN '2026-03-01' AND '2026-03-20' "
+          "     AND b.ds BETWEEN '2026-03-10' AND '2026-03-31'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-31", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/ScopeGuard.h>
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
+
+using namespace facebook::velox;
+
+namespace axiom::sql {
+namespace {
+
+// Runs the EXPLAIN (TYPE IO) cases under both optimizer v1 and v2 (the bool
+// parameter), which must produce identical IO JSON.
+class ExplainIoTest : public SqlQueryRunnerTestBase,
+                      public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    runner_ = makeRunner(
+        "test",
+        /*queryIdGenerator=*/{},
+        /*permissionCheck=*/{},
+        /*useOptimizerV2=*/GetParam());
+  }
+};
+
+TEST_P(ExplainIoTest, inputAndOutputTables) {
+  testConnector_->addTpchTables();
+
+  // Parses and re-serializes JSON with sorted keys for deterministic
+  // comparison.
+  auto normalizeJson = [](const std::string& jsonStr) {
+    folly::json::serialization_opts opts;
+    opts.pretty_formatting = true;
+    opts.sort_keys = true;
+    return folly::json::serialize(folly::parseJson(jsonStr), opts);
+  };
+
+  auto getJson = [&](const std::string& query) {
+    auto result = run(query);
+    VELOX_CHECK(result.message.has_value());
+    return normalizeJson(result.message.value());
+  };
+
+  // SELECT with no table scans.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT 1"),
+      normalizeJson(R"({"inputTableColumnInfos": []})"));
+
+  // SELECT with table scan.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM nation"), normalizeJson(R"({
+        "inputTableColumnInfos": [{
+          "table": {
+            "catalog": "test",
+            "schemaTable": {"schema": "default", "table": "nation"}
+          },
+          "columnConstraints": []
+        }]
+      })"));
+
+  // CTAS with output table.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) CREATE TABLE t AS SELECT * FROM nation"),
+      normalizeJson(R"({
+        "inputTableColumnInfos": [{
+          "table": {
+            "catalog": "test",
+            "schemaTable": {"schema": "default", "table": "nation"}
+          },
+          "columnConstraints": []
+        }],
+        "outputTable": {
+          "catalog": "test",
+          "schemaTable": {"schema": "default", "table": "t"}
+        }
+      })"));
+
+  // INSERT with output table.
+  testConnector_->addTable("t", ROW({"key", "name"}, {BIGINT(), VARCHAR()}));
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) INSERT INTO t(key, name) "
+          "SELECT r_regionkey, r_name FROM region"),
+      normalizeJson(R"({
+        "inputTableColumnInfos": [{
+          "table": {
+            "catalog": "test",
+            "schemaTable": {"schema": "default", "table": "region"}
+          },
+          "columnConstraints": []
+        }],
+        "outputTable": {
+          "catalog": "test",
+          "schemaTable": {"schema": "default", "table": "t"}
+        }
+      })"));
+
+  // JOIN: multiple input tables sorted by name.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM nation, region WHERE n_regionkey = r_regionkey"),
+      normalizeJson(R"({
+        "inputTableColumnInfos": [
+          {
+            "table": {
+              "catalog": "test",
+              "schemaTable": {"schema": "default", "table": "nation"}
+            },
+            "columnConstraints": []
+          },
+          {
+            "table": {
+              "catalog": "test",
+              "schemaTable": {"schema": "default", "table": "region"}
+            },
+            "columnConstraints": []
+          }
+        ]
+      })"));
+}
+
+TEST_P(ExplainIoTest, columnConstraints) {
+  run("CREATE TABLE t (x BIGINT, n BIGINT, ds VARCHAR, region VARCHAR) "
+      "WITH (explain_io = ARRAY['n', 'ds', 'region'])");
+  SCOPE_EXIT {
+    run("DROP TABLE t");
+  };
+
+  auto normalizeJson = [](const std::string& jsonStr) {
+    folly::json::serialization_opts opts;
+    opts.pretty_formatting = true;
+    opts.sort_keys = true;
+    return folly::json::serialize(folly::parseJson(jsonStr), opts);
+  };
+
+  auto getJson = [&](const std::string& query) {
+    auto result = run(query);
+    VELOX_CHECK(result.message.has_value());
+    return normalizeJson(result.message.value());
+  };
+
+  auto makeConstraint = [&](const std::string& columnName,
+                            const std::string& typeSignature,
+                            const std::string& domainJson) {
+    return normalizeJson(
+        fmt::format(
+            R"({{"columnName": "{}", "typeSignature": "{}", "domain": {}}})",
+            columnName,
+            typeSignature,
+            domainJson));
+  };
+
+  auto makeTable = [&](const std::string& constraintsJson) {
+    return normalizeJson(
+        fmt::format(
+            R"({{
+          "inputTableColumnInfos": [{{
+            "table": {{
+              "catalog": "test",
+              "schemaTable": {{"schema": "default", "table": "t"}}
+            }},
+            "columnConstraints": [{}]
+          }}]
+        }})",
+            constraintsJson));
+  };
+
+  // Equality constraint.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds = '2026-03-17'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+
+  // IN constraint.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds IN ('2026-03-17', '2026-03-18')"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
+            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
+
+  // Range constraint.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds >= '2026-03-01' AND ds <= '2026-03-31'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+
+  // BETWEEN maps to a closed range, inclusive on both ends.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+
+  // BETWEEN on an integer column produces the same closed range.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE n BETWEEN 1 AND 10"),
+      makeTable(makeConstraint(
+          "n",
+          "BIGINT",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": 1, "bound": "EXACTLY"},
+             "high": {"value": 10, "bound": "EXACTLY"}}]})")));
+
+  // LIKE with a literal prefix maps to a half-open range [prefix, prefix++),
+  // where the upper bound increments the last byte of the prefix.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05%'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-05", "bound": "EXACTLY"},
+             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+
+  // The '_' single-character wildcard also terminates the prefix.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05_'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-05", "bound": "EXACTLY"},
+             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+
+  // LIKE with no wildcards degenerates to equality.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05-01'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-05-01", "bound": "EXACTLY"},
+             "high": {"value": "2026-05-01", "bound": "EXACTLY"}}]})")));
+
+  auto noConstraints = normalizeJson(R"({
+    "inputTableColumnInfos": [{
+      "table": {
+        "catalog": "test",
+        "schemaTable": {"schema": "default", "table": "t"}
+      },
+      "columnConstraints": []
+    }]
+  })");
+
+  // No constraint on explain_io column (filter on non-explain_io column only).
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE x = 1"), noConstraints);
+
+  // Unconvertible filter on explain_io column drops the column entirely.
+  // NOT is not supported, so ds <> 'foo' (which becomes NOT(eq(ds, 'foo')))
+  // causes the column to be dropped.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds <> 'foo'"),
+      noConstraints);
+
+  // NOT BETWEEN (parsed as not(between(...))) is unconvertible and drops the
+  // column, same as other negations.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
+      noConstraints);
+
+  // BETWEEN with low > high is an empty range, so the whole table is excluded.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
+      normalizeJson(R"({"inputTableColumnInfos": []})"));
+
+  // LIKE with a leading wildcard has no usable prefix, so it is dropped.
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '%05'"),
+      noConstraints);
+
+  // LIKE with an ESCAPE clause is not converted (escape semantics are not
+  // interpreted), so the column is dropped.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds LIKE '2026-05%' ESCAPE '#'"),
+      noConstraints);
+
+  // Mix of convertible and unconvertible filters: unconvertible conjunct is
+  // skipped (broader is safe), convertible conjunct is shown.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds >= '2026-03-01' AND ds <> 'foo'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-01", "bound": "EXACTLY"}}]})")));
+
+  // IS NULL OR equality: nullsAllowed is true.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds IS NULL OR ds = '2026-03-17'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": true, "ranges": [
+            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+
+  // OR with unconvertible disjunct: the entire OR expression cannot be
+  // converted (dropping a disjunct would narrow the result, which is unsafe).
+  // The unconvertible OR is skipped as a conjunct (broader is safe).
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds = '2026-03-17' OR length(ds) > 3"),
+      noConstraints);
+
+  // Constraints on both explain_io columns.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds = '2026-03-17' AND region = 'us'"),
+      normalizeJson(R"({
+        "inputTableColumnInfos": [{
+          "table": {
+            "catalog": "test",
+            "schemaTable": {"schema": "default", "table": "t"}
+          },
+          "columnConstraints": [
+            {
+              "columnName": "ds",
+              "typeSignature": "VARCHAR",
+              "domain": {
+                "nullsAllowed": false,
+                "ranges": [{
+                  "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                  "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+                }]
+              }
+            },
+            {
+              "columnName": "region",
+              "typeSignature": "VARCHAR",
+              "domain": {
+                "nullsAllowed": false,
+                "ranges": [{
+                  "low": {"value": "us", "bound": "EXACTLY"},
+                  "high": {"value": "us", "bound": "EXACTLY"}
+                }]
+              }
+            }
+          ]
+        }]
+      })"));
+
+  // Greater-than (exclusive low bound).
+  ASSERT_EQ(
+      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds > '2026-03-01'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-01", "bound": "ABOVE"}}]})")));
+
+  // Subquery: constraints are extracted from the inner table scan.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM (SELECT * FROM t WHERE ds = '2026-03-17') sub"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+
+  // UNION ALL: same table scanned twice, merged into one entry with
+  // united constraints.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t WHERE ds = '2026-03-17' "
+          "UNION ALL "
+          "SELECT * FROM t WHERE ds = '2026-03-18'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
+            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
+             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
+
+  // UNION (distinct): domains from both branches are united.
+  // (2026-03-17, +inf) ∪ (2026-03-18, +inf) = (2026-03-17, +inf).
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t WHERE ds > '2026-03-17' "
+          "UNION "
+          "SELECT * FROM t WHERE ds > '2026-03-18'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({"nullsAllowed": false, "ranges": [
+            {"low": {"value": "2026-03-17", "bound": "ABOVE"}}]})")));
+
+  // ds <= x OR ds >= x covers all values — constraint is omitted.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) SELECT * FROM t "
+          "WHERE ds <= '2026-03-17' OR ds >= '2026-03-17'"),
+      noConstraints);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SqlQueryRunner,
+    ExplainIoTest,
+    ::testing::Values(false, true),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "v2" : "v1";
+    });
+
+} // namespace
+} // namespace axiom::sql

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -25,14 +25,13 @@
 #include <stdexcept>
 #include <thread>
 #include "axiom/cli/QueryIdGenerator.h"
-#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
 #include "axiom/connectors/tests/TestConnector.h"
 #include "axiom/runner/QueryProgress.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "velox/common/base/VeloxException.h"
 #include "velox/common/base/tests/GTestUtils.h"
-#include "velox/connectors/ConnectorRegistry.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
 #include "velox/vector/tests/utils/VectorTestBase.h"
 
@@ -43,79 +42,9 @@ namespace {
 
 namespace runner = facebook::axiom::runner;
 
-class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
+class SqlQueryRunnerTest : public SqlQueryRunnerTestBase {
  protected:
-  static void SetUpTestCase() {
-    facebook::velox::memory::MemoryManager::testingSetInstance(
-        facebook::velox::memory::MemoryManager::Options{});
-  }
-
-  void SetUp() override {
-    runner_ = makeRunner();
-  }
-
-  void TearDown() override {
-    runner_.reset();
-    for (const auto& id : connectorIds_) {
-      facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(id);
-      facebook::velox::connector::ConnectorRegistry::global().erase(id);
-    }
-  }
-
-  inline static const std::string kDefaultSchema{
-      facebook::axiom::connector::TestConnector::kDefaultSchema};
-
-  std::unique_ptr<SqlQueryRunner> makeRunner(
-      const std::string& connectorId = "test",
-      std::function<std::string()> queryIdGenerator = {},
-      PermissionCheck permissionCheck = {}) {
-    auto runner =
-        std::make_unique<SqlQueryRunner>("test_user", &progressScheduler_);
-
-    auto initConnectors = [&]() {
-      testConnector_ =
-          std::make_shared<facebook::axiom::connector::TestConnector>(
-              connectorId);
-      facebook::velox::connector::ConnectorRegistry::global().insert(
-          testConnector_->connectorId(), testConnector_);
-      facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
-          testConnector_->connectorId(), testConnector_->metadata());
-
-      connectorIds_.emplace_back(testConnector_->connectorId());
-
-      return std::make_pair(testConnector_->connectorId(), kDefaultSchema);
-    };
-
-    runner->initialize(
-        initConnectors,
-        std::move(permissionCheck),
-        std::move(queryIdGenerator));
-
-    return runner;
-  }
-
-  SqlQueryRunner::SqlResult run(std::string_view sql) {
-    return runner_->run(sql, {});
-  }
-
-  RowVectorPtr fetchSingleRow(
-      std::string_view sql,
-      const SqlQueryRunner::RunOptions& options = {}) {
-    auto result = runner_->run(sql, options);
-    VELOX_CHECK(
-        !result.message.has_value(), "Query failed: {}", *result.message);
-    VELOX_CHECK_EQ(1, result.results.size());
-    VELOX_CHECK_EQ(1, result.results[0]->size());
-    return result.results[0];
-  }
-
-  // Runs 'sql', which must return a single row and a single column, and returns
-  // that value.
-  template <typename T>
-  T fetchSingleValue(std::string_view sql) {
-    return fetchSingleRow(sql)->childAt(0)->variantAt(0).value<T>();
-  }
-
+  // Asserts SHOW SCHEMAS returns exactly 'expected', in order.
   void assertSchemas(const std::vector<std::string>& expected) {
     auto result = run("SHOW SCHEMAS");
     ASSERT_FALSE(result.message.has_value());
@@ -125,6 +54,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         makeRowVector({"Schema"}, {makeFlatVector(expected)}));
   }
 
+  // Asserts 'query' (SHOW TABLES by default) returns exactly 'expected', in
+  // order.
   void assertTables(
       const std::vector<std::string>& expected,
       const std::string& query = "SHOW TABLES") {
@@ -136,6 +67,8 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         makeRowVector({"Table"}, {makeFlatVector(expected)}));
   }
 
+  // Asserts SHOW SESSION LIKE 'name' reports the given current value and
+  // default.
   void assertSessionProperty(
       std::string_view name,
       std::string_view expectedValue,
@@ -152,15 +85,6 @@ class SqlQueryRunnerTest : public ::testing::Test, public test::VectorTestBase {
         row->childAt(2)->as<SimpleVector<StringView>>()->valueAt(0),
         expectedDefault);
   }
-
-  // Drives progress polling for runners built by makeRunner(); declared before
-  // runner_ so it outlives any reporter a query starts.
-  folly::FunctionScheduler progressScheduler_;
-  std::unique_ptr<SqlQueryRunner> runner_;
-  std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
-
- private:
-  std::vector<std::string> connectorIds_;
 };
 
 TEST_F(SqlQueryRunnerTest, runSingleStatement) {
@@ -369,417 +293,6 @@ TEST_F(SqlQueryRunnerTest, explainDropTable) {
 
   // EXPLAIN is side-effect-free.
   run("DROP TABLE t");
-}
-
-TEST_F(SqlQueryRunnerTest, explainIo) {
-  testConnector_->addTpchTables();
-
-  // Parses and re-serializes JSON with sorted keys for deterministic
-  // comparison.
-  auto normalizeJson = [](const std::string& jsonStr) {
-    folly::json::serialization_opts opts;
-    opts.pretty_formatting = true;
-    opts.sort_keys = true;
-    return folly::json::serialize(folly::parseJson(jsonStr), opts);
-  };
-
-  auto getJson = [&](const std::string& query) {
-    auto result = run(query);
-    VELOX_CHECK(result.message.has_value());
-    return normalizeJson(result.message.value());
-  };
-
-  // SELECT with no table scans.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT 1"),
-      normalizeJson(R"({"inputTableColumnInfos": []})"));
-
-  // SELECT with table scan.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM nation"), normalizeJson(R"({
-        "inputTableColumnInfos": [{
-          "table": {
-            "catalog": "test",
-            "schemaTable": {"schema": "default", "table": "nation"}
-          },
-          "columnConstraints": []
-        }]
-      })"));
-
-  // CTAS with output table.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) CREATE TABLE t AS SELECT * FROM nation"),
-      normalizeJson(R"({
-        "inputTableColumnInfos": [{
-          "table": {
-            "catalog": "test",
-            "schemaTable": {"schema": "default", "table": "nation"}
-          },
-          "columnConstraints": []
-        }],
-        "outputTable": {
-          "catalog": "test",
-          "schemaTable": {"schema": "default", "table": "t"}
-        }
-      })"));
-
-  // INSERT with output table.
-  testConnector_->addTable("t", ROW({"key", "name"}, {BIGINT(), VARCHAR()}));
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) INSERT INTO t(key, name) "
-          "SELECT r_regionkey, r_name FROM region"),
-      normalizeJson(R"({
-        "inputTableColumnInfos": [{
-          "table": {
-            "catalog": "test",
-            "schemaTable": {"schema": "default", "table": "region"}
-          },
-          "columnConstraints": []
-        }],
-        "outputTable": {
-          "catalog": "test",
-          "schemaTable": {"schema": "default", "table": "t"}
-        }
-      })"));
-
-  // JOIN: multiple input tables sorted by name.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM nation, region WHERE n_regionkey = r_regionkey"),
-      normalizeJson(R"({
-        "inputTableColumnInfos": [
-          {
-            "table": {
-              "catalog": "test",
-              "schemaTable": {"schema": "default", "table": "nation"}
-            },
-            "columnConstraints": []
-          },
-          {
-            "table": {
-              "catalog": "test",
-              "schemaTable": {"schema": "default", "table": "region"}
-            },
-            "columnConstraints": []
-          }
-        ]
-      })"));
-}
-
-TEST_F(SqlQueryRunnerTest, explainIoColumnConstraints) {
-  run("CREATE TABLE t (x BIGINT, n BIGINT, ds VARCHAR, region VARCHAR) "
-      "WITH (explain_io = ARRAY['n', 'ds', 'region'])");
-  SCOPE_EXIT {
-    run("DROP TABLE t");
-  };
-
-  auto normalizeJson = [](const std::string& jsonStr) {
-    folly::json::serialization_opts opts;
-    opts.pretty_formatting = true;
-    opts.sort_keys = true;
-    return folly::json::serialize(folly::parseJson(jsonStr), opts);
-  };
-
-  auto getJson = [&](const std::string& query) {
-    auto result = run(query);
-    VELOX_CHECK(result.message.has_value());
-    return normalizeJson(result.message.value());
-  };
-
-  auto makeConstraint = [&](const std::string& columnName,
-                            const std::string& typeSignature,
-                            const std::string& domainJson) {
-    return normalizeJson(
-        fmt::format(
-            R"({{"columnName": "{}", "typeSignature": "{}", "domain": {}}})",
-            columnName,
-            typeSignature,
-            domainJson));
-  };
-
-  auto makeTable = [&](const std::string& constraintsJson) {
-    return normalizeJson(
-        fmt::format(
-            R"({{
-          "inputTableColumnInfos": [{{
-            "table": {{
-              "catalog": "test",
-              "schemaTable": {{"schema": "default", "table": "t"}}
-            }},
-            "columnConstraints": [{}]
-          }}]
-        }})",
-            constraintsJson));
-  };
-
-  // Equality constraint.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds = '2026-03-17'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
-
-  // IN constraint.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds IN ('2026-03-17', '2026-03-18')"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
-            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
-
-  // Range constraint.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds >= '2026-03-01' AND ds <= '2026-03-31'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
-
-  // BETWEEN maps to a closed range, inclusive on both ends.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
-
-  // BETWEEN on an integer column produces the same closed range.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE n BETWEEN 1 AND 10"),
-      makeTable(makeConstraint(
-          "n",
-          "BIGINT",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": 1, "bound": "EXACTLY"},
-             "high": {"value": 10, "bound": "EXACTLY"}}]})")));
-
-  // LIKE with a literal prefix maps to a half-open range [prefix, prefix++),
-  // where the upper bound increments the last byte of the prefix.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05%'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05", "bound": "EXACTLY"},
-             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
-
-  // The '_' single-character wildcard also terminates the prefix.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05_'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05", "bound": "EXACTLY"},
-             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
-
-  // LIKE with no wildcards degenerates to equality.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05-01'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-05-01", "bound": "EXACTLY"}}]})")));
-
-  auto noConstraints = normalizeJson(R"({
-    "inputTableColumnInfos": [{
-      "table": {
-        "catalog": "test",
-        "schemaTable": {"schema": "default", "table": "t"}
-      },
-      "columnConstraints": []
-    }]
-  })");
-
-  // No constraint on explain_io column (filter on non-explain_io column only).
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE x = 1"), noConstraints);
-
-  // Unconvertible filter on explain_io column drops the column entirely.
-  // NOT is not supported, so ds <> 'foo' (which becomes NOT(eq(ds, 'foo')))
-  // causes the column to be dropped.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds <> 'foo'"),
-      noConstraints);
-
-  // NOT BETWEEN (parsed as not(between(...))) is unconvertible and drops the
-  // column, same as other negations.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
-      noConstraints);
-
-  // BETWEEN with low > high is an empty range, so the whole table is excluded.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
-      normalizeJson(R"({"inputTableColumnInfos": []})"));
-
-  // LIKE with a leading wildcard has no usable prefix, so it is dropped.
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '%05'"),
-      noConstraints);
-
-  // LIKE with an ESCAPE clause is not converted (escape semantics are not
-  // interpreted), so the column is dropped.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds LIKE '2026-05%' ESCAPE '#'"),
-      noConstraints);
-
-  // Mix of convertible and unconvertible filters: unconvertible conjunct is
-  // skipped (broader is safe), convertible conjunct is shown.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds >= '2026-03-01' AND ds <> 'foo'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"}}]})")));
-
-  // IS NULL OR equality: nullsAllowed is true.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds IS NULL OR ds = '2026-03-17'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": true, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
-
-  // OR with unconvertible disjunct: the entire OR expression cannot be
-  // converted (dropping a disjunct would narrow the result, which is unsafe).
-  // The unconvertible OR is skipped as a conjunct (broader is safe).
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds = '2026-03-17' OR length(ds) > 3"),
-      noConstraints);
-
-  // Constraints on both explain_io columns.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds = '2026-03-17' AND region = 'us'"),
-      normalizeJson(R"({
-        "inputTableColumnInfos": [{
-          "table": {
-            "catalog": "test",
-            "schemaTable": {"schema": "default", "table": "t"}
-          },
-          "columnConstraints": [
-            {
-              "columnName": "ds",
-              "typeSignature": "VARCHAR",
-              "domain": {
-                "nullsAllowed": false,
-                "ranges": [{
-                  "low": {"value": "2026-03-17", "bound": "EXACTLY"},
-                  "high": {"value": "2026-03-17", "bound": "EXACTLY"}
-                }]
-              }
-            },
-            {
-              "columnName": "region",
-              "typeSignature": "VARCHAR",
-              "domain": {
-                "nullsAllowed": false,
-                "ranges": [{
-                  "low": {"value": "us", "bound": "EXACTLY"},
-                  "high": {"value": "us", "bound": "EXACTLY"}
-                }]
-              }
-            }
-          ]
-        }]
-      })"));
-
-  // Greater-than (exclusive low bound).
-  ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds > '2026-03-01'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "ABOVE"}}]})")));
-
-  // Subquery: constraints are extracted from the inner table scan.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) "
-          "SELECT * FROM (SELECT * FROM t WHERE ds = '2026-03-17') sub"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
-
-  // UNION ALL: same table scanned twice, merged into one entry with
-  // united constraints.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) "
-          "SELECT * FROM t WHERE ds = '2026-03-17' "
-          "UNION ALL "
-          "SELECT * FROM t WHERE ds = '2026-03-18'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
-            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
-
-  // UNION (distinct): domains from both branches are united.
-  // (2026-03-17, +inf) ∪ (2026-03-18, +inf) = (2026-03-17, +inf).
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) "
-          "SELECT * FROM t WHERE ds > '2026-03-17' "
-          "UNION "
-          "SELECT * FROM t WHERE ds > '2026-03-18'"),
-      makeTable(makeConstraint(
-          "ds",
-          "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "ABOVE"}}]})")));
-
-  // ds <= x OR ds >= x covers all values — constraint is omitted.
-  ASSERT_EQ(
-      getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds <= '2026-03-17' OR ds >= '2026-03-17'"),
-      noConstraints);
 }
 
 TEST_F(SqlQueryRunnerTest, showStats) {

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "velox/connectors/ConnectorRegistry.h"
+
+using namespace facebook::velox;
+
+namespace axiom::sql {
+
+const std::string SqlQueryRunnerTestBase::kDefaultSchema{
+    facebook::axiom::connector::TestConnector::kDefaultSchema};
+
+void SqlQueryRunnerTestBase::SetUpTestCase() {
+  memory::MemoryManager::testingSetInstance(memory::MemoryManager::Options{});
+}
+
+void SqlQueryRunnerTestBase::SetUp() {
+  runner_ = makeRunner();
+}
+
+void SqlQueryRunnerTestBase::TearDown() {
+  runner_.reset();
+  for (const auto& id : connectorIds_) {
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().erase(id);
+    connector::ConnectorRegistry::global().erase(id);
+  }
+}
+
+std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
+    const std::string& connectorId,
+    std::function<std::string()> queryIdGenerator,
+    PermissionCheck permissionCheck,
+    bool useOptimizerV2) {
+  auto runner = std::make_unique<SqlQueryRunner>(
+      "test_user", &progressScheduler_, useOptimizerV2);
+
+  auto initConnectors = [&]() {
+    testConnector_ =
+        std::make_shared<facebook::axiom::connector::TestConnector>(
+            connectorId);
+    connector::ConnectorRegistry::global().insert(
+        testConnector_->connectorId(), testConnector_);
+    facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+        testConnector_->connectorId(), testConnector_->metadata());
+
+    connectorIds_.emplace_back(testConnector_->connectorId());
+
+    return std::make_pair(testConnector_->connectorId(), kDefaultSchema);
+  };
+
+  runner->initialize(
+      initConnectors, std::move(permissionCheck), std::move(queryIdGenerator));
+
+  return runner;
+}
+
+SqlQueryRunner::SqlResult SqlQueryRunnerTestBase::run(std::string_view sql) {
+  return runner_->run(sql, {});
+}
+
+RowVectorPtr SqlQueryRunnerTestBase::fetchSingleRow(
+    std::string_view sql,
+    const SqlQueryRunner::RunOptions& options) {
+  auto result = runner_->run(sql, options);
+  VELOX_CHECK(!result.message.has_value(), "Query failed: {}", *result.message);
+  VELOX_CHECK_EQ(1, result.results.size());
+  VELOX_CHECK_EQ(1, result.results[0]->size());
+  return result.results[0];
+}
+
+} // namespace axiom::sql

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.h
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/executors/FunctionScheduler.h>
+#include <gtest/gtest.h>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "axiom/cli/SqlQueryRunner.h"
+#include "axiom/connectors/tests/TestConnector.h"
+#include "velox/vector/tests/utils/VectorTestBase.h"
+
+namespace axiom::sql {
+
+// Shared fixture for tests that drive queries through a SqlQueryRunner backed
+// by a TestConnector. makeRunner() selects the optimizer, so a derived fixture
+// can parameterize over v1/v2.
+class SqlQueryRunnerTestBase : public ::testing::Test,
+                               public facebook::velox::test::VectorTestBase {
+ protected:
+  // Installs the process-wide Velox MemoryManager the runner allocates from.
+  static void SetUpTestCase();
+
+  // Builds the default runner_ (optimizer v1). Override to select v2.
+  void SetUp() override;
+
+  // Destroys runner_ and unregisters every connector makeRunner() created.
+  void TearDown() override;
+
+  // Builds a SqlQueryRunner over a freshly created TestConnector registered
+  // under 'connectorId', wired as the default connector/schema. The connector
+  // is unregistered in TearDown. 'useOptimizerV2' selects the optimizer.
+  std::unique_ptr<SqlQueryRunner> makeRunner(
+      const std::string& connectorId = "test",
+      std::function<std::string()> queryIdGenerator = {},
+      PermissionCheck permissionCheck = {},
+      bool useOptimizerV2 = false);
+
+  // Runs 'sql' on runner_ with default options.
+  SqlQueryRunner::SqlResult run(std::string_view sql);
+
+  // Runs 'sql', which must succeed and return exactly one row, and returns it.
+  facebook::velox::RowVectorPtr fetchSingleRow(
+      std::string_view sql,
+      const SqlQueryRunner::RunOptions& options = {});
+
+  // Runs 'sql', which must return a single row and a single column, and returns
+  // that value.
+  template <typename T>
+  T fetchSingleValue(std::string_view sql) {
+    return fetchSingleRow(sql)->childAt(0)->variantAt(0).value<T>();
+  }
+
+  // Default schema of the TestConnectors makeRunner() creates.
+  static const std::string kDefaultSchema;
+
+  // Drives progress polling for runners built by makeRunner(); declared before
+  // runner_ so it outlives any reporter a query starts.
+  folly::FunctionScheduler progressScheduler_;
+  std::unique_ptr<SqlQueryRunner> runner_;
+  std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
+
+ private:
+  std::vector<std::string> connectorIds_;
+};
+
+} // namespace axiom::sql

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -147,15 +147,17 @@ std::optional<ColumnDomainMap> computeColumnDomains(
   return domains;
 }
 
-// Merges column domains from two scans of the same table by uniting domains
-// for each column.
+// Merges another scan's column domains into 'target' by uniting the two scans'
+// domains per column. A column present in only one scan is unconstrained (all)
+// in the other, so its union is all and it is dropped rather than carried over.
 void mergeColumnDomains(ColumnDomainMap& target, const ColumnDomainMap& other) {
-  for (const auto& [columnName, domain] : other) {
-    auto it = target.find(columnName);
-    if (it == target.end()) {
-      target.emplace(columnName, domain);
+  for (auto it = target.begin(); it != target.end();) {
+    auto otherIt = other.find(it->first);
+    if (otherIt == other.end()) {
+      it = target.erase(it);
     } else {
-      it->second = it->second.unite(domain);
+      it->second = it->second.unite(otherIt->second);
+      ++it;
     }
   }
 }

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -99,28 +99,15 @@ Domain columnDomain(ColumnCP column, const ExprVector& columnFilters) {
   return domain;
 }
 
-// Recursively collects all BaseTables from a DerivedTable tree.
-void collectBaseTables(
-    DerivedTableCP dt,
-    std::vector<BaseTableCP>& baseTables) {
-  for (auto* table : dt->tables) {
-    if (table->is(PlanType::kTableNode)) {
-      baseTables.push_back(table->as<BaseTable>());
-    } else if (table->is(PlanType::kDerivedTableNode)) {
-      collectBaseTables(table->as<DerivedTable>(), baseTables);
-    }
-  }
-  for (auto* child : dt->unionInputs) {
-    collectBaseTables(child, baseTables);
-  }
-}
-
 // Per-column domains for a single table. Maps connector column name to Domain.
 using ColumnDomainMap = folly::F14FastMap<std::string, Domain>;
 
-// Computes column domains for a single BaseTable. Returns nullopt if any
-// explain_io column has an empty domain (table should be excluded).
-std::optional<ColumnDomainMap> computeColumnDomains(BaseTableCP baseTable) {
+// Computes column domains for a single BaseTable from 'filters' (the scan's
+// conjuncts). Returns nullopt if any explain_io column has an empty domain
+// (table should be excluded).
+std::optional<ColumnDomainMap> computeColumnDomains(
+    BaseTableCP baseTable,
+    const ExprVector& filters) {
   const auto* connectorTable = baseTable->schemaTable->connectorTable;
   ColumnDomainMap domains;
 
@@ -149,7 +136,7 @@ std::optional<ColumnDomainMap> computeColumnDomains(BaseTableCP baseTable) {
         connectorColumn->name(),
         connectorColumn->type()->toString());
 
-    auto domain = columnDomain(column, baseTable->columnFilters);
+    auto domain = columnDomain(column, filters);
     if (domain.isNone()) {
       return std::nullopt;
     }
@@ -202,19 +189,16 @@ folly::dynamic columnDomainsToJson(
 } // namespace
 
 std::string explainIo(
-    DerivedTableCP rootDt,
+    const std::vector<std::pair<BaseTableCP, ExprVector>>& tableFilters,
     std::optional<CatalogSchemaTableName> outputTable) {
-  std::vector<BaseTableCP> baseTables;
-  collectBaseTables(rootDt, baseTables);
-
-  // Group BaseTables by connector table and merge column domains. Multiple
+  // Group input tables by connector table and merge column domains. Multiple
   // scans of the same table (e.g., UNION ALL branches) are combined by
   // uniting their per-column domains.
   folly::F14FastMap<const connector::Table*, ColumnDomainMap> mergedDomains;
   std::vector<const connector::Table*> tableOrder;
 
-  for (auto* baseTable : baseTables) {
-    auto domains = computeColumnDomains(baseTable);
+  for (const auto& [baseTable, filters] : tableFilters) {
+    auto domains = computeColumnDomains(baseTable, filters);
     if (!domains) {
       continue;
     }
@@ -273,6 +257,38 @@ std::string explainIo(
   opts.pretty_formatting = true;
   opts.sort_keys = false;
   return folly::json::serialize(root, opts);
+}
+
+namespace {
+// Recursively collects all BaseTables from a DerivedTable tree.
+void collectBaseTables(
+    DerivedTableCP dt,
+    std::vector<BaseTableCP>& baseTables) {
+  for (auto* table : dt->tables) {
+    if (table->is(PlanType::kTableNode)) {
+      baseTables.push_back(table->as<BaseTable>());
+    } else if (table->is(PlanType::kDerivedTableNode)) {
+      collectBaseTables(table->as<DerivedTable>(), baseTables);
+    }
+  }
+  for (auto* child : dt->unionInputs) {
+    collectBaseTables(child, baseTables);
+  }
+}
+} // namespace
+
+std::string explainIo(
+    DerivedTableCP rootDt,
+    std::optional<CatalogSchemaTableName> outputTable) {
+  std::vector<BaseTableCP> baseTables;
+  collectBaseTables(rootDt, baseTables);
+
+  std::vector<std::pair<BaseTableCP, ExprVector>> tableFilters;
+  tableFilters.reserve(baseTables.size());
+  for (auto* baseTable : baseTables) {
+    tableFilters.emplace_back(baseTable, baseTable->columnFilters);
+  }
+  return explainIo(tableFilters, std::move(outputTable));
 }
 
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/ExplainIo.h
+++ b/axiom/optimizer/ExplainIo.h
@@ -17,18 +17,28 @@
 
 #include <optional>
 #include <string>
+#include <utility>
+#include <vector>
 
 #include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/optimizer/DerivedTable.h"
 
 namespace facebook::axiom::optimizer {
 
-/// Generates EXPLAIN IO JSON from the query graph.
+/// Generates EXPLAIN IO JSON from a set of input tables and their scan filters.
 ///
-/// Walks the DerivedTable tree to find input tables. If 'outputTable' is
-/// provided (INSERT/CTAS), includes it in the JSON output. For each input
-/// table, extracts column constraints from columnFilters for columns marked
-/// with includeInExplainIo (e.g., partition columns).
+/// For each (BaseTable, filters) pair, extracts column constraints from
+/// 'filters' for columns marked with includeInExplainIo (e.g., partition
+/// columns), grouping and merging by connector table. If 'outputTable' is
+/// provided (INSERT/CTAS), includes it in the JSON output. This is the shared
+/// core used by both the v1 (DerivedTable) and v2 (Scan tree) optimizers.
+std::string explainIo(
+    const std::vector<std::pair<BaseTableCP, ExprVector>>& tableFilters,
+    std::optional<CatalogSchemaTableName> outputTable = std::nullopt);
+
+/// Generates EXPLAIN IO JSON from the v1 query graph by walking the
+/// DerivedTable tree to find input tables and reading each table's
+/// columnFilters.
 std::string explainIo(
     DerivedTableCP rootDt,
     std::optional<CatalogSchemaTableName> outputTable = std::nullopt);

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/optimizer/v2/Optimize.h"
 
+#include "axiom/optimizer/ExplainIo.h"
 #include "axiom/optimizer/v2/Builder.h"
 #include "axiom/optimizer/v2/DecorrelatePass.h"
 #include "axiom/optimizer/v2/EmitPass.h"
@@ -30,6 +31,44 @@
 #include "axiom/optimizer/v2/TranslatePass.h"
 
 namespace facebook::axiom::optimizer::v2 {
+
+namespace {
+
+// Bundles the outputs of the front-end passes shared by full optimization and
+// EXPLAIN (TYPE IO).
+struct FrontendResult {
+  TranslatePass::Result translated;
+  NodeCP pushed;
+};
+
+// Runs the front-end passes shared by `optimize` and `explainIo`. 'schema' and
+// 'builder' must outlive the returned IR.
+FrontendResult translateAndPushdown(
+    const logical_plan::LogicalPlanNode& plan,
+    Schema& schema,
+    velox::core::ExpressionEvaluator& evaluator,
+    Builder& builder) {
+  auto translated = TranslatePass::run(plan, schema, evaluator, builder);
+  NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
+  NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
+  NodeCP pushed = PushdownAndPrunePass::run(limited, builder, evaluator);
+  return {std::move(translated), pushed};
+}
+
+// Collects each Scan's base table and its pushed-down filter conjuncts.
+void collectScans(
+    NodeCP node,
+    std::vector<std::pair<BaseTableCP, ExprVector>>& tableFilters) {
+  if (node->is(NodeType::kScan)) {
+    const auto* scan = node->as<Scan>();
+    tableFilters.emplace_back(scan->baseTable(), scan->filters());
+  }
+  for (auto* input : node->inputs()) {
+    collectScans(input, tableFilters);
+  }
+}
+
+} // namespace
 
 PlanAndStats optimize(
     const logical_plan::LogicalPlanNode& plan,
@@ -49,12 +88,9 @@ PlanAndStats optimize(
   ScanHandleCache scanHandles;
 
   Builder builder;
-  auto translated = TranslatePass::run(plan, schema, evaluator, builder);
-  NodeCP decorrelated = DecorrelatePass::run(translated.root, builder);
-  NodeCP limited = LimitAndOrderPass::run(decorrelated, builder);
-  NodeCP pushed = PushdownAndPrunePass::run(limited, builder, evaluator);
+  auto frontend = translateAndPushdown(plan, schema, evaluator, builder);
   NodeCP folded = FoldMetadataAggregatePass::run(
-      pushed, builder, session, evaluator, scanHandles);
+      frontend.pushed, builder, session, evaluator, scanHandles);
   if (session.options().useFilteredTableStats) {
     EstimateLeafStatsPass::run(folded, session, evaluator, scanHandles);
   }
@@ -71,8 +107,8 @@ PlanAndStats optimize(
 
   EmitPass::Result emitted = EmitPass::run(
       root,
-      translated.outputColumns,
-      translated.outputNames,
+      frontend.translated.outputColumns,
+      frontend.translated.outputNames,
       session,
       evaluator,
       scanHandles,
@@ -83,6 +119,25 @@ PlanAndStats optimize(
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
   return result;
+}
+
+std::string explainIo(
+    const logical_plan::LogicalPlanNode& plan,
+    const connector::SchemaResolver& schemaResolver,
+    velox::core::ExpressionEvaluator& evaluator,
+    std::optional<CatalogSchemaTableName> outputTable) {
+  // Schema is owned here so its `connector::TablePtr`s — and the raw pointers
+  // the IR's `BaseTable` nodes hold into them — stay alive for the duration.
+  Schema schema(schemaResolver);
+
+  // Run only the passes that push predicates into scans; join ordering and Emit
+  // are not needed to report IO.
+  Builder builder;
+  auto frontend = translateAndPushdown(plan, schema, evaluator, builder);
+
+  std::vector<std::pair<BaseTableCP, ExprVector>> tableFilters;
+  collectScans(frontend.pushed, tableFilters);
+  return optimizer::explainIo(tableFilters, std::move(outputTable));
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Optimize.h
+++ b/axiom/optimizer/v2/Optimize.h
@@ -16,6 +16,10 @@
 
 #pragma once
 
+#include <optional>
+#include <string>
+
+#include "axiom/common/CatalogSchemaTableName.h"
 #include "axiom/connectors/SchemaResolver.h"
 #include "axiom/logical_plan/LogicalPlanNode.h"
 #include "axiom/optimizer/MultiFragmentPlan.h"
@@ -56,5 +60,16 @@ PlanAndStats optimize(
     const OptimizerSession& session,
     velox::core::ExpressionEvaluator& evaluator,
     const MultiFragmentPlan::Options& options);
+
+/// Produces the EXPLAIN (TYPE IO) JSON for 'plan'. Runs the pipeline only
+/// through PushdownAndPrunePass (predicate pushdown into scans) — join ordering
+/// and Emit are skipped — then extracts per-table column domains from the scan
+/// filters. 'outputTable' is included for INSERT/CTAS. Must be called with an
+/// active QueryGraphContext, as `optimize` requires.
+std::string explainIo(
+    const logical_plan::LogicalPlanNode& plan,
+    const connector::SchemaResolver& schemaResolver,
+    velox::core::ExpressionEvaluator& evaluator,
+    std::optional<CatalogSchemaTableName> outputTable = std::nullopt);
 
 } // namespace facebook::axiom::optimizer::v2


### PR DESCRIPTION
Summary:
When a query scans the same table more than once with filters on different
columns (e.g. a self-join), `EXPLAIN (TYPE IO)` reported the intersection of
the per-scan column constraints instead of their union, under-reporting the IO.

Concretely, for the query:

  SELECT a.x FROM t a, t b WHERE a.ds = '2026-03-17' AND b.region = 'us'

scan `a` reads ds='2026-03-17' (all regions) and scan `b` reads region='us'
(all ds), so together they may read the whole table — IO should report no
column constraints. The old code intersected the two scans and instead
reported:

  ds = '2026-03-17' AND region = 'us'

which is less than is actually read, the unsafe direction for a cost or
permissions estimate.

The fix reports a column only when it is constrained in every scan of the
table, uniting their domains. This is a pre-existing defect in the shared
EXPLAIN IO core, so it corrects both the v1 and v2 optimizers.

Differential Revision: D112941681


