### PR TITLE
fix(sql): Flatten AND/OR chains into n-ary calls (#1643)

### DIFF
--- a/axiom/optimizer/tests/TestConnectorQueryTest.cpp
+++ b/axiom/optimizer/tests/TestConnectorQueryTest.cpp
@@ -150,6 +150,26 @@ TEST_P(TestConnectorQueryTest, sharedSubexpressionConversion) {
   ASSERT_NO_THROW(toSingleNodePlan(logicalPlan));
 }
 
+// A wide same-operator OR chain flattens into one n-ary call and executes;
+// without flattening the left-nested tree would exceed the nesting depth cap.
+TEST_P(TestConnectorQueryTest, wideOrChainExecutes) {
+  auto data = makeRowVector({"a"}, {makeFlatVector<int64_t>({-1, 0, 1, 2})});
+  testConnector_->addTable("t", data->rowType())->addData(data);
+
+  // Well past the 512 nesting depth cap (a pre-flatten tree would be rejected),
+  // kept small enough to plan and execute quickly.
+  constexpr uint32_t kWidth = 5'000;
+  std::string sql = "SELECT a FROM t WHERE a = 0";
+  for (uint32_t i = 1; i < kWidth; ++i) {
+    sql += fmt::format(" OR a = {}", i);
+  }
+
+  auto expected = makeRowVector({makeFlatVector<int64_t>({0, 1, 2})});
+  auto logicalPlan = parseSelect(sql, kTestConnectorId);
+  auto results = runVelox(logicalPlan, options_);
+  exec::test::assertEqualResults(results.results, {expected});
+}
+
 AXIOM_INSTANTIATE_V1_V2(TestConnectorQueryTest);
 
 } // namespace

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -891,20 +891,6 @@ lp::ExprApi ExpressionPlanner::toExpr(
       return lp::Call("like", std::move(inputs));
     }
 
-    case NodeType::kLogicalBinaryExpression: {
-      auto* logical = node->as<LogicalBinaryExpression>();
-      auto left = toExpr(logical->left(), options);
-      auto right = toExpr(logical->right(), options);
-
-      switch (logical->op()) {
-        case LogicalBinaryExpression::Operator::kAnd:
-          return left && right;
-
-        case LogicalBinaryExpression::Operator::kOr:
-          return left || right;
-      }
-    }
-
     case NodeType::kArithmeticUnaryExpression: {
       auto* unary = node->as<ArithmeticUnaryExpression>();
       if (unary->sign() == ArithmeticUnaryExpression::Sign::kMinus) {

--- a/axiom/sql/presto/ParserOptions.cpp
+++ b/axiom/sql/presto/ParserOptions.cpp
@@ -59,6 +59,13 @@ std::vector<ConfigProperty> buildProperties(
           "Maximum subquery nesting depth; deeper nesting is rejected to avoid "
           "a stack overflow.",
       },
+      {
+          std::string(ParserOptions::kMaxExpressionWidth),
+          ConfigPropertyType::kInteger,
+          fmt::to_string(ParserOptions::kMaxExpressionWidthDefault),
+          "Maximum number of operands in a single flattened AND/OR chain; "
+          "wider chains are rejected.",
+      },
   };
 
   if (configOverrides.empty()) {
@@ -115,6 +122,7 @@ ParserOptions ParserOptions::from(
   setBool(kParseDecimalLiteralAsDouble, options.parseDecimalLiteralAsDouble);
   setUint32(kMaxExpressionDepth, options.maxExpressionDepth);
   setUint32(kMaxSubqueryDepth, options.maxSubqueryDepth);
+  setUint32(kMaxExpressionWidth, options.maxExpressionWidth);
   return options;
 }
 

--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -34,11 +34,14 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
       "parse_decimal_literal_as_double";
   static constexpr std::string_view kMaxExpressionDepth =
       "max_expression_depth";
+  static constexpr std::string_view kMaxExpressionWidth =
+      "max_expression_width";
   static constexpr std::string_view kMaxSubqueryDepth = "max_subquery_depth";
 
   static constexpr bool kFriendlySqlDefault = true;
   static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
   static constexpr uint32_t kMaxExpressionDepthDefault = 512;
+  static constexpr uint32_t kMaxExpressionWidthDefault = 100'000;
   static constexpr uint32_t kMaxSubqueryDepthDefault = 1024;
 
   ParserOptions();
@@ -57,9 +60,22 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
   /// property.
   bool parseDecimalLiteralAsDouble{kParseDecimalLiteralAsDoubleDefault};
 
-  /// Maximum expression nesting depth; deeper expressions are rejected to
-  /// avoid a stack overflow.
+  /// Maximum nesting depth of an expression tree; deeper expressions are
+  /// rejected to avoid a stack overflow. Depth is how deeply operators nest,
+  /// e.g. a - (b - (c - d)) is three deep. Distinct from maxExpressionWidth,
+  /// which instead bounds the operand count of a single flattened AND/OR node.
   uint32_t maxExpressionDepth{kMaxExpressionDepthDefault};
+
+  /// Maximum number of operands in a single flattened AND/OR chain; wider
+  /// chains are rejected. Width is how many operands one flattened node holds,
+  /// e.g. a OR b OR c OR d is one node of width four. Distinct from
+  /// maxExpressionDepth, which instead bounds how deeply operators nest.
+  ///
+  /// The default is large because flattening collapses a chain into a single
+  /// node whose operand count downstream passes process in linear time, and the
+  /// widest chains seen in production (autoanalyzer output) reach on the order
+  /// of 42K operands; 100'000 clears that with roughly 2x headroom.
+  uint32_t maxExpressionWidth{kMaxExpressionWidthDefault};
 
   /// Maximum subquery nesting depth; deeper nesting is rejected to avoid a
   /// stack overflow.

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1822,16 +1822,45 @@ std::any AstBuilder::visitLogicalBinary(
     PrestoSqlParser::LogicalBinaryContext* ctx) {
   trace("visitLogicalBinary");
 
-  auto leftExpr = visitExpression(ctx->left);
-  auto rightExpr = visitExpression(ctx->right);
+  const auto location = getLocation(ctx);
+  const bool isAnd = ctx->AND() != nullptr;
 
-  LogicalBinaryExpression::Operator op = ctx->AND() != nullptr
-      ? LogicalBinaryExpression::Operator::kAnd
-      : LogicalBinaryExpression::Operator::kOr;
+  // Flatten a same-operator chain into one n-ary call.
+  std::vector<ExpressionPtr> arguments;
 
-  return std::static_pointer_cast<Expression>(
-      std::make_shared<LogicalBinaryExpression>(
-          getLocation(ctx), op, leftExpr, rightExpr));
+  // Fail fast: reject an oversize chain without building every operand.
+  auto checkWidth = [&] {
+    AXIOM_PRESTO_SEMANTIC_CHECK_LE(
+        arguments.size(),
+        options_.maxExpressionWidth,
+        location,
+        /*token=*/std::nullopt,
+        "Expression exceeds maximum width");
+  };
+
+  auto* current = ctx;
+  while (true) {
+    arguments.push_back(visitExpression(current->right));
+    checkWidth();
+    auto* leftBinary =
+        dynamic_cast<PrestoSqlParser::LogicalBinaryContext*>(current->left);
+    const bool leftIsSameOp =
+        leftBinary != nullptr && (leftBinary->AND() != nullptr) == isAnd;
+    if (!leftIsSameOp) {
+      break;
+    }
+    current = leftBinary;
+  }
+  arguments.push_back(visitExpression(current->left));
+  checkWidth();
+  // Operands were collected right to left; restore their original order.
+  std::reverse(arguments.begin(), arguments.end());
+
+  return std::static_pointer_cast<Expression>(std::make_shared<FunctionCall>(
+      location,
+      std::make_shared<QualifiedName>(
+          location, std::vector<std::string>{isAnd ? "and" : "or"}),
+      arguments));
 }
 
 namespace {

--- a/axiom/sql/presto/ast/AstExpressions.h
+++ b/axiom/sql/presto/ast/AstExpressions.h
@@ -640,53 +640,6 @@ class QuantifiedComparisonExpression : public Expression {
 };
 
 // Logical Expressions
-class LogicalBinaryExpression : public Expression {
- public:
-  enum class Operator { kAnd, kOr };
-
-  LogicalBinaryExpression(
-      NodeLocation location,
-      Operator op,
-      const ExpressionPtr& left,
-      const ExpressionPtr& right)
-      : Expression(NodeType::kLogicalBinaryExpression, location),
-        operator_(op),
-        left_(left),
-        right_(right) {}
-
-  Operator op() const {
-    return operator_;
-  }
-
-  const ExpressionPtr& left() const {
-    return left_;
-  }
-
-  const ExpressionPtr& right() const {
-    return right_;
-  }
-
-  void accept(AstVisitor* visitor) override;
-
-  size_t hash() const override {
-    return folly::hash::hash_combine(
-        std::hash<Operator>{}(operator_),
-        Node::deepHash(left_),
-        Node::deepHash(right_));
-  }
-
- protected:
-  bool equals(const Node& other) const override {
-    const auto& o = *other.as<LogicalBinaryExpression>();
-    return operator_ == o.operator_ && Node::deepEqual(left_, o.left_) &&
-        Node::deepEqual(right_, o.right_);
-  }
-
- private:
-  Operator operator_;
-  ExpressionPtr left_;
-  ExpressionPtr right_;
-};
 
 class NotExpression : public Expression {
  public:

--- a/axiom/sql/presto/ast/AstNode.h
+++ b/axiom/sql/presto/ast/AstNode.h
@@ -72,7 +72,6 @@ enum class NodeType {
   kQuantifiedComparisonExpression,
 
   // Logical Expressions
-  kLogicalBinaryExpression,
   kNotExpression,
 
   // Conditional Expressions

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -69,7 +69,6 @@ const auto& nodeTypeNames() {
        "QuantifiedComparisonExpression"},
 
       // Logical Expressions
-      {NodeType::kLogicalBinaryExpression, "LogicalBinaryExpression"},
       {NodeType::kNotExpression, "NotExpression"},
 
       // Conditional Expressions
@@ -373,10 +372,6 @@ void QuantifiedComparisonExpression::accept(AstVisitor* visitor) {
 }
 
 // Logical Expression implementations
-void LogicalBinaryExpression::accept(AstVisitor* visitor) {
-  visitor->visitLogicalBinaryExpression(this);
-}
-
 void NotExpression::accept(AstVisitor* visitor) {
   visitor->visitNotExpression(this);
 }

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -98,17 +98,6 @@ std::string toString(ArithmeticBinaryExpression::Operator op) {
   VELOX_FAIL("Unsupported arithmetic operator");
 }
 
-std::string toString(LogicalBinaryExpression::Operator op) {
-  switch (op) {
-    case LogicalBinaryExpression::Operator::kAnd:
-      return "and";
-    case LogicalBinaryExpression::Operator::kOr:
-      return "or";
-  }
-
-  VELOX_FAIL("Unsupported logical operator");
-}
-
 std::string toString(ComparisonExpression::Operator op) {
   switch (op) {
     case ComparisonExpression::Operator::kEqual:
@@ -160,16 +149,6 @@ void AstPrinter::visitArithmeticBinaryExpression(
   printHeader("Arithmetic", node, [&](std::ostream& out) {
     out << toString(node->op());
   });
-
-  indent_++;
-  printChild("Left", node->left());
-  printChild("Right", node->right());
-  indent_--;
-}
-
-void AstPrinter::visitLogicalBinaryExpression(LogicalBinaryExpression* node) {
-  printHeader(
-      "Logical", node, [&](std::ostream& out) { out << toString(node->op()); });
 
   indent_++;
   printChild("Left", node->left());

--- a/axiom/sql/presto/ast/AstPrinter.h
+++ b/axiom/sql/presto/ast/AstPrinter.h
@@ -91,8 +91,6 @@ class AstPrinter : public AstVisitor {
       QuantifiedComparisonExpression* node) override;
 
   // Logical Expressions
-  void visitLogicalBinaryExpression(LogicalBinaryExpression* node) override;
-
   void visitNotExpression(NotExpression* node) override;
 
   // Conditional Expressions

--- a/axiom/sql/presto/ast/AstVisitor.h
+++ b/axiom/sql/presto/ast/AstVisitor.h
@@ -162,10 +162,6 @@ class AstVisitor {
   }
 
   // Logical Expressions
-  virtual void visitLogicalBinaryExpression(LogicalBinaryExpression* node) {
-    defaultVisit(node);
-  }
-
   virtual void visitNotExpression(NotExpression* node) {
     defaultVisit(node);
   }

--- a/axiom/sql/presto/ast/DefaultTraversalVisitor.h
+++ b/axiom/sql/presto/ast/DefaultTraversalVisitor.h
@@ -628,15 +628,6 @@ class DefaultTraversalVisitor : public AstVisitor {
     }
   }
 
-  void visitLogicalBinaryExpression(LogicalBinaryExpression* node) override {
-    if (node->left()) {
-      node->left()->accept(this);
-    }
-    if (node->right()) {
-      node->right()->accept(this);
-    }
-  }
-
   void visitNotExpression(NotExpression* node) override {
     if (node->value()) {
       node->value()->accept(this);

--- a/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
+++ b/axiom/sql/presto/ast/tests/AstEqualityTest.cpp
@@ -627,30 +627,6 @@ TEST(AstEqualityTest, quantifiedComparisonExpressionNotEqualQuantifier) {
   EXPECT_FALSE(*a == *b);
 }
 
-TEST(AstEqualityTest, logicalBinaryExpressionEquals) {
-  auto a = std::make_shared<LogicalBinaryExpression>(
-      loc(0, 0),
-      LogicalBinaryExpression::Operator::kAnd,
-      longLit(1),
-      longLit(2));
-  auto b = std::make_shared<LogicalBinaryExpression>(
-      loc(5, 5),
-      LogicalBinaryExpression::Operator::kAnd,
-      longLit(1),
-      longLit(2));
-  EXPECT_TRUE(*a == *b);
-  EXPECT_EQ(a->hash(), b->hash());
-}
-
-TEST(AstEqualityTest, logicalBinaryExpressionNotEqualOperator) {
-  // a AND b vs a OR b.
-  auto a = std::make_shared<LogicalBinaryExpression>(
-      loc(), LogicalBinaryExpression::Operator::kAnd, longLit(1), longLit(2));
-  auto b = std::make_shared<LogicalBinaryExpression>(
-      loc(), LogicalBinaryExpression::Operator::kOr, longLit(1), longLit(2));
-  EXPECT_FALSE(*a == *b);
-}
-
 TEST(AstEqualityTest, notExpressionEquals) {
   auto a = std::make_shared<NotExpression>(loc(0, 0), longLit(1));
   auto b = std::make_shared<NotExpression>(loc(5, 5), longLit(1));

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 #include <limits>
+#include "axiom/sql/presto/tests/ExprMatcher.h"
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
 #include "velox/common/base/tests/GTestUtils.h"
 #include "velox/functions/prestosql/types/QDigestRegistration.h"
@@ -23,22 +24,35 @@
 #include "velox/functions/prestosql/types/TDigestRegistration.h"
 #include "velox/functions/prestosql/types/TDigestType.h"
 #include "velox/functions/prestosql/types/TimestampWithTimeZoneType.h"
+#include "velox/parse/ExpressionsParser.h"
 
 namespace axiom::sql::presto::test {
 
 using namespace facebook::velox;
 namespace lp = facebook::axiom::logical_plan;
+using facebook::axiom::logical_plan::test::ExprMatcher;
 
 namespace {
 
 class ExpressionParserTest : public PrestoParserTestBase {
  protected:
-  lp::ExprPtr parseExpr(std::string_view sql) {
-    return makeParser().parseExpression(sql, true);
+  lp::ExprPtr parseExpr(
+      std::string_view sql,
+      uint32_t maxExpressionWidth = ParserOptions::kMaxExpressionWidthDefault) {
+    ParserOptions options;
+    options.maxExpressionWidth = maxExpressionWidth;
+    return PrestoParser(
+               kConnectorId, "default", makeParserSession(std::move(options)))
+        .parseExpression(sql, true);
   }
 
   lp::ExprPtr parseStrictExpr(std::string_view sql) {
     return makeStrictParser().parseExpression(sql, true);
+  }
+
+  // Matches a parsed expression against a reference expression (DuckDB syntax).
+  bool match(const lp::ExprPtr& expr, const std::string& expected) {
+    return ExprMatcher::match(expr, duckParser_.parseExpr(expected));
   }
 
   // Parses 'SELECT <expr> FROM nation' and verifies the project expression
@@ -72,6 +86,8 @@ class ExpressionParserTest : public PrestoParserTestBase {
     ASSERT_FALSE(v->isNull());
     ASSERT_EQ(v->value<T>(), value);
   }
+
+  facebook::velox::parse::DuckSqlExpressionsParser duckParser_;
 };
 
 TEST_F(ExpressionParserTest, types) {
@@ -1122,7 +1138,6 @@ TEST_F(ExpressionParserTest, nestingDepthCapped) {
         "Expression exceeds maximum nesting depth");
   };
   expectRejected("1", " + 0");
-  expectRejected("true", " AND true");
   expectRejected("'a'", " || 'a'");
   expectRejected("x", "[1]");
 
@@ -1130,6 +1145,67 @@ TEST_F(ExpressionParserTest, nestingDepthCapped) {
   AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
       parseSql(chain("SELECT 1", " UNION ALL SELECT 1", past)),
       "Expression exceeds maximum nesting depth");
+}
+
+// A same-operator chain past the depth cap flattens into one n-ary call.
+TEST_F(ExpressionParserTest, deepChainFlattens) {
+  const uint32_t numTerms = ParserOptions::kMaxExpressionDepthDefault + 1;
+  auto test = [&](std::string_view op, lp::SpecialForm form) {
+    SCOPED_TRACE(op);
+    std::string sql = "1 = 0";
+    for (uint32_t i = 1; i < numTerms; ++i) {
+      sql += fmt::format(" {} 1 = {}", op, i);
+    }
+    auto expr = parseExpr(sql);
+    ASSERT_TRUE(expr->isSpecialForm());
+    auto* special = expr->as<lp::SpecialFormExpr>();
+    EXPECT_EQ(special->form(), form);
+    EXPECT_EQ(special->inputs().size(), numTerms);
+  };
+  test("OR", lp::SpecialForm::kOr);
+  test("AND", lp::SpecialForm::kAnd);
+}
+
+// Operands keep source order after flattening.
+TEST_F(ExpressionParserTest, flattenPreservesOperandOrder) {
+  ASSERT_TRUE(match(
+      parseExpr("1 = 2 OR 3 = 4 OR 5 = 6"), R"("or"(1 = 2, 3 = 4, 5 = 6))"));
+}
+
+// Operators of different kinds are not merged; the AND stays nested in the OR.
+TEST_F(ExpressionParserTest, mixedOperatorsNotFlattened) {
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 AND 2 = 0 OR 3 = 0"), "(1 = 0 AND 2 = 0) OR 3 = 0"));
+}
+
+// A parenthesized chain stays grouped; only a plain chain is flattened.
+TEST_F(ExpressionParserTest, parenthesizedChainNotFlattened) {
+  ASSERT_TRUE(match(
+      parseExpr("1 = 0 OR (2 = 0 OR 3 = 0)"),
+      R"("or"(1 = 0, "or"(2 = 0, 3 = 0)))"));
+}
+
+// A flattened chain wider than max_expression_width is rejected.
+TEST_F(ExpressionParserTest, chainWiderThanCapRejected) {
+  // A chain at exactly the cap is accepted and flattens to that many operands.
+  auto atCap = parseExpr("1 = 0 OR 1 = 1 OR 1 = 2", /*maxExpressionWidth=*/3);
+  ASSERT_TRUE(atCap->isSpecialForm());
+  auto* atCapOr = atCap->as<lp::SpecialFormExpr>();
+  EXPECT_EQ(atCapOr->form(), lp::SpecialForm::kOr);
+  EXPECT_EQ(atCapOr->inputs().size(), 3u);
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr("1 = 0 OR 1 = 1 OR 1 = 2 OR 1 = 3", /*maxExpressionWidth=*/3),
+      "Expression exceeds maximum width");
+}
+
+// The width cap applies to each flattened node, not just the outermost.
+TEST_F(ExpressionParserTest, nestedChainWidthEnforcedPerNode) {
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseExpr(
+          "(1 = 0 AND 1 = 1 AND 1 = 2 AND 1 = 3) OR 1 = 4",
+          /*maxExpressionWidth=*/3),
+      "Expression exceeds maximum width");
 }
 
 } // namespace


### PR DESCRIPTION
Summary:

A long chain like `x = 0 OR x = 1 OR ... OR x = 999` was rejected with `Expression exceeds maximum nesting depth`, even though it is wide, not deeply nested. Machine-generated filters — long OR/AND chains — hit this all the time.

The parser now builds a same-operator AND/OR chain as one n-ary `and`/`or` call instead of a deep tree of binary nodes, so a wide chain no longer counts against the depth cap. Only a plain chain flattens; a chain grouped with parentheses is still bounded by the depth cap.

Because flattening lifts the depth-based limit on how wide a chain can get, a new `max_expression_width` session property (default 100000) caps the number of operands in one flattened chain.

Also removes the now-unused `LogicalBinaryExpression` node: AND/OR are `and`/`or` calls everywhere now.

Reviewed By: mbasmanova

Differential Revision: D113254966


