### PR TITLE
fix(optimizer): Keep filter columns when pruning v2 Values (#1644)

### DIFF
--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -967,15 +967,18 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   }
 
   NodeCP rewriteValues(const Values* node, PushdownContext& context) override {
-    // Keep every column the output needs (`required`), not just those demanded
-    // strictly above (`requiredAbove`): a pending conjunct wrapped as a Filter
-    // over this Values reads the Values' output, so its columns must survive.
+    // Keep every column the output needs (`required`) plus every column a
+    // pending conjunct reads: maybeWrapFilter re-materializes those conjuncts
+    // as a Filter over this Values, so their columns must survive.
+    PlanObjectSet keep = context.required;
+    keep.unionColumns(context.pending);
+
     ColumnVector survivingOutputs;
     QGVector<velox::column_index_t> survivingChannels;
     const auto& outputColumns = node->outputColumns();
     const auto& channels = node->channels();
     for (size_t i = 0; i < outputColumns.size(); ++i) {
-      if (context.required.contains(outputColumns[i])) {
+      if (keep.contains(outputColumns[i])) {
         survivingOutputs.push_back(outputColumns[i]);
         survivingChannels.push_back(channels[i]);
       }


### PR DESCRIPTION
Summary:

X-link: https://github.com/facebookincubator/axel/pull/165

A v2 query with an aggregate that needs no input columns and a WHERE over a VALUES failed. For example:

    SELECT COUNT(*) FROM (VALUES 1) t(x) WHERE x IN (null, 0)

failed with `Field not found: c0`. The same query over a real table was fine, because its filter pushes into the scan.

PushdownAndPrunePass moves a Filter's conjuncts into `pending` and prunes each node's output to the columns consumed above (`required`). `rewriteValues` kept only `required` columns, then re-materialized the pending conjuncts as a Filter over the Values — so for COUNT(*), where `required` is empty, it pruned the Values to zero columns while the wrapped Filter still read one. Keep the columns the pending conjuncts read too, as rewriteProject and rewriteAggregate already do.

Reviewed By: natashasehgal

Differential Revision: D113303960


