### PR TITLE
fix(optimizer): Don't distribute source-less inputs in v2 (#1635)

### DIFF
--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -1709,7 +1709,10 @@ std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
 }
 
 // Sets 'fragment.type' (and 'width' for kFixed) from the contents at 'node'. At
-// numWorkers == 1 all parallelism collapses to one task.
+// numWorkers == 1 all parallelism collapses to one task. A fragment with no
+// split source (no scan; only exchanges and/or values below) is single-task
+// regardless of its output partitioning: kSource requires connector splits to
+// drive its task count, so the fallback is kSingle, not kSource.
 void decideFragmentType(
     NodeCP node,
     int32_t numWorkers,
@@ -1719,7 +1722,7 @@ void decideFragmentType(
     return;
   }
   fragment.type =
-      fragmentTypeContribution(node).value_or(FragmentType::kSource);
+      fragmentTypeContribution(node).value_or(FragmentType::kSingle);
   if (fragment.type == FragmentType::kFixed) {
     fragment.width = numWorkers;
   }

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -982,7 +982,10 @@ bool MarkDistinct::KeyEq::operator()(const MarkDistinct* node, const Key& key)
 }
 
 Values::Values(Key key)
-    : Node(NodeType::kValues, ColumnVector{key.outputColumns}, {}),
+    : Node(
+          NodeType::kValues,
+          ColumnVector{key.outputColumns},
+          {.globalPartition = Partitioning::globalGather()}),
       source_(key.source),
       rows_(key.rows),
       channels_(std::move(key.channels)) {
@@ -1184,13 +1187,29 @@ bool Unnest::KeyEq::operator()(const Unnest* node, const Key& key) const {
 
 namespace {
 
-// Output global partitioning of a union: bucketed on the union output columns
-// when every leg is connector-bucketed on leg columns that map (via legColumns)
-// to those same output columns, with copartitionable partitionings. The
-// representative type is the min-partition-count leg's — its count equals the
-// copartition's — reused as a query-lifetime pointer. Unspecified otherwise, so
-// the union then distributes its legs independently.
+// Output global partitioning of a union:
+//  - Gather, when every leg is already gathered (single-task): the union then
+//    runs as one task, so no isolating exchange is needed.
+//  - Otherwise bucketed on the union output columns, when every leg is
+//    connector-bucketed on leg columns that map (via legColumns) to those same
+//    output columns, with copartitionable partitionings. The representative
+//    type is the min-partition-count leg's — its count equals the copartition's
+//    — reused as a query-lifetime pointer.
+//  - Unspecified otherwise, so the union then distributes its legs
+//    independently.
 Partitioning unionGlobalPartition(const UnionAll::Key& key) {
+  bool allGathered = true;
+  for (const auto* input : key.inputs) {
+    if (!input->physicalProperties().globalPartition.is(
+            PartitionKind::kGather)) {
+      allGathered = false;
+      break;
+    }
+  }
+  if (allGathered) {
+    return Partitioning::globalGather();
+  }
+
   const connector::PartitionType* representative = nullptr;
   ExprVector outputKeys;
   for (size_t leg = 0; leg < key.inputs.size(); ++leg) {

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -740,11 +740,16 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       // to the same output columns with copartitionable types, and then all
       // legs share one grouped fragment. Otherwise each leg distributes
       // independently (arbitrary / round-robin).
-      NodeCP coBucketed = builder().make<UnionAll>(
+      NodeCP coalesced = builder().make<UnionAll>(
           {newInputs, node->legColumns(), node->outputColumns()});
-      if (coBucketed->physicalProperties().globalPartition.is(
-              PartitionKind::kPartitioned)) {
-        return coBucketed;
+      const auto& partition = coalesced->physicalProperties().globalPartition;
+      // No isolating exchange is needed when the legs co-bucket into one
+      // grouped fragment, nor when every leg is single-task (gathered) — then
+      // the union itself runs as a single task. See DistributedExecution.md
+      // section 1.
+      if (partition.is(PartitionKind::kPartitioned) ||
+          partition.is(PartitionKind::kGather)) {
+        return coalesced;
       }
       for (NodeCP& newInput : newInputs) {
         newInput = arbitrary(newInput);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/155


Under distributed v2, a query with no table scan — only constant rows — could return 0 rows or fail with `Wrong number of columns`. For example:

      SELECT y, map_union_sum(x) FROM (SELECT 1 y, ... UNION ALL SELECT 1 y, ...) GROUP BY y

The aggregation landed in its own fragment typed `kSource`, whose task count comes from table splits. With no scan there are no splits, so Axel ran it with zero tasks. v1 keeps such a query in one fragment.

Fix: a subtree with no scan stays single-task. Physical planning no longer inserts a shuffle above it, and its fragment is typed single-task instead of `kSource`.

bypass-github-export-checks

Reviewed By: xiaoxmeng

Differential Revision: D113214605
