### PR TITLE
fix: Support boolean partition columns in EXPLAIN IO

### DIFF
--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -146,8 +146,8 @@ TEST_P(ExplainIoTest, inputAndOutputTables) {
 }
 
 TEST_P(ExplainIoTest, columnConstraints) {
-  run("CREATE TABLE t (x BIGINT, n BIGINT, ds VARCHAR, region VARCHAR) "
-      "WITH (explain_io = ARRAY['n', 'ds', 'region'])");
+  run("CREATE TABLE t (x BIGINT, n BIGINT, b BOOLEAN, ds VARCHAR, region VARCHAR) "
+      "WITH (explain_io = ARRAY['n', 'b', 'ds', 'region'])");
   SCOPE_EXIT {
     run("DROP TABLE t");
   };
@@ -206,6 +206,64 @@ TEST_P(ExplainIoTest, columnConstraints) {
               {
                 "low": {"value": "2026-03-17", "bound": "EXACTLY"},
                 "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // Equality on a boolean explain_io column yields a single-value domain.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE b = true"),
+      makeTable(makeConstraint(
+          "b",
+          "BOOLEAN",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": true, "bound": "EXACTLY"},
+                "high": {"value": true, "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // Equality against FALSE yields the false single-value domain (the value is
+  // carried literally, not treated as an absent bound).
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE b = false"),
+      makeTable(makeConstraint(
+          "b",
+          "BOOLEAN",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": false, "bound": "EXACTLY"},
+                "high": {"value": false, "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // IS NULL OR equality on a boolean column: nullsAllowed is true.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE b IS NULL OR b = true"),
+      makeTable(makeConstraint(
+          "b",
+          "BOOLEAN",
+          R"({
+            "nullsAllowed": true,
+            "ranges": [
+              {
+                "low": {"value": true, "bound": "EXACTLY"},
+                "high": {"value": true, "bound": "EXACTLY"}
               }
             ]
           })")));

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -126,12 +126,13 @@ std::optional<ColumnDomainMap> computeColumnDomains(
     const auto typeKind = connectorColumn->type()->kind();
     VELOX_USER_CHECK(
         typeKind == velox::TypeKind::VARCHAR ||
+            typeKind == velox::TypeKind::BOOLEAN ||
             typeKind == velox::TypeKind::TINYINT ||
             typeKind == velox::TypeKind::SMALLINT ||
             typeKind == velox::TypeKind::INTEGER ||
             typeKind == velox::TypeKind::BIGINT,
         "Unsupported type for EXPLAIN IO column. "
-        "Only VARCHAR and integer types are supported: {}.{} {}",
+        "Only VARCHAR, BOOLEAN, and integer types are supported: {}.{} {}",
         baseTable->schemaTable->name(),
         connectorColumn->name(),
         connectorColumn->type()->toString());


### PR DESCRIPTION
Summary:
`EXPLAIN (TYPE IO)` aborted on tables that have a BOOLEAN partition column. Referencing such a column tripped the io-output type check, so a common reporting query family (`SELECT ... WHERE is_manager = FALSE ... GROUP BY ...`) failed to explain, while Presto handles it.

`computeColumnDomains` previously allowed only VARCHAR and integer column types. It now also allows BOOLEAN and reports `boolcol = TRUE/FALSE` as a single-value boolean domain, matching Presto.

Out of scope: other io-output column types that are still rejected (DATE, DECIMAL, TIMESTAMP, REAL, DOUBLE).

Reviewed By: mbasmanova

Differential Revision: D111399483


