### PR TITLE
feat(connectors): Add prefix-capable table-name listing (#1641)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -1272,6 +1272,32 @@ class ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const std::string& schemaName) = 0;
 
+  /// Returns whether this connector pushes a table-name prefix into its listing
+  /// (serving listTableNames(session, schema, prefix) without a full
+  /// enumeration).
+  virtual bool listTableNamesPrefixSupported() const {
+    return false;
+  }
+
+  /// Returns table names in the given schema, pruned to those starting with
+  /// 'prefix' by pushing the prefix to the source. The result is best-effort
+  /// and may be a superset of the exact-prefix matches (e.g. when the source
+  /// interprets glob metacharacters in 'prefix'), so callers must still apply
+  /// the exact predicate. Only valid when listTableNamesPrefixSupported() is
+  /// true; connectors that opt in must override this.
+  ///
+  /// Overloads the two-argument listTableNames(); a subclass that overrides
+  /// only one overload hides the other, so a subclass overriding just the
+  /// two-argument form must add `using ConnectorMetadata::listTableNames;` to
+  /// keep this one visible.
+  virtual std::vector<std::string> listTableNames(
+      const ConnectorSessionPtr& /*session*/,
+      const std::string& /*schemaName*/,
+      std::string_view /*prefix*/) {
+    VELOX_UNSUPPORTED(
+        "listTableNames with prefix requires listTableNamesPrefixSupported()");
+  }
+
   /// Creates a schema with the given name and properties. If 'ifNotExists' is
   /// true, succeeds silently when the schema already exists. Otherwise, raises
   /// a user error if the schema already exists.

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -2893,7 +2893,20 @@ SqlStatementPtr parseShowTables(
       metadata->listTableNamesSupported(),
       "SHOW TABLES is not supported for catalog '{}'",
       connectorId);
-  auto tableNames = metadata->listTableNames(session, schema);
+  // Push a prefix from a LIKE pattern (e.g. 'foo%') into the listing when the
+  // connector supports it.
+  std::vector<std::string> tableNames;
+  std::string prefix;
+  if (showTables.likePattern().has_value() &&
+      metadata->listTableNamesPrefixSupported()) {
+    prefix = detail::likePrefix(
+        showTables.likePattern().value(), showTables.escape());
+  }
+  if (!prefix.empty()) {
+    tableNames = metadata->listTableNames(session, schema, prefix);
+  } else {
+    tableNames = metadata->listTableNames(session, schema);
+  }
   std::sort(tableNames.begin(), tableNames.end());
 
   std::vector<Variant> data;
@@ -3238,6 +3251,39 @@ SqlStatementPtr doPlan(
       "Unsupported statement type");
 }
 } // namespace
+
+namespace detail {
+
+std::string likePrefix(
+    std::string_view pattern,
+    const std::optional<std::string>& escape) {
+  if (escape.has_value()) {
+    VELOX_USER_CHECK_EQ(
+        escape->size(), 1, "Escape string must be a single character");
+  }
+  const bool hasEscape = escape.has_value();
+  const char escapeChar = hasEscape ? escape->front() : '\0';
+  std::string prefix;
+  for (size_t i = 0; i < pattern.size(); ++i) {
+    const char c = pattern[i];
+    if (hasEscape && c == escapeChar) {
+      // The next character is escaped to a literal; a trailing escape char is
+      // malformed, so stop and let the residual LIKE surface the error.
+      if (i + 1 >= pattern.size()) {
+        break;
+      }
+      prefix.push_back(pattern[++i]);
+      continue;
+    }
+    if (c == '%' || c == '_') {
+      break;
+    }
+    prefix.push_back(c);
+  }
+  return prefix;
+}
+
+} // namespace detail
 
 SqlStatementPtr PrestoParser::doParse(
     std::string_view sql,

--- a/axiom/sql/presto/PrestoParser.h
+++ b/axiom/sql/presto/PrestoParser.h
@@ -72,4 +72,17 @@ class PrestoParser {
   const ParserSessionPtr session_;
 };
 
+// Implementation detail exposed for testing; not part of the public parser API.
+namespace detail {
+
+// Returns the literal leading substring of a SQL LIKE 'pattern' up to the first
+// unescaped '%' or '_' wildcard, honoring 'escape'. Returns "" when the pattern
+// starts with a wildcard (e.g. '%foo'), i.e. has no usable prefix. Fails with a
+// user error if 'escape' is set but is not a single character.
+std::string likePrefix(
+    std::string_view pattern,
+    const std::optional<std::string>& escape);
+
+} // namespace detail
+
 } // namespace axiom::sql::presto

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "axiom/sql/presto/PrestoParser.h"
 #include "axiom/sql/presto/PrestoSqlError.h"
 #include "axiom/sql/presto/tests/ExpectPrestoSqlError.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
@@ -27,6 +28,35 @@ namespace lp = facebook::axiom::logical_plan;
 namespace {
 
 class PrestoParserTest : public PrestoParserTestBase {};
+
+TEST(LikePrefixTest, extractsLiteralPrefix) {
+  // Pure prefix: the literal run before the trailing '%'.
+  EXPECT_EQ(detail::likePrefix("foo%", std::nullopt), "foo");
+  // No wildcard: the whole pattern is the literal prefix (exact match).
+  EXPECT_EQ(detail::likePrefix("foo", std::nullopt), "foo");
+  // A '_' wildcard also ends the prefix.
+  EXPECT_EQ(detail::likePrefix("fo_o%", std::nullopt), "fo");
+  // Leading wildcard -> no usable prefix (caller falls back to a full listing).
+  EXPECT_EQ(detail::likePrefix("%foo", std::nullopt), "");
+  EXPECT_EQ(detail::likePrefix("%foo%", std::nullopt), "");
+  EXPECT_EQ(detail::likePrefix("_foo", std::nullopt), "");
+  EXPECT_EQ(detail::likePrefix("", std::nullopt), "");
+  // Escaped wildcards are literal and stay in the prefix.
+  EXPECT_EQ(detail::likePrefix("foo\\%bar%", std::string("\\")), "foo%bar");
+  EXPECT_EQ(detail::likePrefix("\\%foo%", std::string("\\")), "%foo");
+  // A trailing lone escape character has nothing to escape; the prefix ends
+  // there and the residual LIKE surfaces the malformed pattern.
+  EXPECT_EQ(detail::likePrefix("foo\\", std::string("\\")), "foo");
+}
+
+TEST(LikePrefixTest, rejectsNonSingleCharacterEscape) {
+  VELOX_ASSERT_THROW(
+      detail::likePrefix("foo%", std::string("ab")),
+      "Escape string must be a single character");
+  VELOX_ASSERT_THROW(
+      detail::likePrefix("foo%", std::string("")),
+      "Escape string must be a single character");
+}
 
 TEST_F(PrestoParserTest, unnest) {
   {


### PR DESCRIPTION
Summary:

Adds an opt-in way for a connector to serve `SHOW TABLES ... LIKE 'foo%'` by pushing a literal name prefix into its table listing, instead of enumerating the whole schema and filtering client-side.

New on `ConnectorMetadata`: `listTableNames(session, schema, prefix)` plus a `listTableNamesPrefixSupported()` opt-in gate, following the existing `isPushdownSupported()`/`co_pushdownPlan()` pattern — the base default throws (`VELOX_UNSUPPORTED`), and only connectors that can prune at the source override it (no client-side emulation). The `SHOW TABLES ... LIKE` path in `PrestoParser` extracts the prefix via a new `likePrefix` helper and pushes it when the connector supports it, keeping the existing `LIKE` filter as a residual so the pushed prefix is only a best-effort pruning hint (correctness stays with the residual). A pattern with a leading wildcard (e.g. `%foo`) yields no prefix and falls back to the full listing plus the residual filter.

Differential Revision: D113133865


