### PR TITLE
fix(sql): Canonicalize CREATE TABLE property names

### DIFF
--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -59,12 +59,17 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
 
   // SELECT with no table scans.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT 1"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT 1"),
       normalizeJson(R"({"inputTableColumnInfos": []})"));
 
   // SELECT with table scan.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM nation"), normalizeJson(R"({
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM nation"),
+      normalizeJson(R"({
         "inputTableColumnInfos": [{
           "table": {
             "catalog": "test",
@@ -76,7 +81,9 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
 
   // CTAS with output table.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) CREATE TABLE t AS SELECT * FROM nation"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "CREATE TABLE t AS SELECT * FROM nation"),
       normalizeJson(R"({
         "inputTableColumnInfos": [{
           "table": {
@@ -95,7 +102,8 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
   testConnector_->addTable("t", ROW({"key", "name"}, {BIGINT(), VARCHAR()}));
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) INSERT INTO t(key, name) "
+          "EXPLAIN (TYPE IO) "
+          "INSERT INTO t(key, name) "
           "SELECT r_regionkey, r_name FROM region"),
       normalizeJson(R"({
         "inputTableColumnInfos": [{
@@ -114,7 +122,9 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
   // JOIN: multiple input tables sorted by name.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM nation, region WHERE n_regionkey = r_regionkey"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM nation, region "
+          "   WHERE n_regionkey = r_regionkey"),
       normalizeJson(R"({
         "inputTableColumnInfos": [
           {
@@ -183,92 +193,160 @@ TEST_P(ExplainIoTest, columnConstraints) {
 
   // Equality constraint.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds = '2026-03-17'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds = '2026-03-17'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // IN constraint.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds IN ('2026-03-17', '2026-03-18')"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds IN ('2026-03-17', '2026-03-18')"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
-            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // Range constraint.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds >= '2026-03-01' AND ds <= '2026-03-31'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds >= '2026-03-01' AND ds <= '2026-03-31'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-31", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // BETWEEN maps to a closed range, inclusive on both ends.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds BETWEEN '2026-03-01' AND '2026-03-31'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-31", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-31", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // BETWEEN on an integer column produces the same closed range.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE n BETWEEN 1 AND 10"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE n BETWEEN 1 AND 10"),
       makeTable(makeConstraint(
           "n",
           "BIGINT",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": 1, "bound": "EXACTLY"},
-             "high": {"value": 10, "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": 1, "bound": "EXACTLY"},
+                "high": {"value": 10, "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // LIKE with a literal prefix maps to a half-open range [prefix, prefix++),
   // where the upper bound increments the last byte of the prefix.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05%'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05%'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05", "bound": "EXACTLY"},
-             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-05", "bound": "EXACTLY"},
+                "high": {"value": "2026-06", "bound": "BELOW"}
+              }
+            ]
+          })")));
 
   // The '_' single-character wildcard also terminates the prefix.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05_'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05_'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05", "bound": "EXACTLY"},
-             "high": {"value": "2026-06", "bound": "BELOW"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-05", "bound": "EXACTLY"},
+                "high": {"value": "2026-06", "bound": "BELOW"}
+              }
+            ]
+          })")));
 
   // LIKE with no wildcards degenerates to equality.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '2026-05-01'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05-01'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-05-01", "bound": "EXACTLY"},
-             "high": {"value": "2026-05-01", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-05-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-05-01", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   auto noConstraints = normalizeJson(R"({
     "inputTableColumnInfos": [{
@@ -282,81 +360,110 @@ TEST_P(ExplainIoTest, columnConstraints) {
 
   // No constraint on explain_io column (filter on non-explain_io column only).
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE x = 1"), noConstraints);
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE x = 1"),
+      noConstraints);
 
   // Unconvertible filter on explain_io column drops the column entirely.
   // NOT is not supported, so ds <> 'foo' (which becomes NOT(eq(ds, 'foo')))
   // causes the column to be dropped.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds <> 'foo'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds <> 'foo'"),
       noConstraints);
 
   // NOT BETWEEN (parsed as not(between(...))) is unconvertible and drops the
   // column, same as other negations.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds NOT BETWEEN '2026-03-01' AND '2026-03-31'"),
       noConstraints);
 
   // BETWEEN with low > high is an empty range, so the whole table is excluded.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds BETWEEN '2026-03-31' AND '2026-03-01'"),
       normalizeJson(R"({"inputTableColumnInfos": []})"));
 
   // LIKE with a leading wildcard has no usable prefix, so it is dropped.
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds LIKE '%05'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '%05'"),
       noConstraints);
 
   // LIKE with an ESCAPE clause is not converted (escape semantics are not
   // interpreted), so the column is dropped.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds LIKE '2026-05%' ESCAPE '#'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds LIKE '2026-05%' ESCAPE '#'"),
       noConstraints);
 
   // Mix of convertible and unconvertible filters: unconvertible conjunct is
   // skipped (broader is safe), convertible conjunct is shown.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds >= '2026-03-01' AND ds <> 'foo'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds >= '2026-03-01' AND ds <> 'foo'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // IS NULL OR equality: nullsAllowed is true.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds IS NULL OR ds = '2026-03-17'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds IS NULL OR ds = '2026-03-17'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": true, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": true,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // OR with unconvertible disjunct: the entire OR expression cannot be
   // converted (dropping a disjunct would narrow the result, which is unsafe).
   // The unconvertible OR is skipped as a conjunct (broader is safe).
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds = '2026-03-17' OR length(ds) > 3"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds = '2026-03-17' OR length(ds) > 3"),
       noConstraints);
 
   // Constraints on both explain_io columns.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds = '2026-03-17' AND region = 'us'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds = '2026-03-17' AND region = 'us'"),
       normalizeJson(R"({
         "inputTableColumnInfos": [{
           "table": {
@@ -392,12 +499,21 @@ TEST_P(ExplainIoTest, columnConstraints) {
 
   // Greater-than (exclusive low bound).
   ASSERT_EQ(
-      getJson("EXPLAIN (TYPE IO) SELECT * FROM t WHERE ds > '2026-03-01'"),
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds > '2026-03-01'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-01", "bound": "ABOVE"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "ABOVE"}
+              }
+            ]
+          })")));
 
   // Subquery: constraints are extracted from the inner table scan.
   ASSERT_EQ(
@@ -407,9 +523,15 @@ TEST_P(ExplainIoTest, columnConstraints) {
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // UNION ALL: same table scanned twice, merged into one entry with
   // united constraints.
@@ -422,11 +544,19 @@ TEST_P(ExplainIoTest, columnConstraints) {
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-17", "bound": "EXACTLY"}},
-            {"low": {"value": "2026-03-18", "bound": "EXACTLY"},
-             "high": {"value": "2026-03-18", "bound": "EXACTLY"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 
   // UNION (distinct): domains from both branches are united.
   // (2026-03-17, +inf) ∪ (2026-03-18, +inf) = (2026-03-17, +inf).
@@ -439,15 +569,78 @@ TEST_P(ExplainIoTest, columnConstraints) {
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",
-          R"({"nullsAllowed": false, "ranges": [
-            {"low": {"value": "2026-03-17", "bound": "ABOVE"}}]})")));
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "ABOVE"}
+              }
+            ]
+          })")));
 
   // ds <= x OR ds >= x covers all values — constraint is omitted.
   ASSERT_EQ(
       getJson(
-          "EXPLAIN (TYPE IO) SELECT * FROM t "
-          "WHERE ds <= '2026-03-17' OR ds >= '2026-03-17'"),
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ds <= '2026-03-17' OR ds >= '2026-03-17'"),
       noConstraints);
+
+  // Same table scanned twice with filters on different columns: neither column
+  // is constrained in both scans, so the whole table may be read.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT a.x FROM t a, t b "
+          "   WHERE a.ds = '2026-03-17' AND b.region = 'us'"),
+      noConstraints);
+
+  // Same table scanned twice: ds is constrained in both (values unioned), but
+  // region only in one, so region is dropped (the other scan reads all
+  // regions).
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT a.x FROM t a, t b "
+          "   WHERE a.ds = '2026-03-17' "
+          "     AND b.ds = '2026-03-18' AND b.region = 'us'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // Same table scanned twice with overlapping ds ranges: the union coalesces
+  // them into a single range spanning both.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT a.x FROM t a, t b "
+          "   WHERE a.ds BETWEEN '2026-03-01' AND '2026-03-20' "
+          "     AND b.ds BETWEEN '2026-03-10' AND '2026-03-31'"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-01", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-31", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -567,7 +567,7 @@ std::vector<SqlFunctionDefinitionPtr> TestConnectorMetadata::findFunction(
   if (it == functions_.end()) {
     return {};
   }
-  return {it->second};
+  return it->second;
 }
 
 void TestConnectorMetadata::addFunction(
@@ -577,10 +577,8 @@ void TestConnectorMetadata::addFunction(
       schemas_.contains(functionName.schema),
       "Schema not found: {}",
       functionName.schema);
-  auto [_, inserted] = functions_.emplace(
-      functionName,
+  functions_[functionName].push_back(
       std::make_shared<const SqlFunctionDefinition>(std::move(definition)));
-  VELOX_CHECK(inserted, "Function already registered: {}", functionName);
 }
 
 ProcedurePtr TestConnectorMetadata::findProcedure(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -622,8 +622,9 @@ class TestConnectorMetadata : public ConnectorMetadata {
   std::vector<SqlFunctionDefinitionPtr> findFunction(
       const SchemaFunctionName& functionName) override;
 
-  /// Registers a SQL-invoked function for findFunction() resolution. Throws if
-  /// a function with the same name is already registered.
+  /// Registers a SQL-invoked function overload for findFunction() resolution.
+  /// Multiple overloads may be registered under the same name; they are
+  /// returned together and selected by argument type.
   void addFunction(
       const SchemaFunctionName& functionName,
       SqlFunctionDefinition definition);
@@ -682,7 +683,8 @@ class TestConnectorMetadata : public ConnectorMetadata {
 
   folly::F14FastSet<std::string> schemas_{"default"};
   folly::F14FastMap<SchemaTypeName, velox::TypePtr> types_;
-  folly::F14FastMap<SchemaFunctionName, SqlFunctionDefinitionPtr> functions_;
+  folly::F14FastMap<SchemaFunctionName, std::vector<SqlFunctionDefinitionPtr>>
+      functions_;
   folly::F14FastMap<SchemaProcedureName, ProcedurePtr> procedures_;
 };
 

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -147,15 +147,17 @@ std::optional<ColumnDomainMap> computeColumnDomains(
   return domains;
 }
 
-// Merges column domains from two scans of the same table by uniting domains
-// for each column.
+// Merges another scan's column domains into 'target' by uniting the two scans'
+// domains per column. A column present in only one scan is unconstrained (all)
+// in the other, so its union is all and it is dropped rather than carried over.
 void mergeColumnDomains(ColumnDomainMap& target, const ColumnDomainMap& other) {
-  for (const auto& [columnName, domain] : other) {
-    auto it = target.find(columnName);
-    if (it == target.end()) {
-      target.emplace(columnName, domain);
+  for (auto it = target.begin(); it != target.end();) {
+    auto otherIt = other.find(it->first);
+    if (otherIt == other.end()) {
+      it = target.erase(it);
     } else {
-      it->second = it->second.unite(domain);
+      it->second = it->second.unite(otherIt->second);
+      ++it;
     }
   }
 }

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -51,6 +51,7 @@ namespace {
 
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
+using facebook::axiom::connector::SqlFunctionDefinitionPtr;
 
 class ErrorListener : public antlr4::BaseErrorListener {
  public:
@@ -1818,6 +1819,88 @@ lp::ExprPtr wrapWithNullGuard(
       body);
 }
 
+// Formats a function call or signature as "name(type1, type2)".
+std::string toSignatureString(
+    const std::string& name,
+    const std::vector<TypePtr>& argTypes) {
+  std::ostringstream out;
+  out << name << "(";
+  for (size_t i = 0; i < argTypes.size(); ++i) {
+    if (i > 0) {
+      out << ", ";
+    }
+    out << argTypes[i]->toString();
+  }
+  out << ")";
+  return out.str();
+}
+
+// Selects the overload of a SQL-invoked function whose declared argument types
+// best match 'argTypes'. Reuses the same per-argument coercion (TypeCoercer)
+// and lowest-cost ranking (Coercion::pickLowestCost) that resolve native
+// function overloads, so SQL functions resolve identically. The resolver owns
+// this matching; the expression resolver applies the coercion to
+// 'argumentTypes' later. Throws a user error - consistent with native function
+// resolution - when no overload's signature matches, including an ambiguous
+// match. 'name' is the qualified function name, used only for error messages.
+SqlFunctionDefinitionPtr resolveSqlFunctionOverload(
+    const std::string& name,
+    const std::vector<SqlFunctionDefinitionPtr>& overloads,
+    const std::vector<TypePtr>& argTypes,
+    const TypeCoercer& coercer) {
+  std::vector<std::pair<std::vector<Coercion>, SqlFunctionDefinitionPtr>>
+      candidates;
+  for (const auto& overload : overloads) {
+    if (overload->argumentTypes.size() != argTypes.size()) {
+      continue;
+    }
+    std::vector<Coercion> coercions(argTypes.size());
+    bool viable = true;
+    for (size_t i = 0; i < argTypes.size(); ++i) {
+      const auto& declaredType = overload->argumentTypes[i];
+      if (argTypes[i]->equivalent(*declaredType)) {
+        continue;
+      }
+      if (auto coercion = coercer.coerce(argTypes[i], declaredType)) {
+        coercions[i] = coercion.value();
+        continue;
+      }
+
+      viable = false;
+      break;
+    }
+
+    if (viable) {
+      candidates.emplace_back(std::move(coercions), overload);
+    }
+  }
+
+  const auto selected =
+      Coercion::pickLowestCost(candidates, argTypes, [&](size_t i) {
+        return Coercion::CandidateMetadata{
+            .returnType = candidates[i].second->returnType,
+            .nullOnNull = candidates[i].second->defaultNullBehavior};
+      });
+
+  if (!selected.has_value()) {
+    std::string supportedSignatures;
+    for (const auto& overload : overloads) {
+      if (!supportedSignatures.empty()) {
+        supportedSignatures += ", ";
+      }
+      supportedSignatures += toSignatureString(name, overload->argumentTypes) +
+          " -> " + overload->returnType->toString();
+    }
+
+    VELOX_USER_FAIL(
+        "SQL function signature is not supported: {}. Supported signatures: {}.",
+        toSignatureString(name, argTypes),
+        supportedSignatures);
+  }
+
+  return candidates[selected.value()].second;
+}
+
 // Builds the resolver that inlines connector-defined SQL-invoked functions.
 // Only names that the frontend marked with a leading '.' are treated as
 // qualified function references; everything else returns nullopt so builtin
@@ -1851,38 +1934,11 @@ lp::ExprResolver::SqlFunctionResolver makeSqlFunctionResolver(
     auto overloads =
         metadata->findFunction({/*schema=*/parts[1], /*function=*/parts[2]});
     VELOX_USER_CHECK(
-        !overloads.empty(), "SQL function not found: {}", name.substr(1));
+        !overloads.empty(), "SQL function doesn't exist: {}.", name.substr(1));
 
-    // Multiple signatures for one name are not supported yet.
-    VELOX_USER_CHECK_EQ(
-        overloads.size(),
-        1,
-        "Overloaded SQL functions are not supported: {}",
-        name.substr(1));
-    const auto& definition = *overloads.front();
-
-    // Match the call to the signature: argument count, then each argument type
-    // coercible to its declared type. The resolver owns this matching, so the
-    // expression resolver only applies the coercion later, never re-checks it.
-    VELOX_USER_CHECK_EQ(
-        argTypes.size(),
-        definition.argumentTypes.size(),
-        "SQL function called with wrong number of arguments: {}",
-        name.substr(1));
-    for (size_t i = 0; i < argTypes.size(); ++i) {
-      const auto& declaredType = definition.argumentTypes[i];
-      if (argTypes[i]->equivalent(*declaredType)) {
-        continue;
-      }
-
-      VELOX_USER_CHECK(
-          coercer->coerce(argTypes[i], declaredType).has_value(),
-          "Cannot coerce SQL function argument {} to its declared type: {} to {}: {}",
-          i,
-          argTypes[i]->toString(),
-          declaredType->toString(),
-          name.substr(1));
-    }
+    const auto definitionPtr = resolveSqlFunctionOverload(
+        name.substr(1), overloads, argTypes, *coercer);
+    const auto& definition = *definitionPtr;
 
     lp::ExprResolver::ResolvedSqlFunction resolved;
     resolved.argumentNames = definition.argumentNames;

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2493,7 +2493,9 @@ std::unordered_map<std::string, lp::ExprPtr> parseTableProperties(
     const std::vector<std::shared_ptr<Property>>& props) {
   std::unordered_map<std::string, lp::ExprPtr> properties;
   for (const auto& p : props) {
-    const auto& name = p->name()->value();
+    // Property names are identifiers; canonicalize so connectors receive
+    // canonical option keys regardless of the case or quoting the user wrote.
+    const auto name = canonicalizeIdentifier(*p->name());
     auto expr = resolveSqlExpression(user, p->value());
     AXIOM_PRESTO_SEMANTIC_CHECK(
         expr->looksConstant(),

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -133,14 +133,20 @@ TEST_F(DdlParserTest, createTable) {
     ASSERT_TRUE(createTable->ifNotExists());
   }
 
-  // properties
-  testCreateTable(
-      "CREATE TABLE t (id INTEGER, ds VARCHAR) "
-      "WITH (partitioned_by = ARRAY['ds'], format = 'ORC')",
-      "t",
-      ROW({"id", "ds"}, {INTEGER(), VARCHAR()}),
-      /*properties=*/
-      {{"partitioned_by", "array_constructor(ds)"}, {"format", "ORC"}});
+  // Properties. Names are identifiers canonicalized to lowercase, so the same
+  // option keys reach the connector whether written lowercase or uppercase.
+  for (const auto* withClause : {
+           "WITH (partitioned_by = ARRAY['ds'], format = 'ORC')",
+           "WITH (PARTITIONED_BY = array['ds'], FORMAT = 'ORC')",
+           "with (partitioned_By = ARRAY['ds'], Format = 'ORC')",
+       }) {
+    testCreateTable(
+        std::string("CREATE TABLE t (id INTEGER, ds VARCHAR) ") + withClause,
+        "t",
+        ROW({"id", "ds"}, {INTEGER(), VARCHAR()}),
+        /*properties=*/
+        {{"partitioned_by", "array_constructor(ds)"}, {"format", "ORC"}});
+  }
 
   // a variety of different types
   testCreateTable(

--- a/axiom/sql/presto/tests/SqlFunctionTest.cpp
+++ b/axiom/sql/presto/tests/SqlFunctionTest.cpp
@@ -147,6 +147,73 @@ TEST_F(SqlFunctionTest, inlines) {
           .output());
 }
 
+// Overloads of one name are selected by argument count, then by type,
+// preferring an exact match over a coercible one - the same ranking used for
+// native functions.
+TEST_F(SqlFunctionTest, overloads) {
+  // pick(x) := x  and  pick(a, b) := a + b differ by argument count.
+  metadata_->addFunction(
+      {"default", "pick"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x",
+          .defaultNullBehavior = false,
+      });
+  metadata_->addFunction(
+      {"default", "pick"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"a", "b"},
+          .argumentTypes = {BIGINT(), BIGINT()},
+          .body = "a + b",
+          .defaultNullBehavior = false,
+      });
+
+  testSelect(
+      "SELECT tc.default.pick(n_nationkey) FROM nation",
+      matchScan("nation").project({"n_nationkey"}).output());
+  testSelect(
+      "SELECT tc.default.pick(n_nationkey, n_regionkey) FROM nation",
+      matchScan("nation").project({"n_nationkey + n_regionkey"}).output());
+
+  // widen(x BIGINT) and widen(x DOUBLE) have the same arity; the exact type
+  // match is preferred over coercing the argument.
+  metadata_->addFunction(
+      {"default", "widen"},
+      {
+          .returnType = BIGINT(),
+          .argumentNames = {"x"},
+          .argumentTypes = {BIGINT()},
+          .body = "x",
+          .defaultNullBehavior = false,
+      });
+  metadata_->addFunction(
+      {"default", "widen"},
+      {
+          .returnType = DOUBLE(),
+          .argumentNames = {"x"},
+          .argumentTypes = {DOUBLE()},
+          .body = "x",
+          .defaultNullBehavior = false,
+      });
+
+  // A BIGINT argument binds to the BIGINT overload with no coercion.
+  testSelect(
+      "SELECT tc.default.widen(n_nationkey) FROM nation",
+      matchScan("nation").project({"n_nationkey"}).output());
+  // A DOUBLE argument binds to the DOUBLE overload.
+  testSelect(
+      "SELECT tc.default.widen(cast(n_nationkey as double)) FROM nation",
+      matchScan("nation").project({"cast(n_nationkey as double)"}).output());
+
+  // No overload matches the argument types.
+  VELOX_ASSERT_THROW(
+      parseSelect("SELECT tc.default.widen(n_name) FROM nation"),
+      "SQL function signature is not supported");
+}
+
 // Each argument is cast to its declared type, and the body is cast to the
 // declared return type.
 TEST_F(SqlFunctionTest, coercion) {
@@ -251,18 +318,18 @@ TEST_F(SqlFunctionTest, resolutionErrors) {
   // No such function.
   VELOX_ASSERT_THROW(
       parseSelect("SELECT tc.default.missing(n_nationkey) FROM nation"),
-      "SQL function not found");
+      "SQL function doesn't exist");
 
-  // Wrong number of arguments.
+  // Wrong number of arguments: no overload matches.
   VELOX_ASSERT_THROW(
       parseSelect(
           "SELECT tc.default.identity(n_nationkey, n_regionkey) FROM nation"),
-      "SQL function called with wrong number of arguments");
+      "SQL function signature is not supported");
 
-  // Argument not coercible to the declared type.
+  // Argument not coercible to the declared type: no overload matches.
   VELOX_ASSERT_THROW(
       parseSelect("SELECT tc.default.identity(n_name) FROM nation"),
-      "Cannot coerce SQL function argument");
+      "SQL function signature is not supported");
 
   // Body does not use every argument.
   metadata_->addFunction(


### PR DESCRIPTION
Summary:
Property names in a WITH clause were passed through as written, so an uppercase name produced a non-canonical option key. For example:

    CREATE TABLE t (...) WITH (PARTITIONED_BY = ARRAY['ds'])

produced the key `PARTITIONED_BY` rather than `partitioned_by`, which a connector expecting canonical lowercase keys would not recognize. Property names are identifiers, so they are now canonicalized to lowercase like every other identifier. The connector then receives the canonical key regardless of the case the user wrote.

Differential Revision: D112964188


