### PR TITLE
fix(sql): Cap query nesting depth to avoid stack overflow (#1632)

### DIFF
--- a/axiom/sql/presto/ParserOptions.cpp
+++ b/axiom/sql/presto/ParserOptions.cpp
@@ -52,6 +52,13 @@ std::vector<ConfigProperty> buildProperties(
           "Maximum expression nesting depth; deeper expressions are rejected "
           "to avoid a stack overflow.",
       },
+      {
+          std::string(ParserOptions::kMaxSubqueryDepth),
+          ConfigPropertyType::kInteger,
+          fmt::to_string(ParserOptions::kMaxSubqueryDepthDefault),
+          "Maximum subquery nesting depth; deeper nesting is rejected to avoid "
+          "a stack overflow.",
+      },
   };
 
   if (configOverrides.empty()) {
@@ -107,6 +114,7 @@ ParserOptions ParserOptions::from(
   setBool(kFriendlySql, options.friendlySql);
   setBool(kParseDecimalLiteralAsDouble, options.parseDecimalLiteralAsDouble);
   setUint32(kMaxExpressionDepth, options.maxExpressionDepth);
+  setUint32(kMaxSubqueryDepth, options.maxSubqueryDepth);
   return options;
 }
 

--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -34,10 +34,12 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
       "parse_decimal_literal_as_double";
   static constexpr std::string_view kMaxExpressionDepth =
       "max_expression_depth";
+  static constexpr std::string_view kMaxSubqueryDepth = "max_subquery_depth";
 
   static constexpr bool kFriendlySqlDefault = true;
   static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
-  static constexpr uint32_t kMaxExpressionDepthDefault = 256;
+  static constexpr uint32_t kMaxExpressionDepthDefault = 512;
+  static constexpr uint32_t kMaxSubqueryDepthDefault = 1024;
 
   ParserOptions();
 
@@ -58,6 +60,10 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   /// Maximum expression nesting depth; deeper expressions are rejected to
   /// avoid a stack overflow.
   uint32_t maxExpressionDepth{kMaxExpressionDepthDefault};
+
+  /// Maximum subquery nesting depth; deeper nesting is rejected to avoid a
+  /// stack overflow.
+  uint32_t maxSubqueryDepth{kMaxSubqueryDepthDefault};
 
   /// Constructs options from session property name-value pairs.
   /// Keys are unqualified property names (e.g., "friendly_sql").

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1377,6 +1377,17 @@ class RelationPlanner : public AstVisitor {
   }
 
   void processQuery(Query* query) {
+    AXIOM_PRESTO_SEMANTIC_CHECK_LT(
+        subqueryDepth_,
+        options_.maxSubqueryDepth,
+        query->location(),
+        /*token=*/std::nullopt,
+        "Subquery exceeds maximum nesting depth");
+    ++subqueryDepth_;
+    SCOPE_EXIT {
+      --subqueryDepth_;
+    };
+
     auto scope = ctes_.enterScope();
     auto savedAccumulatedNames = displayNames_.accumulatedNames;
     SCOPE_EXIT {
@@ -1603,6 +1614,8 @@ class RelationPlanner : public AstVisitor {
   const std::string user_;
   std::shared_ptr<lp::PlanBuilder> builder_;
   ParserOptions options_;
+  // Current processQuery recursion depth.
+  uint32_t subqueryDepth_{0};
   ExpressionPlanner exprPlanner_{
       user_,
       [this](Query* query) { return planSubquery(query); },

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -360,6 +360,38 @@ TEST_F(PrestoParserTest, withBasic) {
   }
 }
 
+TEST_F(PrestoParserTest, subqueryDepthCapped) {
+  // Chained CTEs have a shallow AST but recurse once per level in planning.
+  static constexpr auto kChainedCtes =
+      "WITH a AS (SELECT 1 AS x), "
+      "b AS (SELECT 2 FROM a), "
+      "c AS (SELECT 3 FROM b) "
+      "SELECT 4 AS r FROM c";
+
+  // Under the default cap the whole chain plans.
+  testSelect(
+      kChainedCtes,
+      matchValues().project().project().project().project().output({"r"}));
+
+  // The same query is rejected once the cap drops below the chain length.
+  auto parseWithDepth = [&](std::string_view sql, uint32_t maxSubqueryDepth) {
+    ParserOptions options;
+    options.maxSubqueryDepth = maxSubqueryDepth;
+    PrestoParser parser(
+        kConnectorId, "default", makeParserSession(std::move(options)));
+    return parser.parse(sql, true);
+  };
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseWithDepth(kChainedCtes, 2),
+      "Subquery exceeds maximum nesting depth");
+
+  // The cap also covers nested derived tables, not just CTE chains.
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseWithDepth(
+          "SELECT * FROM (SELECT * FROM (SELECT * FROM (SELECT 1 AS x)))", 2),
+      "Subquery exceeds maximum nesting depth");
+}
+
 TEST_F(PrestoParserTest, withShadowingCte) {
   // Inner CTE shadows outer CTE with the same name. The inner CTE uses a table
   // scan (producing a Scan node) while the outer uses VALUES. Without proper


### PR DESCRIPTION
Summary:

A deeply nested query can crash instead of returning an error. A long chain of CTEs, nested views, or nested subqueries makes the planner re-plan each body recursively, one C++ stack frame per level. Deep enough, that exhausts the stack and the process SIGSEGVs. A chain of ~8K CTEs crashes:

    WITH t0 AS (SELECT 1 AS x), t1 AS (SELECT x FROM t0), ... SELECT x FROM tN

The query tree here is shallow, so the existing AST-build and expression-depth caps do not catch it as the recursion is in planning, not parsing.

Add a nesting-depth counter in the planner, capped by the `max_query_depth` session property (default 512). Once exceeded, fail with *"Query exceeds maximum nesting depth"* instead of crashing.

The counter lives in `processQuery`, the single re-planning entry point for every CTE, view, and subquery body, so one check covers them all.

Note: extremely deep parentheses/subqueries may still overflow in the parser before planning; a follow-up diff adds a parse-depth cap to protect that layer.

Not counted (by design) are code paths that re-enter a query body without `processQuery`:
- Deeply nested set operations (chained UNION/INTERSECT/EXCEPT) already hit the expression-depth cap, so they can’t overflow.  
- Recursive CTEs can’t reach a stack overflow—recursive execution isn’t implemented yet, so they fail cleanly at execution; any deep body is still caught by the expression-depth cap.

Reviewed By: mbasmanova

Differential Revision: D113163490


