### PR TITLE
fix(parser): Aggregate in a RANGE window frame bound (#1630)

### DIFF
--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -81,3 +81,12 @@ SELECT DISTINCT a, COUNT(*) AS cnt FROM t GROUP BY a ORDER BY a
 -- Aggregate alias collides with a GROUP BY key name.
 -- duckdb: SELECT max(b) FROM t GROUP BY b
 SELECT MAX(b) AS b FROM t GROUP BY b
+----
+-- ORDER BY over a global aggregation: the sort key resolves to the aggregate
+-- output, whether written as the aggregate expression or the SELECT alias.
+SELECT count(*) AS c FROM t ORDER BY count(*) DESC
+----
+SELECT count(*) AS c FROM t ORDER BY c DESC
+----
+-- Global aggregation with HAVING and ORDER BY together.
+SELECT count(*) AS c FROM t HAVING count(*) > 1 ORDER BY count(*)

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -200,3 +200,10 @@ SELECT a, c FROM t ORDER BY c / sum(c) OVER () DESC
 -- SELECT DISTINCT with a nested window in ORDER BY that repeats a SELECT item.
 -- ordered
 SELECT DISTINCT c / sum(c) OVER () AS s FROM t ORDER BY c / sum(c) OVER ()
+----
+-- A window whose ORDER BY key is an aggregate and whose frame is a RANGE
+-- offset, over a GROUP BY.
+-- ordered
+SELECT count(*) OVER (ORDER BY max(d) RANGE BETWEEN INTERVAL '1' DAY PRECEDING AND CURRENT ROW) AS c
+FROM (VALUES (DATE '2025-01-01', 1), (DATE '2025-01-02', 2), (DATE '2025-01-03', 3)) AS t(d, n)
+GROUP BY d

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -187,3 +187,16 @@ FROM (
             / sum(b) OVER (PARTITION BY a)) AS pct
     FROM t
 )
+----
+-- ORDER BY a window nested in an expression that also appears in the SELECT
+-- list: the sort key matches the SELECT item and reuses its window.
+-- ordered
+SELECT a, c, c / sum(c) OVER () AS share FROM t ORDER BY c / sum(c) OVER () DESC
+----
+-- ORDER BY a window nested in an expression not present in the SELECT list.
+-- ordered
+SELECT a, c FROM t ORDER BY c / sum(c) OVER () DESC
+----
+-- SELECT DISTINCT with a nested window in ORDER BY that repeats a SELECT item.
+-- ordered
+SELECT DISTINCT c / sum(c) OVER () AS s FROM t ORDER BY c / sum(c) OVER ()

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -438,7 +438,8 @@ void GroupByPlanner::plan(
 
 bool GroupByPlanner::tryPlanGlobalAgg(
     const std::vector<SelectItemPtr>& selectItems,
-    const ExpressionPtr& having) && {
+    const ExpressionPtr& having,
+    const OrderByPtr& orderBy) && {
   for (const auto& item : selectItems) {
     if (item->is(NodeType::kAllColumns) || item->is(NodeType::kSelectColumns)) {
       return false;
@@ -472,8 +473,7 @@ bool GroupByPlanner::tryPlanGlobalAgg(
     selectExprs.push_back(std::move(expr));
   }
 
-  std::move(*this).plan(
-      {}, /*distinct=*/false, selectExprs, having, /*orderBy=*/nullptr);
+  std::move(*this).plan({}, /*distinct=*/false, selectExprs, having, orderBy);
   return true;
 }
 

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -47,8 +47,8 @@ using AggregateExprMap = folly::
     F14FastMap<core::ExprPtr, core::ExprPtr, core::IExprHash, core::IExprEqual>;
 
 // Rewrites a window function expression: replaces column references in the
-// function arguments, PARTITION BY keys, and ORDER BY keys using the provided
-// rewrite function. Constructs a new WindowCallExpr directly.
+// function arguments, PARTITION BY keys, ORDER BY keys, and frame bounds using
+// the provided rewrite function. Constructs a new WindowCallExpr directly.
 lp::ExprApi rewriteWindowExpr(
     const lp::ExprApi& item,
     const std::function<core::ExprPtr(const core::ExprPtr&)>& rewriteIExpr) {
@@ -74,13 +74,26 @@ lp::ExprApi rewriteWindowExpr(
         {rewriteIExpr(key.expr), key.ascending, key.nullsFirst});
   }
 
+  // Rewrite frame bounds. A RANGE offset bound is rewritten to
+  // `<order_by> +/- <offset>`, so it can reference the same aggregate as the
+  // ORDER BY key and must be rewritten alongside it.
+  std::optional<core::WindowCallExpr::Frame> newFrame = window->frame();
+  if (newFrame.has_value()) {
+    if (newFrame->startValue) {
+      newFrame->startValue = rewriteIExpr(newFrame->startValue);
+    }
+    if (newFrame->endValue) {
+      newFrame->endValue = rewriteIExpr(newFrame->endValue);
+    }
+  }
+
   return lp::ExprApi(
       std::make_shared<core::WindowCallExpr>(
           window->name(),
           std::move(newInputs),
           std::move(newPartitionKeys),
           std::move(newOrderByKeys),
-          window->frame(),
+          std::move(newFrame),
           window->isIgnoreNulls()),
       item.name());
 }
@@ -183,8 +196,10 @@ void findAggregates(
       // TODO: Handle aggregates in subqueries.
       return;
     case core::IExpr::Kind::kWindow: {
-      // Recurse into function inputs, partition keys, and order by keys
-      // to find nested aggregates.
+      // Recurse into function inputs, partition keys, order by keys, and frame
+      // bounds to find nested aggregates. A RANGE offset frame bound is
+      // rewritten to `<order_by> +/- <offset>`, so it embeds the ORDER BY
+      // expression and can carry an aggregate.
       auto* window = expr->as<core::WindowCallExpr>();
       for (const auto& input : window->inputs()) {
         findAggregates(input, aggregates, aggregateSet);
@@ -194,6 +209,14 @@ void findAggregates(
       }
       for (const auto& key : window->orderByKeys()) {
         findAggregates(key.expr, aggregates, aggregateSet);
+      }
+      if (window->frame().has_value()) {
+        if (window->frame()->startValue) {
+          findAggregates(window->frame()->startValue, aggregates, aggregateSet);
+        }
+        if (window->frame()->endValue) {
+          findAggregates(window->frame()->endValue, aggregates, aggregateSet);
+        }
       }
       return;
     }

--- a/axiom/sql/presto/GroupByPlanner.h
+++ b/axiom/sql/presto/GroupByPlanner.h
@@ -53,11 +53,13 @@ class GroupByPlanner {
       const OrderByPtr& orderBy) &&;
 
   /// Detects implicit global aggregation (e.g. SELECT count(*) FROM t)
-  /// and plans it. Returns true if aggregation was added. Accepts raw AST
-  /// select items and resolves them internally.
+  /// and plans it, including any ORDER BY over the aggregates. Returns true if
+  /// aggregation was added. Accepts raw AST select items and resolves them
+  /// internally.
   bool tryPlanGlobalAgg(
       const std::vector<SelectItemPtr>& selectItems,
-      const ExpressionPtr& having) &&;
+      const ExpressionPtr& having,
+      const OrderByPtr& orderBy) &&;
 
  private:
   std::vector<std::vector<lp::ExprApi>> expandGroupingSets(

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1478,14 +1478,12 @@ class RelationPlanner : public AstVisitor {
       }
     } else {
       if (GroupByPlanner{builder_, exprPlanner_}.tryPlanGlobalAgg(
-              selectItems, node->having())) {
+              selectItems, node->having(), orderBy)) {
         // GroupByPlanner does not go through buildSelectProjections, so
-        // stage display names from the SELECT items directly.
+        // stage display names from the SELECT items directly. It also plans
+        // ORDER BY over the aggregates. DISTINCT is a no-op since a global
+        // aggregation without a GROUP BY produces one row.
         displayNames_.captureLastNames(selectItems);
-        // Nothing else to do. For aggregation, ORDER BY can only reference
-        // SELECT list (aggregates). DISTINCT will be a no-op since global
-        // aggregations without a group by are 1 row output.
-        addOrderBy(orderBy);
       } else if (distinct) {
         addDistinctAndOrderBy(selectItems, orderBy);
       } else {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1180,8 +1180,8 @@ class RelationPlanner : public AstVisitor {
       builder_->dropHiddenColumns();
       return;
     }
-    extractNestedWindows(projections.value());
     if (orderBy == nullptr) {
+      extractNestedWindows(projections.value());
       builder_->project(projections.value());
       return;
     }
@@ -1191,6 +1191,13 @@ class RelationPlanner : public AstVisitor {
 
     auto ordinals = SortProjection::widenProjections(
         expansion.sortKeyExprs, expansion.preResolved, projections.value());
+    // Extract nested windows after widening. An ORDER BY expression that
+    // repeats a SELECT window (e.g. `x / SUM(x) OVER()`) is matched to its
+    // SELECT item by raw expression during widening, collapsing to an ordinal;
+    // extracting earlier would rewrite the SELECT item but not the sort key, so
+    // the two would no longer match and the sort key would be re-added as an
+    // unresolvable nested-window projection.
+    extractNestedWindows(projections.value());
     builder_->project(projections.value());
     SortProjection::sortAndTrim(
         *builder_,
@@ -1211,9 +1218,15 @@ class RelationPlanner : public AstVisitor {
       addOrderBy(orderBy);
       return;
     }
+    // Match ORDER BY against the SELECT list before extractNestedWindows
+    // rewrites nested windows to column references; otherwise a sort key that
+    // repeats a SELECT window (e.g. `x / sum(x) OVER ()`) would not match its
+    // SELECT item. The matched ordinals index the projected output
+    // positionally.
+    auto selectExprs = projections.value();
     extractNestedWindows(projections.value());
     builder_->project(projections.value());
-    addDistinctAndOrderByOnProjection(projections.value(), orderBy);
+    addDistinctAndOrderByOnProjection(selectExprs, orderBy);
   }
 
   // Adds DISTINCT and (optional) ORDER BY assuming the SELECT list has

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -44,6 +44,24 @@ TEST_F(AggregationParserTest, countStar) {
     auto matcher = matchScan().aggregate().filter().output();
     testSelect("SELECT count(*) FROM nation HAVING count(*) > 100", matcher);
   }
+
+  {
+    // ORDER BY over a global aggregation: the sort key resolves to the
+    // aggregate output, whether written as the aggregate expression, the
+    // SELECT alias, or an ordinal.
+    auto matcher = matchScan().aggregate().sort().output();
+    testSelect("SELECT count(*) FROM nation ORDER BY count(*) DESC", matcher);
+    testSelect("SELECT count(*) AS c FROM nation ORDER BY c DESC", matcher);
+    testSelect("SELECT count(*) FROM nation ORDER BY 1", matcher);
+  }
+
+  {
+    // HAVING and ORDER BY together over a global aggregation.
+    auto matcher = matchScan().aggregate().filter().sort().output();
+    testSelect(
+        "SELECT count(*) FROM nation HAVING count(*) > 100 ORDER BY count(*)",
+        matcher);
+  }
 }
 
 TEST_F(AggregationParserTest, nestedAggregateRejected) {

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -64,6 +64,17 @@ TEST_F(AggregationParserTest, countStar) {
   }
 }
 
+// A window whose ORDER BY key is an aggregate and whose frame is a RANGE
+// offset, over a GROUP BY.
+TEST_F(AggregationParserTest, aggregateInWindowFrameBound) {
+  testSelect(
+      "SELECT count(*) OVER ("
+      "         ORDER BY max(n_nationkey) "
+      "         RANGE BETWEEN 5 PRECEDING AND CURRENT ROW) "
+      "FROM nation GROUP BY n_regionkey",
+      matchScan("nation").aggregate().project().output());
+}
+
 TEST_F(AggregationParserTest, nestedAggregateRejected) {
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql("SELECT sum(count(n_nationkey)) FROM nation"),

--- a/axiom/sql/presto/tests/SortParserTest.cpp
+++ b/axiom/sql/presto/tests/SortParserTest.cpp
@@ -183,6 +183,35 @@ TEST_F(SortParserTest, nonSelectedColumn) {
       parseSql(baseSelect + " ORDER BY 5"), "is not in the select list");
 }
 
+TEST_F(SortParserTest, windowInOrderBy) {
+  connector_->addTable("t", ROW({"a", "b"}, BIGINT()));
+
+  // A window nested in an ORDER BY expression that also appears in the SELECT
+  // list: the sort key matches the SELECT item and reuses its window rather
+  // than being re-added as an unresolvable nested-window projection. The window
+  // is projected once, then the SELECT list, then the sort.
+  testSelect(
+      "SELECT a, a / sum(a) OVER () AS s FROM t ORDER BY a / sum(a) OVER () DESC",
+      matchScan("t").project().project().sort().output({"a", "s"}));
+
+  // The window appears only in the ORDER BY expression: it is widened into the
+  // projection, sorted on, then trimmed back to the SELECT list.
+  testSelect(
+      "SELECT a FROM t ORDER BY a / sum(a) OVER () DESC",
+      matchScan("t").project().project().sort().project().output({"a"}));
+
+  // SELECT DISTINCT: a nested window in ORDER BY that repeats a SELECT item
+  // sorts on the distinct output.
+  testSelect(
+      "SELECT DISTINCT a / sum(a) OVER () AS s FROM t ORDER BY a / sum(a) OVER ()",
+      matchScan("t").project().project().aggregate().sort().output({"s"}));
+
+  // SELECT DISTINCT rejects an ORDER BY expression not in the SELECT list.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("SELECT DISTINCT a AS s FROM t ORDER BY sum(a) OVER ()"),
+      "For SELECT DISTINCT, ORDER BY expressions must be output expressions");
+}
+
 TEST_F(SortParserTest, ambiguousAlias) {
   connector_->addTable("t", ROW({"a", "b", "c"}, INTEGER()));
 


### PR DESCRIPTION
Summary:

A GROUP BY query with a window whose ORDER BY is an aggregate and whose frame is a RANGE offset failed to plan. For example:

    SELECT count(*) OVER (ORDER BY max(d) RANGE BETWEEN INTERVAL '29' DAY PRECEDING AND CURRENT ROW)
    FROM t GROUP BY d

failed with:

    Scalar function doesn't exist: max

A RANGE offset frame bound is rewritten to `<order_by> +/- <offset>`, which embeds the ORDER BY expression — here the aggregate `max(d)` — into the frame bound. `GroupByPlanner` collected and rewrote aggregates from a window's arguments, PARTITION BY, and ORDER BY keys, but not its frame bounds, so this `max(d)` was left unresolved and fell through to scalar-function resolution. Walk the frame bounds too, in both the aggregate collection and the post-aggregate rewrite.

Reviewed By: amitkdutta

Differential Revision: D113145210


