### PR TITLE
feat(optimizer): Show cardinality estimates in v2 EXPLAIN (#1627)

### DIFF
--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(
   axiom_cli_test
   CatalogPropertiesTest.cpp
   ExplainIoTest.cpp
+  ExplainTest.cpp
   ShowStatsTest.cpp
   SqlQueryRunnerTest.cpp
   SqlQueryRunnerTestBase.cpp

--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -31,11 +31,8 @@ class ExplainIoTest : public SqlQueryRunnerTestBase,
                       public ::testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
-    runner_ = makeRunner(
-        "test",
-        /*queryIdGenerator=*/{},
-        /*permissionCheck=*/{},
-        /*useOptimizerV2=*/GetParam());
+    useV2_ = GetParam();
+    SqlQueryRunnerTestBase::SetUp();
   }
 };
 

--- a/axiom/cli/tests/ExplainTest.cpp
+++ b/axiom/cli/tests/ExplainTest.cpp
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/String.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
+#include "axiom/connectors/ConnectorMetadata.h"
+#include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+using namespace facebook::velox;
+
+namespace axiom::sql {
+namespace {
+
+// Runs EXPLAIN under both optimizer v1 and v2 (the bool parameter).
+class ExplainTest : public SqlQueryRunnerTestBase,
+                    public ::testing::WithParamInterface<bool> {
+ protected:
+  void SetUp() override {
+    useV2_ = GetParam();
+    SqlQueryRunnerTestBase::SetUp();
+  }
+};
+
+// Plain EXPLAIN annotates each plan node with the optimizer's cardinality
+// estimate, drawn from the registered TPC-H statistics and the WHERE
+// selectivity: the filter and project carry the post-filter row count, the
+// aggregation the distinct l_orderkey count within that range. A single-worker,
+// single-driver plan collapses to one Aggregation with no repartition, so v1
+// and v2 emit the same shape; StartsWith covers the Aggregation and Project
+// lines, whose optimizer-internal column names differ between v1 and v2.
+TEST_P(ExplainTest, showsCardinalityEstimate) {
+  testConnector_->addTpchTables(1);
+
+  auto result = runner_->run(
+      "EXPLAIN "
+      "SELECT l_orderkey, sum(l_extendedprice * l_discount) "
+      "FROM lineitem "
+      "WHERE l_orderkey < 1000 "
+      "GROUP BY 1",
+      {.numWorkers = 1, .numDrivers = 1});
+  ASSERT_TRUE(result.message.has_value());
+
+  std::vector<std::string> lines;
+  folly::split('\n', *result.message, lines);
+
+  using ::testing::Eq;
+  using ::testing::StartsWith;
+
+  EXPECT_THAT(
+      lines,
+      ::testing::ElementsAre(
+          Eq("Fragment 0: fragment1 SINGLE:"),
+          StartsWith("-- Aggregation[3][SINGLE [l_orderkey] sum := sum("),
+          StartsWith("   Estimate: 249.75 rows, "),
+          StartsWith("  -- Project[2][expressions: (l_orderkey:BIGINT, "),
+          StartsWith("     Estimate: 999.202 rows, "),
+          StartsWith("    -- Filter[1][expression: lt(\"l_orderkey\",1000)]"),
+          StartsWith("       Estimate: 999.202 rows, "),
+          StartsWith("      -- TableScan[0][\"default\".\"lineitem\"]"),
+          Eq(""),
+          Eq("")));
+}
+
+TEST_P(ExplainTest, explainCreateTable) {
+  auto result = run("EXPLAIN CREATE TABLE t(x int)");
+  EXPECT_EQ(result.message, R"(CREATE TABLE test."default"."t")");
+
+  // EXPLAIN is side-effect-free.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      run("SELECT * FROM t"), "Table not found: t");
+
+  // Fails if the table already exists.
+  run("CREATE TABLE t(x int)");
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN CREATE TABLE t(x int)"), "Table already exists");
+
+  // IF NOT EXISTS succeeds even if the table exists.
+  result = run("EXPLAIN CREATE TABLE IF NOT EXISTS t(x int)");
+  EXPECT_EQ(result.message, R"(CREATE TABLE IF NOT EXISTS test."default"."t")");
+}
+
+TEST_P(ExplainTest, explainDropTable) {
+  // Fails if the table doesn't exist.
+  VELOX_ASSERT_THROW(run("EXPLAIN DROP TABLE t"), "Table does not exist");
+
+  // IF EXISTS succeeds even if the table doesn't exist.
+  auto result = run("EXPLAIN DROP TABLE IF EXISTS t");
+  EXPECT_EQ(result.message, R"(DROP TABLE IF EXISTS test."default"."t")");
+
+  run("CREATE TABLE t(x int)");
+
+  result = run("EXPLAIN DROP TABLE t");
+  EXPECT_EQ(result.message, R"(DROP TABLE test."default"."t")");
+
+  // EXPLAIN is side-effect-free.
+  run("DROP TABLE t");
+}
+
+TEST_P(ExplainTest, explainAddColumn) {
+  auto findTable = [&]() {
+    auto metadata = facebook::axiom::connector::ConnectorMetadataRegistry::get(
+        testConnector_->connectorId());
+    return metadata->findTable({"default", "t"});
+  };
+
+  run("CREATE TABLE t(x BIGINT)");
+
+  auto result = run("EXPLAIN ALTER TABLE t ADD COLUMN y VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(ALTER TABLE test."default"."t" ADD COLUMN y VARCHAR)");
+
+  // EXPLAIN must not have side effects.
+  ASSERT_NE(nullptr, findTable());
+  VELOX_ASSERT_EQ_TYPES(findTable()->type(), ROW({"x"}, {BIGINT()}));
+
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
+      "Table does not exist");
+
+  result =
+      run("EXPLAIN ALTER TABLE IF EXISTS no_such_table ADD COLUMN y VARCHAR");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(ALTER TABLE IF EXISTS test."default"."no_such_table" ADD COLUMN y VARCHAR)");
+
+  // EXPLAIN throws when column already exists and !ifNotExists.
+  run("ALTER TABLE t ADD COLUMN dup VARCHAR");
+  VELOX_ASSERT_THROW(
+      run("EXPLAIN ALTER TABLE t ADD COLUMN dup INTEGER"),
+      "Column already exists");
+
+  // EXPLAIN with IF NOT EXISTS on existing column is a no-op (no throw).
+  result = run("EXPLAIN ALTER TABLE t ADD COLUMN IF NOT EXISTS dup INTEGER");
+  EXPECT_EQ(
+      result.message.value(),
+      R"(ALTER TABLE test."default"."t" ADD COLUMN IF NOT EXISTS dup INTEGER)");
+
+  // EXPLAIN must not have mutated the column type.
+  VELOX_EXPECT_EQ_TYPES(
+      findTable()->type(), ROW({"x", "dup"}, {BIGINT(), VARCHAR()}));
+
+  run("DROP TABLE t");
+}
+
+TEST_P(ExplainTest, explainCtas) {
+  {
+    auto result = run("EXPLAIN (TYPE LOGICAL) CREATE TABLE t AS SELECT 1 AS x");
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(
+        result.message.value(),
+        ::testing::HasSubstr("- TableWrite CREATE: -> ROW<rows:BIGINT>"));
+  }
+
+  // TYPE OPTIMIZED is v1-only.
+  if (useV2_) {
+    VELOX_ASSERT_THROW(
+        run("EXPLAIN (TYPE OPTIMIZED) CREATE TABLE t AS SELECT 1 AS x"),
+        "EXPLAIN TYPE OPTIMIZED is not supported with --v2");
+  } else {
+    auto result =
+        run("EXPLAIN (TYPE OPTIMIZED) CREATE TABLE t AS SELECT 1 AS x");
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(
+        result.message.value(),
+        ::testing::HasSubstr("TableWrite [1.00 rows] ->"));
+  }
+
+  {
+    auto result = run("EXPLAIN CREATE TABLE t AS SELECT 1 AS x");
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(result.message.value(), ::testing::HasSubstr("-- TableWrite"));
+  }
+
+  // EXPLAIN is side-effect-free.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      run("SELECT * FROM t"), "Table not found: t");
+
+  // EXPLAIN ANALYZE runs the query and creates the table.
+  {
+    auto result = run("EXPLAIN ANALYZE CREATE TABLE t AS SELECT 1 AS x");
+    ASSERT_TRUE(result.message.has_value());
+    EXPECT_THAT(result.message.value(), ::testing::HasSubstr("-- TableWrite"));
+  }
+
+  {
+    auto result = run("SELECT * FROM t");
+    ASSERT_FALSE(result.message.has_value());
+    ASSERT_EQ(1, result.results.size());
+    test::assertEqualVectors(
+        result.results[0], makeRowVector({makeFlatVector<int32_t>({1})}));
+  }
+}
+
+TEST_P(ExplainTest, explainPopulatesOptimizeTiming) {
+  auto runWithTiming = [&](std::string_view sql) {
+    QueryTiming timing;
+    SqlQueryRunner::RunOptions options{
+        .onComplete = [&](const QueryCompletionInfo& info) {
+          timing = info.timing;
+        }};
+    runner_->run(sql, options);
+    return timing;
+  };
+
+  // EXPLAIN (TYPE LOGICAL) does not populate optimize timing.
+  EXPECT_EQ(0, runWithTiming("EXPLAIN (TYPE LOGICAL) SELECT 1").optimize);
+
+  // TYPE GRAPH and TYPE OPTIMIZED are v1-only; the other EXPLAIN variants
+  // populate optimize timing under both optimizers.
+  if (!useV2_) {
+    EXPECT_GT(runWithTiming("EXPLAIN (TYPE GRAPH) SELECT 1").optimize, 0);
+    EXPECT_GT(runWithTiming("EXPLAIN (TYPE OPTIMIZED) SELECT 1").optimize, 0);
+  }
+  EXPECT_GT(runWithTiming("EXPLAIN SELECT 1").optimize, 0);
+  EXPECT_GT(runWithTiming("EXPLAIN (TYPE IO) SELECT 1").optimize, 0);
+
+  // EXPLAIN ANALYZE populates both optimize and execute timing.
+  auto analyzeTiming = runWithTiming("EXPLAIN ANALYZE SELECT 1");
+  EXPECT_GT(analyzeTiming.optimize, 0);
+  EXPECT_GT(analyzeTiming.execute, 0);
+}
+
+TEST_P(ExplainTest, explainFormatGraphviz) {
+  // TYPE LOGICAL FORMAT GRAPHVIZ produces DOT output under both optimizers.
+  {
+    auto graphviz =
+        run("EXPLAIN (TYPE LOGICAL, FORMAT GRAPHVIZ) SELECT 1 AS x");
+    ASSERT_TRUE(graphviz.message.has_value());
+    EXPECT_THAT(graphviz.message.value(), ::testing::HasSubstr("digraph"));
+
+    // Without FORMAT, produces text (no "digraph").
+    auto text = run("EXPLAIN (TYPE LOGICAL) SELECT 1 AS x");
+    ASSERT_TRUE(text.message.has_value());
+    EXPECT_THAT(
+        text.message.value(), ::testing::Not(::testing::HasSubstr("digraph")));
+  }
+
+  // TYPE GRAPH is v1-only.
+  if (useV2_) {
+    VELOX_ASSERT_THROW(
+        run("EXPLAIN (TYPE GRAPH, FORMAT GRAPHVIZ) SELECT 1 AS x"),
+        "EXPLAIN TYPE GRAPH is not supported with --v2");
+  } else {
+    auto graphviz = run("EXPLAIN (TYPE GRAPH, FORMAT GRAPHVIZ) SELECT 1 AS x");
+    ASSERT_TRUE(graphviz.message.has_value());
+    EXPECT_THAT(graphviz.message.value(), ::testing::HasSubstr("digraph"));
+
+    auto text = run("EXPLAIN (TYPE GRAPH) SELECT 1 AS x");
+    ASSERT_TRUE(text.message.has_value());
+    EXPECT_THAT(
+        text.message.value(), ::testing::Not(::testing::HasSubstr("digraph")));
+  }
+
+  // FORMAT GRAPHVIZ with unsupported TYPE fails (checked before the v2 gate).
+  VELOX_ASSERT_USER_THROW(
+      run("EXPLAIN (TYPE OPTIMIZED, FORMAT GRAPHVIZ) SELECT 1 AS x"),
+      "EXPLAIN FORMAT GRAPHVIZ is supported for TYPE LOGICAL and TYPE GRAPH only");
+
+  VELOX_ASSERT_USER_THROW(
+      run("EXPLAIN (FORMAT GRAPHVIZ) SELECT 1 AS x"),
+      "EXPLAIN FORMAT GRAPHVIZ is supported for TYPE LOGICAL and TYPE GRAPH only");
+
+  // FORMAT JSON is rejected.
+  VELOX_ASSERT_USER_THROW(
+      run("EXPLAIN (FORMAT JSON) SELECT 1 AS x"),
+      "Unsupported EXPLAIN format: JSON");
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    SqlQueryRunner,
+    ExplainTest,
+    ::testing::Values(false, true),
+    [](const ::testing::TestParamInfo<bool>& info) {
+      return info.param ? "v2" : "v1";
+    });
+
+} // namespace
+} // namespace axiom::sql

--- a/axiom/cli/tests/ShowStatsTest.cpp
+++ b/axiom/cli/tests/ShowStatsTest.cpp
@@ -29,11 +29,8 @@ class ShowStatsTest : public SqlQueryRunnerTestBase,
                       public ::testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
-    runner_ = makeRunner(
-        "test",
-        /*queryIdGenerator=*/{},
-        /*permissionCheck=*/{},
-        /*useOptimizerV2=*/GetParam());
+    useV2_ = GetParam();
+    SqlQueryRunnerTestBase::SetUp();
   }
 };
 

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -177,94 +177,6 @@ TEST_F(SqlQueryRunnerTest, parseMultipleWithInvalidStatement) {
       std::exception);
 }
 
-TEST_F(SqlQueryRunnerTest, explainPopulatesOptimizeTiming) {
-  auto runWithTiming = [&](std::string_view sql) {
-    QueryTiming timing;
-    SqlQueryRunner::RunOptions options{
-        .onComplete = [&](const QueryCompletionInfo& info) {
-          timing = info.timing;
-        }};
-    runner_->run(sql, options);
-    return timing;
-  };
-
-  // EXPLAIN (TYPE LOGICAL) does not populate optimize timing.
-  EXPECT_EQ(0, runWithTiming("EXPLAIN (TYPE LOGICAL) SELECT 1").optimize);
-
-  // All other EXPLAIN variants populate optimize timing.
-  EXPECT_GT(runWithTiming("EXPLAIN (TYPE GRAPH) SELECT 1").optimize, 0);
-  EXPECT_GT(runWithTiming("EXPLAIN (TYPE OPTIMIZED) SELECT 1").optimize, 0);
-  EXPECT_GT(runWithTiming("EXPLAIN SELECT 1").optimize, 0);
-  EXPECT_GT(runWithTiming("EXPLAIN (TYPE IO) SELECT 1").optimize, 0);
-
-  // EXPLAIN ANALYZE populates both optimize and execute timing.
-  auto analyzeTiming = runWithTiming("EXPLAIN ANALYZE SELECT 1");
-  EXPECT_GT(analyzeTiming.optimize, 0);
-  EXPECT_GT(analyzeTiming.execute, 0);
-}
-
-TEST_F(SqlQueryRunnerTest, explainCtas) {
-  {
-    auto result = run("EXPLAIN (TYPE LOGICAL) CREATE TABLE t AS SELECT 1 AS x");
-    ASSERT_TRUE(result.message.has_value());
-    EXPECT_THAT(
-        result.message.value(),
-        ::testing::HasSubstr("- TableWrite CREATE: -> ROW<rows:BIGINT>"));
-  }
-
-  {
-    auto result =
-        run("EXPLAIN (TYPE OPTIMIZED) CREATE TABLE t AS SELECT 1 AS x");
-    ASSERT_TRUE(result.message.has_value());
-    EXPECT_THAT(
-        result.message.value(),
-        ::testing::HasSubstr("TableWrite [1.00 rows] ->"));
-  }
-
-  {
-    auto result = run("EXPLAIN CREATE TABLE t AS SELECT 1 AS x");
-    ASSERT_TRUE(result.message.has_value());
-    EXPECT_THAT(result.message.value(), ::testing::HasSubstr("-- TableWrite"));
-  }
-
-  // EXPLAIN is side-effect-free.
-  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
-      run("SELECT * FROM t"), "Table not found: t");
-
-  // EXPLAIN ANALYZE runs the query and creates the table.
-  {
-    auto result = run("EXPLAIN ANALYZE CREATE TABLE t AS SELECT 1 AS x");
-    ASSERT_TRUE(result.message.has_value());
-    EXPECT_THAT(result.message.value(), ::testing::HasSubstr("-- TableWrite"));
-  }
-
-  {
-    auto result = run("SELECT * FROM t");
-    ASSERT_FALSE(result.message.has_value());
-    ASSERT_EQ(1, result.results.size());
-    test::assertEqualVectors(
-        result.results[0], makeRowVector({makeFlatVector<int32_t>({1})}));
-  }
-}
-
-TEST_F(SqlQueryRunnerTest, explainCreateTable) {
-  auto result = run("EXPLAIN CREATE TABLE t(x int)");
-  EXPECT_EQ(result.message, R"(CREATE TABLE test."default"."t")");
-
-  // EXPLAIN is side-effect-free.
-  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
-      run("SELECT * FROM t"), "Table not found: t");
-
-  // Fails if the table already exists.
-  run("CREATE TABLE t(x int)");
-  VELOX_ASSERT_THROW(
-      run("EXPLAIN CREATE TABLE t(x int)"), "Table already exists");
-
-  // IF NOT EXISTS succeeds even if the table exists.
-  result = run("EXPLAIN CREATE TABLE IF NOT EXISTS t(x int)");
-  EXPECT_EQ(result.message, R"(CREATE TABLE IF NOT EXISTS test."default"."t")");
-}
-
 TEST_F(SqlQueryRunnerTest, createTableRunsWritePath) {
   // Connectors that commit a new table in finishWrite (not createTable) rely on
   // CREATE TABLE running the write path. Inject a finishWrite error to confirm
@@ -276,23 +188,6 @@ TEST_F(SqlQueryRunnerTest, createTableRunsWritePath) {
 
   // A real CREATE runs the write path, surfacing the commit error.
   VELOX_ASSERT_THROW(run("CREATE TABLE t(x int)"), "boom from finishWrite");
-}
-
-TEST_F(SqlQueryRunnerTest, explainDropTable) {
-  // Fails if the table doesn't exist.
-  VELOX_ASSERT_THROW(run("EXPLAIN DROP TABLE t"), "Table does not exist");
-
-  // IF EXISTS succeeds even if the table doesn't exist.
-  auto result = run("EXPLAIN DROP TABLE IF EXISTS t");
-  EXPECT_EQ(result.message, R"(DROP TABLE IF EXISTS test."default"."t")");
-
-  run("CREATE TABLE t(x int)");
-
-  result = run("EXPLAIN DROP TABLE t");
-  EXPECT_EQ(result.message, R"(DROP TABLE test."default"."t")");
-
-  // EXPLAIN is side-effect-free.
-  run("DROP TABLE t");
 }
 
 TEST_F(SqlQueryRunnerTest, createAndDropSchema) {
@@ -341,38 +236,6 @@ TEST_F(SqlQueryRunnerTest, currentTimestamp) {
   auto row = fetchSingleRow("SELECT current_timestamp", options);
   auto packed = row->childAt(0)->as<SimpleVector<int64_t>>()->valueAt(0);
   EXPECT_EQ(unpackMillisUtc(packed), options.sessionStartTimeMs);
-}
-
-TEST_F(SqlQueryRunnerTest, explainFormatGraphviz) {
-  for (const auto& type : {"LOGICAL", "GRAPH"}) {
-    SCOPED_TRACE(type);
-
-    // FORMAT GRAPHVIZ produces DOT output.
-    auto graphviz = run(
-        fmt::format("EXPLAIN (TYPE {}, FORMAT GRAPHVIZ) SELECT 1 AS x", type));
-    ASSERT_TRUE(graphviz.message.has_value());
-    EXPECT_THAT(graphviz.message.value(), ::testing::HasSubstr("digraph"));
-
-    // Without FORMAT, produces text (no "digraph").
-    auto text = run(fmt::format("EXPLAIN (TYPE {}) SELECT 1 AS x", type));
-    ASSERT_TRUE(text.message.has_value());
-    EXPECT_THAT(
-        text.message.value(), ::testing::Not(::testing::HasSubstr("digraph")));
-  }
-
-  // FORMAT GRAPHVIZ with unsupported TYPE fails.
-  VELOX_ASSERT_USER_THROW(
-      run("EXPLAIN (TYPE OPTIMIZED, FORMAT GRAPHVIZ) SELECT 1 AS x"),
-      "EXPLAIN FORMAT GRAPHVIZ is supported for TYPE LOGICAL and TYPE GRAPH only");
-
-  VELOX_ASSERT_USER_THROW(
-      run("EXPLAIN (FORMAT GRAPHVIZ) SELECT 1 AS x"),
-      "EXPLAIN FORMAT GRAPHVIZ is supported for TYPE LOGICAL and TYPE GRAPH only");
-
-  // FORMAT JSON is rejected.
-  VELOX_ASSERT_USER_THROW(
-      run("EXPLAIN (FORMAT JSON) SELECT 1 AS x"),
-      "Unsupported EXPLAIN format: JSON");
 }
 
 TEST_F(SqlQueryRunnerTest, showSchemasWithLike) {
@@ -1102,53 +965,6 @@ TEST_F(SqlQueryRunnerTest, addColumn) {
   VELOX_ASSERT_THROW(
       run("ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
       "Table does not exist");
-}
-
-TEST_F(SqlQueryRunnerTest, explainAddColumn) {
-  auto findTable = [&]() {
-    auto metadata = facebook::axiom::connector::ConnectorMetadataRegistry::get(
-        testConnector_->connectorId());
-    return metadata->findTable({"default", "t"});
-  };
-
-  run("CREATE TABLE t(x BIGINT)");
-
-  auto result = run("EXPLAIN ALTER TABLE t ADD COLUMN y VARCHAR");
-  EXPECT_EQ(
-      result.message.value(),
-      R"(ALTER TABLE test."default"."t" ADD COLUMN y VARCHAR)");
-
-  // EXPLAIN must not have side effects.
-  ASSERT_NE(nullptr, findTable());
-  VELOX_ASSERT_EQ_TYPES(findTable()->type(), ROW({"x"}, {BIGINT()}));
-
-  VELOX_ASSERT_THROW(
-      run("EXPLAIN ALTER TABLE no_such_table ADD COLUMN y VARCHAR"),
-      "Table does not exist");
-
-  result =
-      run("EXPLAIN ALTER TABLE IF EXISTS no_such_table ADD COLUMN y VARCHAR");
-  EXPECT_EQ(
-      result.message.value(),
-      R"(ALTER TABLE IF EXISTS test."default"."no_such_table" ADD COLUMN y VARCHAR)");
-
-  // EXPLAIN throws when column already exists and !ifNotExists.
-  run("ALTER TABLE t ADD COLUMN dup VARCHAR");
-  VELOX_ASSERT_THROW(
-      run("EXPLAIN ALTER TABLE t ADD COLUMN dup INTEGER"),
-      "Column already exists");
-
-  // EXPLAIN with IF NOT EXISTS on existing column is a no-op (no throw).
-  result = run("EXPLAIN ALTER TABLE t ADD COLUMN IF NOT EXISTS dup INTEGER");
-  EXPECT_EQ(
-      result.message.value(),
-      R"(ALTER TABLE test."default"."t" ADD COLUMN IF NOT EXISTS dup INTEGER)");
-
-  // EXPLAIN must not have mutated the column type.
-  VELOX_EXPECT_EQ_TYPES(
-      findTable()->type(), ROW({"x", "dup"}, {BIGINT(), VARCHAR()}));
-
-  run("DROP TABLE t");
 }
 
 TEST_F(SqlQueryRunnerTest, call) {

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
@@ -45,10 +45,9 @@ void SqlQueryRunnerTestBase::TearDown() {
 std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
     const std::string& connectorId,
     std::function<std::string()> queryIdGenerator,
-    PermissionCheck permissionCheck,
-    bool useOptimizerV2) {
+    PermissionCheck permissionCheck) {
   auto runner = std::make_unique<SqlQueryRunner>(
-      "test_user", &progressScheduler_, useOptimizerV2);
+      "test_user", &progressScheduler_, useV2_);
 
   auto initConnectors = [&]() {
     testConnector_ =

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.h
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.h
@@ -38,7 +38,8 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
   // Installs the process-wide Velox MemoryManager the runner allocates from.
   static void SetUpTestCase();
 
-  // Builds the default runner_ (optimizer v1). Override to select v2.
+  // Builds runner_ for the optimizer selected by useV2_ (default v1). A derived
+  // fixture selects v2 by setting useV2_ before calling this.
   void SetUp() override;
 
   // Destroys runner_ and unregisters every connector makeRunner() created.
@@ -46,12 +47,12 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
 
   // Builds a SqlQueryRunner over a freshly created TestConnector registered
   // under 'connectorId', wired as the default connector/schema. The connector
-  // is unregistered in TearDown. 'useOptimizerV2' selects the optimizer.
+  // is unregistered in TearDown. Selects the optimizer per 'useV2_', which a
+  // parameterized fixture sets before calling.
   std::unique_ptr<SqlQueryRunner> makeRunner(
       const std::string& connectorId = "test",
       std::function<std::string()> queryIdGenerator = {},
-      PermissionCheck permissionCheck = {},
-      bool useOptimizerV2 = false);
+      PermissionCheck permissionCheck = {});
 
   // Runs 'sql' on runner_ with default options.
   SqlQueryRunner::SqlResult run(std::string_view sql);
@@ -76,6 +77,10 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
   folly::FunctionScheduler progressScheduler_;
   std::unique_ptr<SqlQueryRunner> runner_;
   std::shared_ptr<facebook::axiom::connector::TestConnector> testConnector_;
+
+  // Selects the optimizer makeRunner() builds; a parameterized fixture sets
+  // this before calling makeRunner() and branches its expectations on v1 vs v2.
+  bool useV2_{false};
 
  private:
   std::vector<std::string> connectorIds_;

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -24,6 +24,7 @@
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/Schema.h"
 #include "axiom/optimizer/WriteStatsBuilder.h"
+#include "axiom/optimizer/v2/EstimateProvider.h"
 #include "axiom/optimizer/v2/ExprEmitter.h"
 #include "axiom/optimizer/v2/PhysicalProperties.h"
 #include "velox/core/PlanConsistencyChecker.h"
@@ -223,6 +224,12 @@ class Emitter {
         options_{options} {}
 
   velox::core::PlanNodePtr emit(NodeCP node) {
+    auto plan = emitNode(node);
+    recordPrediction(node, plan);
+    return plan;
+  }
+
+  velox::core::PlanNodePtr emitNode(NodeCP node) {
     switch (node->nodeType()) {
       case NodeType::kScan:
         return emitScan(*node->as<Scan>());
@@ -272,6 +279,19 @@ class Emitter {
 
   std::string nextId() {
     return std::to_string(nextNodeId_++);
+  }
+
+  // Records the estimated cardinality of IR 'node' against the emitted Velox
+  // 'plan's top node id, for EXPLAIN. Skips unknown cardinalities.
+  void recordPrediction(NodeCP node, const velox::core::PlanNodePtr& plan) {
+    if (plan == nullptr) {
+      return;
+    }
+    const auto& estimate = estimateProvider_.estimate(node);
+    if (estimate.cardinality.has_value()) {
+      prediction_[plan->id()] =
+          NodePrediction{.cardinality = *estimate.cardinality};
+    }
   }
 
   // Local exchange inserted below a final/single aggregation at numDrivers > 1
@@ -485,6 +505,13 @@ class Emitter {
   // commit or abort the write. Empty (bool false) for read-only queries.
   FinishWrite finishWrite_;
 
+  // Estimates IR-node cardinality for EXPLAIN, memoized over the emit-time IR.
+  EstimateProvider estimateProvider_;
+
+  // Per-node estimated cardinality keyed by emitted PlanNodeId; moved out via
+  // takePrediction.
+  NodePredictionMap prediction_;
+
  public:
   // Lowers 'root' (plus the output rename to 'outputNames') into fragments,
   // returning them with the root fragment last.
@@ -497,6 +524,11 @@ class Emitter {
   // any, to the caller. Empty for read-only queries.
   FinishWrite takeFinishWrite() {
     return std::move(finishWrite_);
+  }
+
+  // Transfers the per-node cardinality predictions collected during emit.
+  NodePredictionMap takePrediction() {
+    return std::move(prediction_);
   }
 };
 
@@ -783,19 +815,27 @@ velox::core::PlanNodePtr Emitter::emitRoot(
     NodeCP node,
     const ColumnVector& outputColumns,
     const std::vector<std::string>& outputNames) {
+  // Emit via emitNode, not emit, so the root's estimate is recorded once below
+  // against the outermost node (the trim/rename projection when one wraps it),
+  // rather than also against the inner node emit() would key it to.
+  velox::core::PlanNodePtr result;
   if (isIdentityLayout(*node, outputColumns, outputNames)) {
-    auto result = emit(node);
+    result = emitNode(node);
     // A scan with a rejected filter emits the filter's columns for the
     // FilterNode; trim them so they do not leak into the query output.
     if (result->outputType()->size() > outputColumns.size()) {
       result = projectToColumns(outputColumns, std::move(result));
     }
-    return result;
+  } else if (node->is(NodeType::kProject)) {
+    result = emitRootProject(*node->as<Project>(), outputColumns, outputNames);
+  } else {
+    result = wrapWithRenameProject(emitNode(node), outputColumns, outputNames);
   }
-  if (node->is(NodeType::kProject)) {
-    return emitRootProject(*node->as<Project>(), outputColumns, outputNames);
-  }
-  return wrapWithRenameProject(emit(node), outputColumns, outputNames);
+
+  // A trim or rename projection is cardinality-neutral, so the root's estimate
+  // annotates whichever node ends up outermost, so EXPLAIN shows it on top.
+  recordPrediction(node, result);
+  return result;
 }
 
 namespace {
@@ -2125,7 +2165,10 @@ EmitPass::Result EmitPass::run(
   VELOX_CHECK_EQ(outputColumns.size(), outputNames.size());
   Emitter emitter(session, evaluator, scanHandles, options);
   auto fragments = emitter.emitFragments(root, outputColumns, outputNames);
-  return Result{std::move(fragments), emitter.takeFinishWrite()};
+  return Result{
+      std::move(fragments),
+      emitter.takeFinishWrite(),
+      emitter.takePrediction()};
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/EmitPass.h
+++ b/axiom/optimizer/v2/EmitPass.h
@@ -18,6 +18,7 @@
 
 #include "axiom/optimizer/MultiFragmentPlan.h"
 #include "axiom/optimizer/OptimizerSession.h"
+#include "axiom/optimizer/ToVelox.h"
 #include "axiom/optimizer/v2/Node.h"
 #include "axiom/optimizer/v2/ScanHandle.h"
 #include "velox/core/Expressions.h"
@@ -34,6 +35,9 @@ class EmitPass {
     std::vector<ExecutableFragment> fragments;
     /// Set when the plan writes a table; empty otherwise.
     FinishWrite finishWrite;
+    /// Per-node estimated cardinality, keyed by emitted `PlanNodeId`, for
+    /// EXPLAIN. Empty when estimates are unavailable.
+    NodePredictionMap prediction;
   };
 
   /// Lowers the tree-IR rooted at 'root' into fragments, projecting to the

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -114,6 +114,7 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
   result.plan = std::make_shared<MultiFragmentPlan>(
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
+  result.prediction = std::move(emitted.prediction);
   return result;
 }
 


### PR DESCRIPTION
Summary:

Under --v2, plain EXPLAIN printed the plan tree without the per-node row-count estimates that v1 shows. It now annotates each node the same way. For example:

    -- Aggregation[3][SINGLE [l_orderkey] ...]
       Estimate: 249.75 rows, 0B peak memory
      -- Project[2][...]
         Estimate: 999.202 rows, 0B peak memory

EmitPass records each IR node's estimated cardinality, read from the EstimateProvider it already builds, against the emitted plan node's id. This flows out through PlanAndStats.prediction, which the plan printer renders for v1 today.

Repartition nodes and a table scan below a residual filter carry no estimate, matching v1.

The EXPLAIN-focused runner tests move into a new parameterized ExplainTest that runs under both optimizers; the shared test base gains a useV2_ member a fixture sets before building its runner.

Differential Revision: D113128276


