### PR TITLE
fix(optimizer): Duplicate columns in v2 INTERSECT/EXCEPT (#1639)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -713,6 +713,13 @@ class PlanBuilder {
     };
   }
 
+  /// Returns the enclosing scope this builder resolves against for correlated
+  /// references, or nullptr if there is none. Unlike scope(), this does not
+  /// expose the builder's own output columns.
+  const Scope& outerScope() const {
+    return outerScope_;
+  }
+
   /// Returns true if the given unqualified name resolves to a column in this
   /// builder's output without chaining to outer scopes.
   bool hasColumn(const std::string& name) const;

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -115,6 +115,20 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
+
+  // The plan's output must have one column per logical-plan output column. A
+  // TableWrite root emits write-stats rows instead of the query columns, so it
+  // is exempt.
+  if (!plan_.is(logical_plan::NodeKind::kTableWrite)) {
+    const auto& veloxOutput =
+        result.plan->fragments().back().fragment.planNode->outputType();
+    VELOX_CHECK(
+        veloxOutput->equivalent(*plan_.outputType()),
+        "Plan output type does not match the logical plan output type: {} vs {}",
+        veloxOutput->toString(),
+        plan_.outputType()->toString());
+  }
+
   return result;
 }
 

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -349,54 +349,58 @@ class Translator {
         simplifier_(builder, evaluator) {}
 
   TranslatePass::Result run(const lp::LogicalPlanNode& plan) {
+    // The query output is a list of (sourceName, outputName) pairs, one per
+    // output position. An OutputNode names them explicitly and may repeat a
+    // source column under several output names; a bare plan (no OutputNode)
+    // uses its own outputType field names for both. Each position resolves by
+    // name through the translated scope: identical output expressions collapse
+    // to one Column, so the scope -- not the node's column list -- carries
+    // every output position.
+    const lp::LogicalPlanNode* node;
+    std::vector<std::pair<std::string, std::string>> outputSpec;
     if (plan.is(lp::NodeKind::kOutput)) {
       const auto& output = *plan.as<lp::OutputNode>();
-      const auto& child = *output.onlyInput();
-      const auto& childOutputType = *child.outputType();
-      // Seed `required` with just the LP names the OutputNode references.
-      // Names not referenced flow as "unused" through the child translation
-      // and get pruned where producers honor the required-set.
-      LpNameSet required;
-      required.reserve(output.entries().size());
+      node = &*output.onlyInput();
+      const auto& childOutputType = *node->outputType();
+      outputSpec.reserve(output.entries().size());
       for (const auto& entry : output.entries()) {
         VELOX_CHECK_LT(entry.index, childOutputType.size());
-        required.insert(childOutputType.nameOf(entry.index));
+        outputSpec.emplace_back(
+            childOutputType.nameOf(entry.index), entry.name);
       }
-      Translated inner = translateNode(child, required);
-      ColumnVector outputColumns;
-      std::vector<std::string> outputNames;
-      outputColumns.reserve(output.entries().size());
-      outputNames.reserve(output.entries().size());
-      for (const auto& entry : output.entries()) {
-        // Resolve via LP-name → Column* scope rather than positionally:
-        // the IR's outputColumns may be narrower than the LP child's
-        // outputType after dup-collapse, and the LP contract is that
-        // same-name == same-thing in a node's outputType.
-        const auto& name = childOutputType.nameOf(entry.index);
-        auto it = inner.scope.find(name);
-        VELOX_CHECK(
-            it != inner.scope.end(),
-            "OutputNode entry name not found in inner scope: {}",
-            name);
-        outputColumns.push_back(it->second);
-        outputNames.push_back(entry.name);
+    } else {
+      node = &plan;
+      const auto& outputType = *plan.outputType();
+      outputSpec.reserve(outputType.size());
+      for (size_t i = 0; i < outputType.size(); ++i) {
+        outputSpec.emplace_back(outputType.nameOf(i), outputType.nameOf(i));
       }
-      return {inner.node, std::move(outputColumns), std::move(outputNames)};
     }
-    // Bare plan (no OutputNode): nothing has narrowed the required set, so
-    // request everything the root advertises. Output names are best-effort here
-    // (the column's own name) and not guaranteed without an OutputNode to pin
-    // them -- see the optimize() contract in Optimize.h.
-    Translated translated = translateNode(plan, allNames(*plan.outputType()));
+
+    // Request only the referenced source names; unreferenced names flow through
+    // as unused and get pruned where producers honor the required-set.
+    LpNameSet required;
+    required.reserve(outputSpec.size());
+    for (const auto& [sourceName, outputName] : outputSpec) {
+      required.insert(sourceName);
+    }
+
+    Translated translated = translateNode(*node, required);
+
+    ColumnVector outputColumns;
     std::vector<std::string> outputNames;
-    outputNames.reserve(translated.node->outputColumns().size());
-    for (ColumnCP column : translated.node->outputColumns()) {
-      outputNames.emplace_back(column->outputName());
+    outputColumns.reserve(outputSpec.size());
+    outputNames.reserve(outputSpec.size());
+    for (const auto& [sourceName, outputName] : outputSpec) {
+      auto it = translated.scope.find(sourceName);
+      VELOX_CHECK(
+          it != translated.scope.end(),
+          "Output name not found in scope: {}",
+          sourceName);
+      outputColumns.push_back(it->second);
+      outputNames.push_back(outputName);
     }
-    return {
-        translated.node,
-        ColumnVector{translated.node->outputColumns()},
-        std::move(outputNames)};
+    return {translated.node, std::move(outputColumns), std::move(outputNames)};
   }
 
  private:

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1757,20 +1757,16 @@ Translated Translator::translateSet(
 
       // Set-op via Join: each leg's columns become join keys, so all of each
       // leg's outputType is consumed.
-      Translated current = {
-          translateNode(
-              *set.inputs().front(),
-              allNames(*set.inputs().front()->outputType()))
-              .node,
-          {}};
+      Translated first = translateNode(
+          *set.inputs().front(), allNames(*set.inputs().front()->outputType()));
+      NodeCP node = first.node;
       for (size_t i = 1; i < set.inputs().size(); ++i) {
-        Translated other = {
+        NodeCP other =
             translateNode(
                 *set.inputs()[i], allNames(*set.inputs()[i]->outputType()))
-                .node,
-            {}};
-        const auto& leftColumns = current.node->outputColumns();
-        const auto& rightColumns = other.node->outputColumns();
+                .node;
+        const auto& leftColumns = node->outputColumns();
+        const auto& rightColumns = other->outputColumns();
         VELOX_CHECK_EQ(leftColumns.size(), rightColumns.size());
         ExprVector leftKeys;
         ExprVector rightKeys;
@@ -1782,9 +1778,9 @@ Translated Translator::translateSet(
           rightKeys.push_back(rightColumns[columnIndex]);
         }
         ColumnVector outputColumns{leftColumns};
-        current.node = builder_.make<Join>(
-            {current.node,
-             other.node,
+        node = builder_.make<Join>(
+            {node,
+             other,
              joinType,
              std::move(leftKeys),
              std::move(rightKeys),
@@ -1794,21 +1790,31 @@ Translated Translator::translateSet(
              std::move(outputColumns)});
       }
 
-      // Output schema is the left side's columns flowing through the Join
-      // unchanged.
-      const ColumnVector& outputColumns = current.node->outputColumns();
+      // Output columns are the first leg's, flowing through the Join unchanged.
+      // Resolve each output position by name through the first leg's scope so
+      // positions the leg collapsed to one Column (see translateProject) map
+      // both symbols to that shared Column.
       Scope scope;
-      populateScope(*set.outputType(), outputColumns, scope);
+      const auto& firstType = *set.inputs().front()->outputType();
+      for (size_t j = 0; j < set.outputType()->size(); ++j) {
+        auto it = first.scope.find(firstType.nameOf(j));
+        VELOX_CHECK(
+            it != first.scope.end(),
+            "Set-op leg scope missing column: {}",
+            firstType.nameOf(j));
+        scope[set.outputType()->nameOf(j)] = it->second;
+      }
 
       if (isDistinct) {
+        const ColumnVector& outputColumns = node->outputColumns();
         AggregateCP aggNode = builder_.make<Aggregate>(
-            {current.node,
+            {node,
              ExprVector{outputColumns.begin(), outputColumns.end()},
              AggregateCallVector{},
              outputColumns});
         return {aggNode, std::move(scope)};
       }
-      return {current.node, std::move(scope)};
+      return {node, std::move(scope)};
     }
   }
   VELOX_UNREACHABLE();

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1576,7 +1576,9 @@ class RelationPlanner : public AstVisitor {
     // SQL set-operation output names come from the left input.
     auto leftDisplayNames = std::move(displayNames_.lastNames);
 
-    builder_ = newBuilder(leftBuilder->scope());
+    // Set-operation branches are independent: the right branch resolves against
+    // the enclosing scope, not the left branch's output columns.
+    builder_ = newBuilder(leftBuilder->outerScope());
     right->accept(this);
     auto rightBuilder = builder_;
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -900,6 +900,12 @@ TEST_F(PrestoParserTest, intersect) {
       matcherAll);
 }
 
+TEST_F(PrestoParserTest, unionAllUnresolvedColumn) {
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT n_name FROM nation UNION ALL SELECT n_name FROM region"),
+      "Cannot resolve column");
+}
+
 TEST_F(PrestoParserTest, exists) {
   {
     auto matcher =


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/160

A v2 INTERSECT or EXCEPT whose branch has two identical columns crashed. For example:

    SELECT NULL, NULL EXCEPT SELECT NULL, NULL FROM nation

failed with `(2 vs. 1) Scope row type / columns mismatch`. UNION ALL of the same shape was unaffected.

v2 deduplicates identical output columns within a branch — `SELECT NULL, NULL` yields one Column — and records both names in the branch's scope. The INTERSECT/EXCEPT translation discarded that scope and read the branch's positional output columns, which are then narrower than the set operation's output type. It now resolves each output position through the branch's scope, so two names share the one deduped Column — the same approach UNION ALL already uses.

bypass-github-export-checks

Differential Revision: D113248553
