### PR TITLE
fix(optimizer): Fold constant aggregate FILTER mask in v2 (#1645)

### DIFF
--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1025,6 +1025,16 @@ const optimizer::Aggregate* Translator::toAggregateCall(
   ExprCP condition = aggregateExpr.filter() != nullptr
       ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
       : nullptr;
+  if (condition != nullptr && condition->is(PlanType::kLiteralExpr)) {
+    if (isConstantTrue(condition)) {
+      condition = nullptr;
+    } else {
+      // A false or null mask means empty-set aggregation, which is not yet
+      // supported.
+      VELOX_NYI(
+          "Aggregate FILTER that folds to constant false or null is not yet supported");
+    }
+  }
 
   auto [orderKeys, orderTypes] =
       dedupOrdering(aggregateExpr.ordering(), scope, applyTarget);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/166


A v2 aggregate whose FILTER folds to a constant failed. For example:

    SELECT sum(b) FILTER (WHERE true) FROM (SELECT count(*) FILTER (WHERE true) AS b)

failed with `Aggregate FILTER must be a column reference`, because the mask reached EmitPass as a constant literal.

Handle a constant mask in TranslatePass: a `FILTER (WHERE true)` masks nothing, so drop it. A false or null mask means the aggregate sees the empty set (its result is the aggregate's empty-input value); that is a separate effort, so for now it fails with a clear "not yet supported" message instead of the opaque EmitPass error.

Differential Revision: D113306357
