### PR TITLE
feat(test): Provision only the TPC-H tables a file needs (#1642)

### DIFF
--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -713,6 +713,13 @@ class PlanBuilder {
     };
   }
 
+  /// Returns the enclosing scope this builder resolves against for correlated
+  /// references, or nullptr if there is none. Unlike scope(), this does not
+  /// expose the builder's own output columns.
+  const Scope& outerScope() const {
+    return outerScope_;
+  }
+
   /// Returns true if the given unqualified name resolves to a column in this
   /// builder's output without chaining to outer scopes.
   bool hasColumn(const std::string& name) const;

--- a/axiom/optimizer/tests/SqlFile.cpp
+++ b/axiom/optimizer/tests/SqlFile.cpp
@@ -222,7 +222,10 @@ std::vector<QueryEntry> parseQueries(
 
 } // namespace
 
-SqlFile SqlFile::parse(std::string_view content, std::string_view baseDir) {
+SqlFile SqlFile::parse(
+    std::string_view content,
+    std::string_view baseDir,
+    const Options& options) {
   SqlFile result;
 
   std::istringstream stream{std::string(content)};
@@ -231,6 +234,14 @@ SqlFile SqlFile::parse(std::string_view content, std::string_view baseDir) {
   bool inSetupBlock = false;
   std::string setupBlockBody;
   bool sawNonSetupLine = false;
+
+  // Precompute the "-- <name>:" prefix for each custom directive so the scan
+  // loop doesn't rebuild them per line.
+  std::vector<std::pair<std::string, std::string>> customPrefixes;
+  customPrefixes.reserve(options.customSetupDirectives.size());
+  for (const auto& name : options.customSetupDirectives) {
+    customPrefixes.emplace_back("-- " + name + ":", name);
+  }
 
   // Scan the top of the content for setup directives. Stop at the first
   // non-directive line outside a setup block.
@@ -291,6 +302,21 @@ SqlFile SqlFile::parse(std::string_view content, std::string_view baseDir) {
     if (trimmed == "-- setup") {
       inSetupBlock = true;
       bytesConsumed = lineEnd;
+      continue;
+    }
+
+    bool capturedCustom = false;
+    for (const auto& [prefix, name] : customPrefixes) {
+      if (trimmed.starts_with(prefix)) {
+        auto value = std::string(ltrim(trimmed.substr(prefix.size())));
+        rtrim(value);
+        result.directives[name] = std::move(value);
+        bytesConsumed = lineEnd;
+        capturedCustom = true;
+        break;
+      }
+    }
+    if (capturedCustom) {
       continue;
     }
 

--- a/axiom/optimizer/tests/SqlFile.h
+++ b/axiom/optimizer/tests/SqlFile.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -71,6 +72,15 @@ struct QueryEntry {
 /// to install reference tables, plus the query entries that test against
 /// them.
 struct SqlFile {
+  /// Parse-time options.
+  struct Options {
+    /// Names of file-level directives to capture. A top-of-file
+    /// `-- <name>: <value>` line whose name is listed here is stored in
+    /// `directives`; names not listed are treated as plain comments. Lets a
+    /// consumer define directives the shared parser need not know about.
+    std::vector<std::string> customSetupDirectives;
+  };
+
   /// DDL statements (CREATE TABLE / INSERT INTO …) collected from the
   /// file's setup directives in source order. Run before any query in the
   /// file executes.
@@ -78,6 +88,11 @@ struct SqlFile {
 
   /// Query entries parsed from the body of the file.
   std::vector<QueryEntry> entries;
+
+  /// Values of the custom directives requested via
+  /// Options::customSetupDirectives and present in the file, keyed by directive
+  /// name.
+  std::map<std::string, std::string> directives;
 
   /// Connector the file's setup DDL and queries run against, from a top-of-file
   /// '-- connector: <test|hive>' directive. Defaults to kTest.
@@ -122,7 +137,11 @@ struct SqlFile {
   /// @param baseDir Directory used to resolve setup_file paths. Pass an
   /// empty string when no setup_file directives are expected (e.g. unit
   /// tests of the parser).
-  static SqlFile parse(std::string_view content, std::string_view baseDir);
+  /// @param options Parse-time options; see Options.
+  static SqlFile parse(
+      std::string_view content,
+      std::string_view baseDir,
+      const Options& options = {});
 };
 
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/tests/SqlFileTest.cpp
+++ b/axiom/optimizer/tests/SqlFileTest.cpp
@@ -399,5 +399,53 @@ TEST_F(SqlFileTest, connectorUnknownRejected) {
       "Unknown connector directive 'postgres'");
 }
 
+TEST_F(SqlFileTest, customDirectiveCaptured) {
+  auto file = SqlFile::parse(
+      "-- tables: orders, nation\n"
+      "SELECT * FROM orders",
+      /*baseDir=*/"",
+      {.customSetupDirectives = {"tables"}});
+  EXPECT_EQ(file.directives.at("tables"), "orders, nation");
+  ASSERT_THAT(file.entries, testing::SizeIs(1));
+  EXPECT_EQ(file.entries[0].sql, "SELECT * FROM orders");
+  // Query line numbers are unaffected by the captured directive.
+  EXPECT_EQ(file.entries[0].lineNumber, 2);
+}
+
+TEST_F(SqlFileTest, customDirectiveNotListedStaysComment) {
+  // A '-- name: value' line whose name is not requested is an ordinary
+  // comment and is not captured.
+  auto file = SqlFile::parse(
+      "-- tables: orders\n"
+      "SELECT 1",
+      /*baseDir=*/"");
+  EXPECT_THAT(file.directives, testing::IsEmpty());
+  ASSERT_THAT(file.entries, testing::SizeIs(1));
+  EXPECT_EQ(file.entries[0].sql, "SELECT 1");
+}
+
+TEST_F(SqlFileTest, customDirectiveAbsent) {
+  auto file = SqlFile::parse(
+      "SELECT 1", /*baseDir=*/"", {.customSetupDirectives = {"tables"}});
+  EXPECT_THAT(file.directives, testing::IsEmpty());
+}
+
+TEST_F(SqlFileTest, customDirectiveWithSetupAndConnector) {
+  auto file = SqlFile::parse(
+      "-- connector: hive\n"
+      "-- tables: none\n"
+      "-- setup\n"
+      "CREATE TABLE t(a BIGINT)\n"
+      "-- end_setup\n"
+      "SELECT a FROM t",
+      /*baseDir=*/"",
+      {.customSetupDirectives = {"tables"}});
+  EXPECT_EQ(file.connector, TestConnectorKind::kLocalHive);
+  EXPECT_EQ(file.directives.at("tables"), "none");
+  ASSERT_THAT(file.setupStatements, testing::SizeIs(1));
+  ASSERT_THAT(file.entries, testing::SizeIs(1));
+  EXPECT_EQ(file.entries[0].sql, "SELECT a FROM t");
+}
+
 } // namespace
 } // namespace facebook::axiom::optimizer::test

--- a/axiom/optimizer/v2/Optimize.cpp
+++ b/axiom/optimizer/v2/Optimize.cpp
@@ -115,6 +115,20 @@ PlanAndStats Optimizer::optimize(const MultiFragmentPlan::Options& options) {
       std::move(emitted.fragments), options);
   result.finishWrite = std::move(emitted.finishWrite);
   result.prediction = std::move(emitted.prediction);
+
+  // The plan's output must have one column per logical-plan output column. A
+  // TableWrite root emits write-stats rows instead of the query columns, so it
+  // is exempt.
+  if (!plan_.is(logical_plan::NodeKind::kTableWrite)) {
+    const auto& veloxOutput =
+        result.plan->fragments().back().fragment.planNode->outputType();
+    VELOX_CHECK(
+        veloxOutput->equivalent(*plan_.outputType()),
+        "Plan output type does not match the logical plan output type: {} vs {}",
+        veloxOutput->toString(),
+        plan_.outputType()->toString());
+  }
+
   return result;
 }
 

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -424,6 +424,15 @@ class Translator {
       const lp::LimitNode& limit,
       const LpNameSet& required);
   Translated translateSort(const lp::SortNode& sort, const LpNameSet& required);
+
+  // Translates ordering keys, dropping any key that repeats an earlier one. A
+  // repeated key cannot refine the order its first occurrence imposes, and
+  // Velox rejects Sort/TopN nodes with duplicate keys.
+  std::pair<ExprVector, OrderTypeVector> dedupOrdering(
+      const std::vector<lp::SortingField>& ordering,
+      const Scope& scope,
+      NodeCP* applyTarget);
+
   Translated translateSample(
       const lp::SampleNode& sample,
       const LpNameSet& required);
@@ -1017,14 +1026,8 @@ const optimizer::Aggregate* Translator::toAggregateCall(
       ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
       : nullptr;
 
-  ExprVector orderKeys;
-  OrderTypeVector orderTypes;
-  orderKeys.reserve(aggregateExpr.ordering().size());
-  orderTypes.reserve(aggregateExpr.ordering().size());
-  for (const auto& field : aggregateExpr.ordering()) {
-    orderKeys.push_back(translateExpr(*field.expression, scope, applyTarget));
-    orderTypes.push_back(toOrderType(field.order));
-  }
+  auto [orderKeys, orderTypes] =
+      dedupOrdering(aggregateExpr.ordering(), scope, applyTarget);
   Value value(toType(aggregateExpr.type()));
 
   Name aggName = toName(aggregateExpr.name());
@@ -1192,6 +1195,26 @@ Translated Translator::translateLimit(
   return {limitNode, std::move(input.scope)};
 }
 
+std::pair<ExprVector, OrderTypeVector> Translator::dedupOrdering(
+    const std::vector<lp::SortingField>& ordering,
+    const Scope& scope,
+    NodeCP* applyTarget) {
+  ExprVector orderKeys;
+  OrderTypeVector orderTypes;
+  orderKeys.reserve(ordering.size());
+  orderTypes.reserve(ordering.size());
+  folly::F14FastSet<ExprCP> seen;
+  for (const auto& field : ordering) {
+    ExprCP key = translateExpr(*field.expression, scope, applyTarget);
+    if (!seen.insert(key).second) {
+      continue;
+    }
+    orderKeys.push_back(key);
+    orderTypes.push_back(toOrderType(field.order));
+  }
+  return {std::move(orderKeys), std::move(orderTypes)};
+}
+
 Translated Translator::translateSort(
     const lp::SortNode& sort,
     const LpNameSet& required) {
@@ -1204,15 +1227,8 @@ Translated Translator::translateSort(
   Translated input = translateNode(*sort.onlyInput(), childRequired);
 
   NodeCP currentInput = input.node;
-  ExprVector orderKeys;
-  OrderTypeVector orderTypes;
-  orderKeys.reserve(sort.ordering().size());
-  orderTypes.reserve(sort.ordering().size());
-  for (const auto& field : sort.ordering()) {
-    orderKeys.push_back(
-        translateExpr(*field.expression, input.scope, &currentInput));
-    orderTypes.push_back(toOrderType(field.order));
-  }
+  auto [orderKeys, orderTypes] =
+      dedupOrdering(sort.ordering(), input.scope, &currentInput);
 
   SortCP sortNode = builder_.make<Sort>(
       {currentInput, std::move(orderKeys), std::move(orderTypes)});

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -349,54 +349,58 @@ class Translator {
         simplifier_(builder, evaluator) {}
 
   TranslatePass::Result run(const lp::LogicalPlanNode& plan) {
+    // The query output is a list of (sourceName, outputName) pairs, one per
+    // output position. An OutputNode names them explicitly and may repeat a
+    // source column under several output names; a bare plan (no OutputNode)
+    // uses its own outputType field names for both. Each position resolves by
+    // name through the translated scope: identical output expressions collapse
+    // to one Column, so the scope -- not the node's column list -- carries
+    // every output position.
+    const lp::LogicalPlanNode* node;
+    std::vector<std::pair<std::string, std::string>> outputSpec;
     if (plan.is(lp::NodeKind::kOutput)) {
       const auto& output = *plan.as<lp::OutputNode>();
-      const auto& child = *output.onlyInput();
-      const auto& childOutputType = *child.outputType();
-      // Seed `required` with just the LP names the OutputNode references.
-      // Names not referenced flow as "unused" through the child translation
-      // and get pruned where producers honor the required-set.
-      LpNameSet required;
-      required.reserve(output.entries().size());
+      node = &*output.onlyInput();
+      const auto& childOutputType = *node->outputType();
+      outputSpec.reserve(output.entries().size());
       for (const auto& entry : output.entries()) {
         VELOX_CHECK_LT(entry.index, childOutputType.size());
-        required.insert(childOutputType.nameOf(entry.index));
+        outputSpec.emplace_back(
+            childOutputType.nameOf(entry.index), entry.name);
       }
-      Translated inner = translateNode(child, required);
-      ColumnVector outputColumns;
-      std::vector<std::string> outputNames;
-      outputColumns.reserve(output.entries().size());
-      outputNames.reserve(output.entries().size());
-      for (const auto& entry : output.entries()) {
-        // Resolve via LP-name → Column* scope rather than positionally:
-        // the IR's outputColumns may be narrower than the LP child's
-        // outputType after dup-collapse, and the LP contract is that
-        // same-name == same-thing in a node's outputType.
-        const auto& name = childOutputType.nameOf(entry.index);
-        auto it = inner.scope.find(name);
-        VELOX_CHECK(
-            it != inner.scope.end(),
-            "OutputNode entry name not found in inner scope: {}",
-            name);
-        outputColumns.push_back(it->second);
-        outputNames.push_back(entry.name);
+    } else {
+      node = &plan;
+      const auto& outputType = *plan.outputType();
+      outputSpec.reserve(outputType.size());
+      for (size_t i = 0; i < outputType.size(); ++i) {
+        outputSpec.emplace_back(outputType.nameOf(i), outputType.nameOf(i));
       }
-      return {inner.node, std::move(outputColumns), std::move(outputNames)};
     }
-    // Bare plan (no OutputNode): nothing has narrowed the required set, so
-    // request everything the root advertises. Output names are best-effort here
-    // (the column's own name) and not guaranteed without an OutputNode to pin
-    // them -- see the optimize() contract in Optimize.h.
-    Translated translated = translateNode(plan, allNames(*plan.outputType()));
+
+    // Request only the referenced source names; unreferenced names flow through
+    // as unused and get pruned where producers honor the required-set.
+    LpNameSet required;
+    required.reserve(outputSpec.size());
+    for (const auto& [sourceName, outputName] : outputSpec) {
+      required.insert(sourceName);
+    }
+
+    Translated translated = translateNode(*node, required);
+
+    ColumnVector outputColumns;
     std::vector<std::string> outputNames;
-    outputNames.reserve(translated.node->outputColumns().size());
-    for (ColumnCP column : translated.node->outputColumns()) {
-      outputNames.emplace_back(column->outputName());
+    outputColumns.reserve(outputSpec.size());
+    outputNames.reserve(outputSpec.size());
+    for (const auto& [sourceName, outputName] : outputSpec) {
+      auto it = translated.scope.find(sourceName);
+      VELOX_CHECK(
+          it != translated.scope.end(),
+          "Output name not found in scope: {}",
+          sourceName);
+      outputColumns.push_back(it->second);
+      outputNames.push_back(outputName);
     }
-    return {
-        translated.node,
-        ColumnVector{translated.node->outputColumns()},
-        std::move(outputNames)};
+    return {translated.node, std::move(outputColumns), std::move(outputNames)};
   }
 
  private:

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1757,20 +1757,16 @@ Translated Translator::translateSet(
 
       // Set-op via Join: each leg's columns become join keys, so all of each
       // leg's outputType is consumed.
-      Translated current = {
-          translateNode(
-              *set.inputs().front(),
-              allNames(*set.inputs().front()->outputType()))
-              .node,
-          {}};
+      Translated first = translateNode(
+          *set.inputs().front(), allNames(*set.inputs().front()->outputType()));
+      NodeCP node = first.node;
       for (size_t i = 1; i < set.inputs().size(); ++i) {
-        Translated other = {
+        NodeCP other =
             translateNode(
                 *set.inputs()[i], allNames(*set.inputs()[i]->outputType()))
-                .node,
-            {}};
-        const auto& leftColumns = current.node->outputColumns();
-        const auto& rightColumns = other.node->outputColumns();
+                .node;
+        const auto& leftColumns = node->outputColumns();
+        const auto& rightColumns = other->outputColumns();
         VELOX_CHECK_EQ(leftColumns.size(), rightColumns.size());
         ExprVector leftKeys;
         ExprVector rightKeys;
@@ -1782,9 +1778,9 @@ Translated Translator::translateSet(
           rightKeys.push_back(rightColumns[columnIndex]);
         }
         ColumnVector outputColumns{leftColumns};
-        current.node = builder_.make<Join>(
-            {current.node,
-             other.node,
+        node = builder_.make<Join>(
+            {node,
+             other,
              joinType,
              std::move(leftKeys),
              std::move(rightKeys),
@@ -1794,21 +1790,31 @@ Translated Translator::translateSet(
              std::move(outputColumns)});
       }
 
-      // Output schema is the left side's columns flowing through the Join
-      // unchanged.
-      const ColumnVector& outputColumns = current.node->outputColumns();
+      // Output columns are the first leg's, flowing through the Join unchanged.
+      // Resolve each output position by name through the first leg's scope so
+      // positions the leg collapsed to one Column (see translateProject) map
+      // both symbols to that shared Column.
       Scope scope;
-      populateScope(*set.outputType(), outputColumns, scope);
+      const auto& firstType = *set.inputs().front()->outputType();
+      for (size_t j = 0; j < set.outputType()->size(); ++j) {
+        auto it = first.scope.find(firstType.nameOf(j));
+        VELOX_CHECK(
+            it != first.scope.end(),
+            "Set-op leg scope missing column: {}",
+            firstType.nameOf(j));
+        scope[set.outputType()->nameOf(j)] = it->second;
+      }
 
       if (isDistinct) {
+        const ColumnVector& outputColumns = node->outputColumns();
         AggregateCP aggNode = builder_.make<Aggregate>(
-            {current.node,
+            {node,
              ExprVector{outputColumns.begin(), outputColumns.end()},
              AggregateCallVector{},
              outputColumns});
         return {aggNode, std::move(scope)};
       }
-      return {current.node, std::move(scope)};
+      return {node, std::move(scope)};
     }
   }
   VELOX_UNREACHABLE();

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1576,7 +1576,9 @@ class RelationPlanner : public AstVisitor {
     // SQL set-operation output names come from the left input.
     auto leftDisplayNames = std::move(displayNames_.lastNames);
 
-    builder_ = newBuilder(leftBuilder->scope());
+    // Set-operation branches are independent: the right branch resolves against
+    // the enclosing scope, not the left branch's output columns.
+    builder_ = newBuilder(leftBuilder->outerScope());
     right->accept(this);
     auto rightBuilder = builder_;
 

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -900,6 +900,12 @@ TEST_F(PrestoParserTest, intersect) {
       matcherAll);
 }
 
+TEST_F(PrestoParserTest, unionAllUnresolvedColumn) {
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT n_name FROM nation UNION ALL SELECT n_name FROM region"),
+      "Cannot resolve column");
+}
+
 TEST_F(PrestoParserTest, exists) {
   {
     auto matcher =


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/162


SqlTest provisioned all eight tiny TPC-H tables into both Axel and DuckDB at startup, regardless of which tables a file actually queried. In dev builds this costs ~40s per test process even for a file that touches no tables. Each `.sql` file now declares the tables it uses, and only those are created.

Dev-build startup, before vs after (wall clock):

    example.sql      (no tables)       39s -> 9s
    castandtype.sql  (orders only)     50s -> 36s
    aggregation.sql  (4 of 8 tables)   128s -> 121s

The saving scales with how much is skipped; a file that still needs `lineitem` (the largest table) saves little.

A file opts in with a top-of-file directive:

    -- tables: nation, orders

The default is none: a file with no directive provisions nothing, so a query against a table it did not declare fails loudly. The harness provisions the union of the tables declared across the files that share a target. To keep the shared parser free of Axel-specific concepts, `SqlFile::parse` takes an `Options` list of directive names to capture into name/value pairs; `-- tables:` is interpreted by the Axel harness, not the parser.

Reviewed By: arhimondr

Differential Revision: D113266810


