### PR TITLE
fix(parser): Don't resolve columns across set-op branches (#1637)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -713,6 +713,13 @@ class PlanBuilder {
     };
   }
 
+  /// Returns the enclosing scope this builder resolves against for correlated
+  /// references, or nullptr if there is none. Unlike scope(), this does not
+  /// expose the builder's own output columns.
+  const Scope& outerScope() const {
+    return outerScope_;
+  }
+
   /// Returns true if the given unqualified name resolves to a column in this
   /// builder's output without chaining to outer scopes.
   bool hasColumn(const std::string& name) const;

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -115,6 +115,20 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
+
+  // The plan's output must have one column per logical-plan output column. A
+  // TableWrite root emits write-stats rows instead of the query columns, so it
+  // is exempt.
+  if (!plan_.is(logical_plan::NodeKind::kTableWrite)) {
+    const auto& veloxOutput =
+        result.plan->fragments().back().fragment.planNode->outputType();
+    VELOX_CHECK(
+        veloxOutput->equivalent(*plan_.outputType()),
+        "Plan output type does not match the logical plan output type: {} vs {}",
+        veloxOutput->toString(),
+        plan_.outputType()->toString());
+  }
+
   return result;
 }
 

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -349,54 +349,58 @@ class Translator {
         simplifier_(builder, evaluator) {}
 
   TranslatePass::Result run(const lp::LogicalPlanNode& plan) {
+    // The query output is a list of (sourceName, outputName) pairs, one per
+    // output position. An OutputNode names them explicitly and may repeat a
+    // source column under several output names; a bare plan (no OutputNode)
+    // uses its own outputType field names for both. Each position resolves by
+    // name through the translated scope: identical output expressions collapse
+    // to one Column, so the scope -- not the node's column list -- carries
+    // every output position.
+    const lp::LogicalPlanNode* node;
+    std::vector<std::pair<std::string, std::string>> outputSpec;
     if (plan.is(lp::NodeKind::kOutput)) {
       const auto& output = *plan.as<lp::OutputNode>();
-      const auto& child = *output.onlyInput();
-      const auto& childOutputType = *child.outputType();
-      // Seed `required` with just the LP names the OutputNode references.
-      // Names not referenced flow as "unused" through the child translation
-      // and get pruned where producers honor the required-set.
-      LpNameSet required;
-      required.reserve(output.entries().size());
+      node = &*output.onlyInput();
+      const auto& childOutputType = *node->outputType();
+      outputSpec.reserve(output.entries().size());
       for (const auto& entry : output.entries()) {
         VELOX_CHECK_LT(entry.index, childOutputType.size());
-        required.insert(childOutputType.nameOf(entry.index));
+        outputSpec.emplace_back(
+            childOutputType.nameOf(entry.index), entry.name);
       }
-      Translated inner = translateNode(child, required);
-      ColumnVector outputColumns;
-      std::vector<std::string> outputNames;
-      outputColumns.reserve(output.entries().size());
-      outputNames.reserve(output.entries().size());
-      for (const auto& entry : output.entries()) {
-        // Resolve via LP-name → Column* scope rather than positionally:
-        // the IR's outputColumns may be narrower than the LP child's
-        // outputType after dup-collapse, and the LP contract is that
-        // same-name == same-thing in a node's outputType.
-        const auto& name = childOutputType.nameOf(entry.index);
-        auto it = inner.scope.find(name);
-        VELOX_CHECK(
-            it != inner.scope.end(),
-            "OutputNode entry name not found in inner scope: {}",
-            name);
-        outputColumns.push_back(it->second);
-        outputNames.push_back(entry.name);
+    } else {
+      node = &plan;
+      const auto& outputType = *plan.outputType();
+      outputSpec.reserve(outputType.size());
+      for (size_t i = 0; i < outputType.size(); ++i) {
+        outputSpec.emplace_back(outputType.nameOf(i), outputType.nameOf(i));
       }
-      return {inner.node, std::move(outputColumns), std::move(outputNames)};
     }
-    // Bare plan (no OutputNode): nothing has narrowed the required set, so
-    // request everything the root advertises. Output names are best-effort here
-    // (the column's own name) and not guaranteed without an OutputNode to pin
-    // them -- see the optimize() contract in Optimize.h.
-    Translated translated = translateNode(plan, allNames(*plan.outputType()));
+
+    // Request only the referenced source names; unreferenced names flow through
+    // as unused and get pruned where producers honor the required-set.
+    LpNameSet required;
+    required.reserve(outputSpec.size());
+    for (const auto& [sourceName, outputName] : outputSpec) {
+      required.insert(sourceName);
+    }
+
+    Translated translated = translateNode(*node, required);
+
+    ColumnVector outputColumns;
     std::vector<std::string> outputNames;
-    outputNames.reserve(translated.node->outputColumns().size());
-    for (ColumnCP column : translated.node->outputColumns()) {
-      outputNames.emplace_back(column->outputName());
+    outputColumns.reserve(outputSpec.size());
+    outputNames.reserve(outputSpec.size());
+    for (const auto& [sourceName, outputName] : outputSpec) {
+      auto it = translated.scope.find(sourceName);
+      VELOX_CHECK(
+          it != translated.scope.end(),
+          "Output name not found in scope: {}",
+          sourceName);
+      outputColumns.push_back(it->second);
+      outputNames.push_back(outputName);
     }
-    return {
-        translated.node,
-        ColumnVector{translated.node->outputColumns()},
-        std::move(outputNames)};
+    return {translated.node, std::move(outputColumns), std::move(outputNames)};
   }
 
  private:

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1576,7 +1576,9 @@ class RelationPlanner : public AstVisitor {
     // SQL set-operation output names come from the left input.
     auto leftDisplayNames = std::move(displayNames_.lastNames);
 
-    builder_ = newBuilder(leftBuilder->scope());
+    // Set-operation branches are independent: the right branch resolves against
+    // the enclosing scope, not the left branch's output columns.
+    builder_ = newBuilder(leftBuilder->outerScope());
     right->accept(this);
     auto rightBuilder = builder_;
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -900,6 +900,12 @@ TEST_F(PrestoParserTest, intersect) {
       matcherAll);
 }
 
+TEST_F(PrestoParserTest, unionAllUnresolvedColumn) {
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT n_name FROM nation UNION ALL SELECT n_name FROM region"),
+      "Cannot resolve column");
+}
+
 TEST_F(PrestoParserTest, exists) {
   {
     auto matcher =


### PR DESCRIPTION
Summary:

A column reference in one branch of a UNION/INTERSECT/EXCEPT could resolve against the other branch's columns. For example:

    SELECT n_name FROM nation UNION ALL SELECT n_name FROM region

region has no `n_name`, but it bound to nation's `n_name` from the left branch. The query built a malformed plan and failed deep in the optimizer with an internal error instead of a user error. It now fails during analysis with `Cannot resolve column`.

The right branch was planned with the left branch's output scope as its outer scope. It now uses the enclosing scope, so branches resolve independently while a correlated subquery around the set operation still sees outer columns.

bypass-github-export-checks

Differential Revision: D113248555
