### PR TITLE
fix(optimizer): Handle OFFSET without LIMIT (#1634)

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -1959,7 +1959,7 @@ void Optimization::addOrderBy(
       std::move(precompute).maybeProject(),
       std::move(orderKeys),
       dt->orderTypes,
-      dt->limit,
+      dt->hasLimit() ? dt->limit : std::numeric_limits<int64_t>::max(),
       dt->offset);
   state.addCost(*orderBy);
   plan = orderBy;

--- a/axiom/optimizer/RelationOp.cpp
+++ b/axiom/optimizer/RelationOp.cpp
@@ -1431,7 +1431,7 @@ OrderBy::OrderBy(
       limit{limit},
       offset{offset} {
   cost_.inputCardinality = inputCardinality();
-  if (limit == -1) {
+  if (isNoLimit()) {
     cost_.fanout = 1;
   } else {
     const auto cardinality = static_cast<float>(limit);

--- a/axiom/optimizer/RelationOp.h
+++ b/axiom/optimizer/RelationOp.h
@@ -721,11 +721,19 @@ struct OrderBy : public RelationOp {
       RelationOpPtr input,
       ExprVector orderKeys,
       OrderTypeVector orderTypes,
-      int64_t limit = -1,
+      int64_t limit = std::numeric_limits<int64_t>::max(),
       int64_t offset = 0);
 
   const int64_t limit;
   const int64_t offset;
+
+  /// True when the sort keeps every row: 'limit' is the no-limit sentinel
+  /// INT64_MAX, or the effective bound 'limit + offset' saturates it. The '>='
+  /// (rather than '>') is required so the bare sentinel is recognized when
+  /// 'offset' is 0.
+  bool isNoLimit() const {
+    return limit >= std::numeric_limits<int64_t>::max() - offset;
+  }
 
   void accept(
       const RelationOpVisitor& visitor,
@@ -758,6 +766,9 @@ struct Limit : public RelationOp {
   const int64_t limit;
   const int64_t offset;
 
+  /// True when this Limit keeps every row: 'limit' is the no-limit sentinel
+  /// INT64_MAX, or the effective bound 'limit + offset' saturates it. See
+  /// OrderBy::isNoLimit for why the comparison is '>='.
   bool isNoLimit() const {
     static const auto kMax = std::numeric_limits<int64_t>::max();
     return limit >= (kMax - offset);

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1091,40 +1091,33 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   auto sortOrder = toSortOrders(op.distribution().orderTypes());
   auto keys = toFieldRefs(op.distribution().orderKeys());
 
+  // An unbounded sort (ORDER BY with no LIMIT) is a full sort; a trailing Limit
+  // applies any offset (its no-limit count keeps every remaining row). A
+  // bounded sort is a TopN over offset + count.
   if (isSingle_) {
     auto input = makeFragment(op.input(), fragment, stages);
 
     if (options_.numDrivers == 1) {
-      if (op.limit <= 0) {
-        return std::make_shared<velox::core::OrderByNode>(
-            nextId(), keys, sortOrder, false, input);
-      }
-
-      auto node =
-          addFinalTopN(nextId(), keys, sortOrder, op.limit + op.offset, input);
-
+      auto node = op.isNoLimit()
+          ? std::make_shared<velox::core::OrderByNode>(
+                nextId(), keys, sortOrder, false, input)
+          : addFinalTopN(
+                nextId(), keys, sortOrder, op.limit + op.offset, input);
       if (op.offset > 0) {
         return addFinalLimit(nextId(), op.offset, op.limit, node);
       }
-
       return node;
     }
 
-    velox::core::PlanNodePtr node;
-    if (op.limit <= 0) {
-      node = std::make_shared<velox::core::OrderByNode>(
-          nextId(), keys, sortOrder, true, input);
-    } else {
-      node = addPartialTopN(
-          nextId(), keys, sortOrder, op.limit + op.offset, input);
-    }
-
+    auto node = op.isNoLimit()
+        ? std::make_shared<velox::core::OrderByNode>(
+              nextId(), keys, sortOrder, true, input)
+        : addPartialTopN(
+              nextId(), keys, sortOrder, op.limit + op.offset, input);
     node = addLocalMerge(nextId(), keys, sortOrder, node);
-
-    if (op.limit > 0) {
+    if (!op.isNoLimit() || op.offset > 0) {
       return addFinalLimit(nextId(), op.offset, op.limit, node);
     }
-
     return node;
   }
 
@@ -1138,7 +1131,7 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   const bool singleDriver = options_.numDrivers == 1;
 
   velox::core::PlanNodePtr node;
-  if (op.limit <= 0) {
+  if (op.isNoLimit()) {
     node = std::make_shared<velox::core::OrderByNode>(
         nextId(), keys, sortOrder, /*isPartial=*/!singleDriver, input);
   } else if (singleDriver) {
@@ -1164,7 +1157,7 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   fragment.inputStages.emplace_back(merge->id(), source.taskPrefix);
   stages.push_back(std::move(source));
 
-  if (op.limit > 0) {
+  if (!op.isNoLimit() || op.offset > 0) {
     return addFinalLimit(nextId(), op.offset, op.limit, merge);
   }
   return merge;

--- a/axiom/optimizer/docs/CardinalityEstimation.md
+++ b/axiom/optimizer/docs/CardinalityEstimation.md
@@ -232,7 +232,7 @@ NullFraction and range are unchanged.
 OrderBy is cardinality-neutral unless it has a LIMIT clause:
 
 ```
-if limit == -1 (no limit):
+if isNoLimit() (no LIMIT clause):
     fanout = 1
 else if inputCardinality <= limit:
     fanout = 1  (limit is no-op)

--- a/axiom/optimizer/tests/sql/limit.sql
+++ b/axiom/optimizer/tests/sql/limit.sql
@@ -43,3 +43,6 @@ SELECT a, b FROM t ORDER BY b OFFSET 0 LIMIT 3
 ----
 -- count 0
 SELECT a, b FROM t OFFSET 0 LIMIT 0
+----
+-- count 13
+SELECT a, b FROM t OFFSET 2

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1369,7 +1369,7 @@ velox::core::PlanNodePtr Emitter::emitLimit(const Limit& limit) {
     input = std::make_shared<velox::core::LimitNode>(
         nextId(),
         /*offset=*/0,
-        limit.offset() + limit.count(),
+        limit.offsetPlusCount(),
         /*isPartial=*/true,
         std::move(input));
     input =

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -372,6 +372,13 @@ class Limit : public Node {
     return count_;
   }
 
+  /// Returns offset + count, saturated at INT64_MAX so a no-limit count
+  /// (INT64_MAX) does not overflow. The '>=' matches the no-limit boundary used
+  /// by RelationOp's isNoLimit.
+  int64_t offsetPlusCount() const {
+    return count_ >= INT64_MAX - offset_ ? INT64_MAX : offset_ + count_;
+  }
+
   std::span<const NodeCP> inputs() const override {
     return {&input_, 1};
   }

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -682,7 +682,7 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     }
 
     NodeCP partial = builder().make<Limit>(
-        {newInput, /*offset=*/0, node->offset() + node->count()});
+        {newInput, /*offset=*/0, node->offsetPlusCount()});
     return builder().make<Limit>(
         {gather(partial), node->offset(), node->count()});
   }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/152

An OFFSET with no LIMIT was mishandled in both optimizers. In v2:

    SELECT a, b FROM t OFFSET 2

aborted with a `VeloxRuntimeError` from signed-integer overflow. In v1, an OFFSET on an ORDER BY:

    SELECT a FROM t ORDER BY a OFFSET 2

returned zero rows instead of skipping the first two.

The two paths disagreed on how "no limit" is spelled: `OrderBy` used `-1` while `DerivedTable` and the v2 `Limit` used `INT64_MAX`. A bare OFFSET set the limit to `INT64_MAX`, so the sort took the bounded TopN path and overflowed computing `offset + count`. `OrderBy` now uses `INT64_MAX` as its only no-limit sentinel and tests `isNoLimit()` rather than the raw value, and `offset + count` saturates at `INT64_MAX`.

Reviewed By: xiaoxmeng

Differential Revision: D113161282


