### PR TITLE
fix(sql): Cap nesting depth during AST construction (#1626)

### DIFF
--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -296,6 +296,15 @@ std::any AstBuilder::visitSingleStatement(
   return visit(ctx->statement());
 }
 
+void AstBuilder::checkNestingDepth(antlr4::ParserRuleContext* ctx) const {
+  AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+      tracingIndent_,
+      options_.maxExpressionDepth,
+      getLocation(ctx),
+      /*token=*/std::nullopt,
+      "Expression exceeds maximum nesting depth");
+}
+
 std::any AstBuilder::visitQuery(PrestoSqlParser::QueryContext* ctx) {
   trace("visitQuery");
 

--- a/axiom/sql/presto/ast/AstBuilder.h
+++ b/axiom/sql/presto/ast/AstBuilder.h
@@ -653,6 +653,7 @@ class AstBuilder : public PrestoSqlVisitor {
       return nullptr;
     }
 
+    checkNestingDepth(ctx);
     ++tracingIndent_;
     SCOPE_EXIT {
       --tracingIndent_;
@@ -706,9 +707,12 @@ class AstBuilder : public PrestoSqlVisitor {
 
   void trace(std::string_view name) const;
 
+  // Throws when AST nesting exceeds options_.maxExpressionDepth.
+  void checkNestingDepth(antlr4::ParserRuleContext* ctx) const;
+
   const ParserOptions options_;
   const bool enableTracing_;
-  int tracingIndent_ = 0;
+  uint32_t tracingIndent_{0};
 };
 
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1100,18 +1100,35 @@ TEST_F(ExpressionParserTest, mixedCaseColumnName) {
       "SELECT ORDERINGID FROM mixedCase", matchScan().project().output()));
 }
 
-TEST_F(ExpressionParserTest, expressionDepthCapBoundary) {
-  auto chain = [](uint32_t terms) {
-    std::string expr = "1";
-    for (uint32_t i = 0; i < terms; ++i) {
-      expr += " + 0";
-    }
-    return expr;
+TEST_F(ExpressionParserTest, nestingDepthCapped) {
+  auto chain =
+      [](std::string_view head, std::string_view unit, uint32_t repetitions) {
+        std::string sql{head};
+        for (uint32_t i = 0; i < repetitions; ++i) {
+          sql += unit;
+        }
+        return sql;
+      };
+
+  // A shallow expression parses.
+  EXPECT_NE(nullptr, parseExpr(chain("1", " + 0", 8)));
+
+  // Nesting past the cap fails cleanly, regardless of construct kind.
+  const uint32_t past = ParserOptions::kMaxExpressionDepthDefault + 1;
+  auto expectRejected = [&](std::string_view head, std::string_view unit) {
+    SCOPED_TRACE(head);
+    AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+        parseExpr(chain(head, unit, past)),
+        "Expression exceeds maximum nesting depth");
   };
-  EXPECT_NE(
-      nullptr, parseExpr(chain(ParserOptions::kMaxExpressionDepthDefault - 1)));
+  expectRejected("1", " + 0");
+  expectRejected("true", " AND true");
+  expectRejected("'a'", " || 'a'");
+  expectRejected("x", "[1]");
+
+  // UNION nests at the statement level, so it goes through parseSql.
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
-      parseExpr(chain(ParserOptions::kMaxExpressionDepthDefault)),
+      parseSql(chain("SELECT 1", " UNION ALL SELECT 1", past)),
       "Expression exceeds maximum nesting depth");
 }
 


### PR DESCRIPTION
Summary:

A hugely nested SQL expression can crash instead of returning an error. Thousands of OR'd predicates, or a long `a + b + c + ...` chain make the parser recurse once per term as it builds the syntax tree. Deep enough, that exhausts the C++ stack and the process SIGSEGVs. For example, this crashes around 9K terms:

    SELECT x + 0 + 0 + ... + 0 FROM t

Solution: Add a nesting-depth counter to `AstBuilder`, capped at the `max_expression_depth` session property (default 256). Past the limit the query fails with "Expression exceeds maximum nesting depth" instead of crashing. The counter sits on `visitTyped`, which every syntax node passes through, so one check catches deep `+`, `||`, `a[i][j]`, `UNION`, and joins alike.

Very deep subqueries or parentheses overflow inside the ANTLR parser, before `AstBuilder` runs, and need a parser-level limit. This will be covered in a follow up.

Reviewed By: mbasmanova

Differential Revision: D112955340


