### PR TITLE
fix(parser): ORDER BY aggregate over global aggregation (#1628)

### DIFF
--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -81,3 +81,12 @@ SELECT DISTINCT a, COUNT(*) AS cnt FROM t GROUP BY a ORDER BY a
 -- Aggregate alias collides with a GROUP BY key name.
 -- duckdb: SELECT max(b) FROM t GROUP BY b
 SELECT MAX(b) AS b FROM t GROUP BY b
+----
+-- ORDER BY over a global aggregation: the sort key resolves to the aggregate
+-- output, whether written as the aggregate expression or the SELECT alias.
+SELECT count(*) AS c FROM t ORDER BY count(*) DESC
+----
+SELECT count(*) AS c FROM t ORDER BY c DESC
+----
+-- Global aggregation with HAVING and ORDER BY together.
+SELECT count(*) AS c FROM t HAVING count(*) > 1 ORDER BY count(*)

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -438,7 +438,8 @@ void GroupByPlanner::plan(
 
 bool GroupByPlanner::tryPlanGlobalAgg(
     const std::vector<SelectItemPtr>& selectItems,
-    const ExpressionPtr& having) && {
+    const ExpressionPtr& having,
+    const OrderByPtr& orderBy) && {
   for (const auto& item : selectItems) {
     if (item->is(NodeType::kAllColumns) || item->is(NodeType::kSelectColumns)) {
       return false;
@@ -472,8 +473,7 @@ bool GroupByPlanner::tryPlanGlobalAgg(
     selectExprs.push_back(std::move(expr));
   }
 
-  std::move(*this).plan(
-      {}, /*distinct=*/false, selectExprs, having, /*orderBy=*/nullptr);
+  std::move(*this).plan({}, /*distinct=*/false, selectExprs, having, orderBy);
   return true;
 }
 

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -53,11 +53,13 @@ class GroupByPlanner {
       const OrderByPtr& orderBy) &&;
 
   /// Detects implicit global aggregation (e.g. SELECT count(*) FROM t)
-  /// and plans it. Returns true if aggregation was added. Accepts raw AST
-  /// select items and resolves them internally.
+  /// and plans it, including any ORDER BY over the aggregates. Returns true if
+  /// aggregation was added. Accepts raw AST select items and resolves them
+  /// internally.
   bool tryPlanGlobalAgg(
       const std::vector<SelectItemPtr>& selectItems,
-      const ExpressionPtr& having) &&;
+      const ExpressionPtr& having,
+      const OrderByPtr& orderBy) &&;
 
  private:
   std::vector<std::vector<lp::ExprApi>> expandGroupingSets(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1478,14 +1478,12 @@ class RelationPlanner : public AstVisitor {
       }
     } else {
       if (GroupByPlanner{builder_, exprPlanner_}.tryPlanGlobalAgg(
-              selectItems, node->having())) {
+              selectItems, node->having(), orderBy)) {
         // GroupByPlanner does not go through buildSelectProjections, so
-        // stage display names from the SELECT items directly.
+        // stage display names from the SELECT items directly. It also plans
+        // ORDER BY over the aggregates. DISTINCT is a no-op since a global
+        // aggregation without a GROUP BY produces one row.
         displayNames_.captureLastNames(selectItems);
-        // Nothing else to do. For aggregation, ORDER BY can only reference
-        // SELECT list (aggregates). DISTINCT will be a no-op since global
-        // aggregations without a group by are 1 row output.
-        addOrderBy(orderBy);
       } else if (distinct) {
         addDistinctAndOrderBy(selectItems, orderBy);
       } else {

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -44,6 +44,24 @@ TEST_F(AggregationParserTest, countStar) {
     auto matcher = matchScan().aggregate().filter().output();
     testSelect("SELECT count(*) FROM nation HAVING count(*) > 100", matcher);
   }
+
+  {
+    // ORDER BY over a global aggregation: the sort key resolves to the
+    // aggregate output, whether written as the aggregate expression, the
+    // SELECT alias, or an ordinal.
+    auto matcher = matchScan().aggregate().sort().output();
+    testSelect("SELECT count(*) FROM nation ORDER BY count(*) DESC", matcher);
+    testSelect("SELECT count(*) AS c FROM nation ORDER BY c DESC", matcher);
+    testSelect("SELECT count(*) FROM nation ORDER BY 1", matcher);
+  }
+
+  {
+    // HAVING and ORDER BY together over a global aggregation.
+    auto matcher = matchScan().aggregate().filter().sort().output();
+    testSelect(
+        "SELECT count(*) FROM nation HAVING count(*) > 100 ORDER BY count(*)",
+        matcher);
+  }
 }
 
 TEST_F(AggregationParserTest, nestedAggregateRejected) {


### PR DESCRIPTION
Summary:

Ordering a global aggregation by one of its aggregates failed to plan. For example:

    SELECT count(*) AS c FROM t ORDER BY count(*) DESC

failed with:

    Scalar function doesn't exist: count

The global-aggregation path planned the aggregate through GroupByPlanner but handled ORDER BY in a separate step that re-resolved the sort expression after the aggregate, where count is no longer an aggregate and falls through to scalar-function resolution. The GROUP BY path already resolves ORDER BY aggregates, so route the global-aggregation path through the same GroupByPlanner::plan() call.

Differential Revision: D113136129
