### PR TITLE
fix(optimizer): Support subqueries in outer join ON clauses

### DIFF
--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -30,6 +30,27 @@ SELECT a + b AS x, a + b AS y, count(a + b) AS z FROM t GROUP BY 1, 2
 -- Dedup: identical FILTER masks.
 SELECT sum(a) FILTER (WHERE b > 0), sum(a) FILTER (WHERE b < 0), sum(a) FILTER (WHERE b > 0) FROM t
 ----
+-- Constant-true FILTER masks nothing.
+SELECT sum(a) FILTER (WHERE true), count(a) FILTER (WHERE true) FROM t
+----
+-- FILTER with an expression that evaluates to true masks nothing.
+SELECT sum(a) FILTER (WHERE 1 = 1) FROM t
+----
+-- Constant-false FILTER: aggregate sees the empty set (count 0, sum null).
+SELECT count(a) FILTER (WHERE false), sum(a) FILTER (WHERE false) FROM t
+----
+-- FILTER with an expression that evaluates to false: empty-set aggregate.
+SELECT count(a) FILTER (WHERE 1 = 0), sum(a) FILTER (WHERE 1 = 0) FROM t
+----
+-- Constant-null FILTER behaves like false: empty-set aggregate.
+SELECT count(a) FILTER (WHERE cast(null AS boolean)) FROM t
+----
+-- Empty-set FILTER with GROUP BY: one row per group, count 0 each.
+SELECT b, count(a) FILTER (WHERE false) FROM t GROUP BY b
+----
+-- Mixed: an unmasked aggregate alongside an empty-set one.
+SELECT sum(a), count(a) FILTER (WHERE 1 = 0) FROM t
+----
 -- Dedup: column ORDER BY keys within aggregates.
 SELECT array_agg(a ORDER BY a, a), array_agg(b ORDER BY b, a, b, a) FROM t
 ----

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -982,3 +982,25 @@ WITH t(x) AS (VALUES (1), (2)),
 SELECT t.x, g.m
 FROM t
 INNER JOIN LATERAL (SELECT u.a AS m FROM u) g ON g.m IN (SELECT t.x)
+----
+-- Uncorrelated scalar subquery in an outer join's ON condition.
+-- error_v1: Unsupported subqueries in the ON clause of a LEFT or RIGHT join
+-- duckdb: VALUES (1, 10), (2, null)
+SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
+LEFT JOIN (VALUES 10, 20) r(a)
+  ON r.a = l.a + (SELECT max(x) FROM (VALUES 8, 9) s(x))
+----
+-- Scalar subquery in an outer join's ON condition correlated to the left input.
+-- error_v1: Failed to place a table
+-- duckdb: VALUES (1, 15), (2, 15)
+SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
+LEFT JOIN (VALUES 10, 15, 20) r(a)
+  ON r.a = (SELECT max(x) FROM (VALUES 10, 15) s(x) WHERE x > l.a)
+----
+-- Scalar subquery in an outer join's ON condition correlated to the right input
+-- is unsupported.
+-- error_v1: Unsupported subqueries in the ON clause of a LEFT or RIGHT join
+-- error_v2: Correlated subquery referencing the right side of an outer join's ON clause is not supported
+SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
+LEFT JOIN (VALUES 10, 15, 20) r(a)
+  ON l.a = (SELECT max(x) FROM (VALUES 10, 15) s(x) WHERE x > r.a)

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1949,6 +1949,24 @@ velox::core::JoinType toVeloxJoinType(lp::JoinType type) {
   VELOX_UNREACHABLE();
 }
 
+// True if a subquery lifted onto the left input correlates to a column of
+// 'right'. Such a correlation can't be satisfied by an Apply on the left input.
+bool correlatesToRight(NodeCP lifted, NodeCP leftBeforeLift, NodeCP right) {
+  const PlanObjectSet rightColumns =
+      PlanObjectSet::fromObjects(right->outputColumns());
+  for (NodeCP node = lifted; node != leftBeforeLift; node = node->inputs()[0]) {
+    if (node->nodeType() != NodeType::kApply) {
+      continue;
+    }
+    for (ColumnCP column : node->as<Apply>()->correlationColumns()) {
+      if (rightColumns.contains(column)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 Translated Translator::translateJoin(
     const lp::JoinNode& join,
     const LpNameSet& required) {
@@ -2038,8 +2056,19 @@ Translated Translator::translateJoin(
 
   JoinCondition::Split split;
   if (join.condition() != nullptr) {
+    // Lift a subquery in the condition onto the left input; the condition then
+    // references the lifted result column.
+    NodeCP leftBeforeLift = left.node;
     ExprCP condition =
-        translateExpr(*join.condition(), merged, /*applyTarget=*/nullptr);
+        translateExpr(*join.condition(), merged, /*applyTarget=*/&left.node);
+    // A subquery correlated to the right input, lifted onto the left,
+    // references a column the left can't provide.
+    if (correlatesToRight(left.node, leftBeforeLift, right.node)) {
+      VELOX_NYI(
+          "Correlated subquery referencing the right side of an outer join's "
+          "ON clause is not supported");
+    }
+
     split = JoinCondition::splitEquiKeys(
         ExprFactory::flattenAnd(condition),
         PlanObjectSet::fromObjects(left.node->outputColumns()),

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -446,6 +446,24 @@ class Translator {
   Translated translateAggregate(
       const lp::AggregateNode& aggregate,
       const LpNameSet& required);
+  // Lowers GROUPING SETS / ROLLUP / CUBE to a GroupId plus a plain aggregate
+  // keyed on an explicit group-id column. Returns the aggregation node.
+  NodeCP lowerGroupingSets(
+      const lp::AggregateNode& aggregate,
+      const ExprVector& groupingKeys,
+      AggregateCallVector aggregates,
+      const ColumnVector& outputColumns,
+      NodeCP currentInput,
+      Scope& newScope);
+  // The result of an aggregate over the empty set (constant false/null FILTER):
+  // the aggregate's empty-input value from the function registry.
+  ExprCP emptySetResult(const optimizer::Aggregate* call);
+  // Wraps 'node' in a Project appending 'columns' (each defined by the matching
+  // expr) to its outputs. Returns 'node' unchanged when 'columns' is empty.
+  NodeCP appendConstantColumns(
+      NodeCP node,
+      const ColumnVector& columns,
+      const ExprVector& exprs);
   Translated translateValues(
       const lp::ValuesNode& values,
       const LpNameSet& required);
@@ -1025,15 +1043,10 @@ const optimizer::Aggregate* Translator::toAggregateCall(
   ExprCP condition = aggregateExpr.filter() != nullptr
       ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
       : nullptr;
-  if (condition != nullptr && condition->is(PlanType::kLiteralExpr)) {
-    if (isConstantTrue(condition)) {
-      condition = nullptr;
-    } else {
-      // A false or null mask means empty-set aggregation, which is not yet
-      // supported.
-      VELOX_NYI(
-          "Aggregate FILTER that folds to constant false or null is not yet supported");
-    }
+  // Drop a constant-true FILTER (it masks nothing). A false or null mask stays
+  // as a literal condition, folded to the empty-set result during assembly.
+  if (condition != nullptr && isConstantTrue(condition)) {
+    condition = nullptr;
   }
 
   auto [orderKeys, orderTypes] =
@@ -1311,25 +1324,61 @@ Translated Translator::translateSample(
   VELOX_UNREACHABLE();
 }
 
+ExprCP Translator::emptySetResult(const optimizer::Aggregate* call) {
+  std::vector<const velox::Type*> argTypes;
+  argTypes.reserve(call->args().size());
+  for (ExprCP arg : call->args()) {
+    argTypes.push_back(arg->value().type);
+  }
+  velox::Variant emptyValue =
+      FunctionRegistry::instance()->aggregateResultForEmptyInput(
+          call->name(), argTypes);
+  return emptyValue.isNull()
+      ? static_cast<ExprCP>(builder_.makeNull(call->value().type))
+      : builder_.makeLiteral(std::move(emptyValue), call->value().type);
+}
+
+NodeCP Translator::appendConstantColumns(
+    NodeCP node,
+    const ColumnVector& columns,
+    const ExprVector& exprs) {
+  if (columns.empty()) {
+    return node;
+  }
+  ExprVector projectExprs;
+  ColumnVector projectColumns;
+  const auto& nodeOutputs = node->outputColumns();
+  projectExprs.reserve(nodeOutputs.size() + columns.size());
+  projectColumns.reserve(nodeOutputs.size() + columns.size());
+  for (ColumnCP column : nodeOutputs) {
+    projectExprs.push_back(column);
+    projectColumns.push_back(column);
+  }
+  appendAll(projectExprs, exprs);
+  appendAll(projectColumns, columns);
+  return builder_.make<Project>(
+      {node, std::move(projectExprs), std::move(projectColumns)});
+}
+
 Translated Translator::translateAggregate(
     const lp::AggregateNode& aggregate,
     const LpNameSet& required) {
   const auto& names = aggregate.outputNames();
   const auto& groupingKeyExpressions = aggregate.groupingKeys();
+  const auto numGroupingKeys = groupingKeyExpressions.size();
   const auto& groupingSets = aggregate.groupingSets();
   const auto& aggregateExpressions = aggregate.aggregates();
   const size_t groupIdSlots = groupingSets.empty() ? 0 : 1;
   VELOX_CHECK_EQ(
       names.size(),
-      groupingKeyExpressions.size() + aggregateExpressions.size() +
-          groupIdSlots);
+      numGroupingKeys + aggregateExpressions.size() + groupIdSlots);
 
   // Decide which aggregates to keep (output not in `required`). Grouping keys
   // and groupId always stay: dropping them would change group cardinality.
   std::vector<size_t> keptAggregateIndices;
   keptAggregateIndices.reserve(aggregateExpressions.size());
   for (size_t i = 0; i < aggregateExpressions.size(); ++i) {
-    if (required.contains(names[groupingKeyExpressions.size() + i])) {
+    if (required.contains(names[numGroupingKeys + i])) {
       keptAggregateIndices.push_back(i);
     }
   }
@@ -1344,22 +1393,21 @@ Translated Translator::translateAggregate(
   Translated input = translateNode(*aggregate.onlyInput(), childRequired);
 
   ExprVector groupingKeys;
-  groupingKeys.reserve(groupingKeyExpressions.size());
+  groupingKeys.reserve(numGroupingKeys);
   ColumnVector outputColumns;
   outputColumns.reserve(
-      groupingKeyExpressions.size() + keptAggregateIndices.size() +
-      groupIdSlots);
+      numGroupingKeys + keptAggregateIndices.size() + groupIdSlots);
   Scope newScope;
   // Grouping-sets case keeps positional alignment between groupingKeys and
   // the set indices; only the simple GROUP BY case can dedup safely here.
   const bool canDedupGroupingKeys = groupingSets.empty();
   folly::F14FastSet<ColumnCP> seenGroupingOutputs;
   if (canDedupGroupingKeys) {
-    seenGroupingOutputs.reserve(groupingKeyExpressions.size());
+    seenGroupingOutputs.reserve(numGroupingKeys);
   }
 
   NodeCP currentInput = input.node;
-  for (size_t i = 0; i < groupingKeyExpressions.size(); ++i) {
+  for (size_t i = 0; i < numGroupingKeys; ++i) {
     ExprCP keyExpr =
         translateExpr(*groupingKeyExpressions[i], input.scope, &currentInput);
     // Reuse the input column when the grouping key is a column reference:
@@ -1384,6 +1432,12 @@ Translated Translator::translateAggregate(
     outputColumns.push_back(column);
   }
 
+  // Aggregates whose FILTER folded to constant false/null see the empty set;
+  // their output is the aggregate's empty-input value, materialized by a
+  // Project above the aggregation.
+  ColumnVector foldedColumns;
+  ExprVector foldedExprs;
+
   AggregateCallVector aggregates;
   aggregates.reserve(keptAggregateIndices.size());
   folly::F14FastMap<const optimizer::Aggregate*, ColumnCP> aggregateToOutput;
@@ -1391,7 +1445,18 @@ Translated Translator::translateAggregate(
   for (size_t idx : keptAggregateIndices) {
     const auto* aggregateCall =
         toAggregateCall(*aggregateExpressions[idx], input.scope, &currentInput);
-    const auto& aggregateName = names[groupingKeyExpressions.size() + idx];
+    const auto& aggregateName = names[numGroupingKeys + idx];
+    // A remaining literal condition can only be false or null: fold to the
+    // empty-set result.
+    if (aggregateCall->condition() != nullptr &&
+        aggregateCall->condition()->is(PlanType::kLiteralExpr)) {
+      auto* column = Column::createForSymbol(
+          toName(aggregateName), aggregateCall->value());
+      foldedColumns.push_back(column);
+      foldedExprs.push_back(emptySetResult(aggregateCall));
+      newScope[aggregateName] = column;
+      continue;
+    }
     if (auto it = aggregateToOutput.find(aggregateCall);
         it != aggregateToOutput.end()) {
       newScope[aggregateName] = it->second;
@@ -1411,8 +1476,32 @@ Translated Translator::translateAggregate(
         .groupingKeys = std::move(groupingKeys),
         .aggregates = std::move(aggregates),
         .outputColumns = std::move(outputColumns)});
-    return {aggNode, std::move(newScope)};
+    return {
+        appendConstantColumns(aggNode, foldedColumns, foldedExprs),
+        std::move(newScope)};
   }
+
+  NodeCP aggNode = lowerGroupingSets(
+      aggregate,
+      groupingKeys,
+      std::move(aggregates),
+      outputColumns,
+      currentInput,
+      newScope);
+  return {
+      appendConstantColumns(aggNode, foldedColumns, foldedExprs),
+      std::move(newScope)};
+}
+
+NodeCP Translator::lowerGroupingSets(
+    const lp::AggregateNode& aggregate,
+    const ExprVector& groupingKeys,
+    AggregateCallVector aggregates,
+    const ColumnVector& outputColumns,
+    NodeCP currentInput,
+    Scope& newScope) {
+  const auto& names = aggregate.outputNames();
+  const auto& groupingSets = aggregate.groupingSets();
 
   // GROUPING SETS / ROLLUP / CUBE lower to GroupId + a plain aggregate keyed on
   // an explicit group-id column: a mechanical translation that lets physical
@@ -1541,7 +1630,7 @@ Translated Translator::translateAggregate(
       .step = AggregateStep::kSingle,
       .groupId = aggGroupId,
       .globalGroupingSets = std::move(globalGroupingSets)});
-  return {aggNode, std::move(newScope)};
+  return aggNode;
 }
 
 std::optional<std::vector<velox::Variant>> Translator::foldExprRowsToVariants(

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1025,6 +1025,16 @@ const optimizer::Aggregate* Translator::toAggregateCall(
   ExprCP condition = aggregateExpr.filter() != nullptr
       ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
       : nullptr;
+  if (condition != nullptr && condition->is(PlanType::kLiteralExpr)) {
+    if (isConstantTrue(condition)) {
+      condition = nullptr;
+    } else {
+      // A false or null mask means empty-set aggregation, which is not yet
+      // supported.
+      VELOX_NYI(
+          "Aggregate FILTER that folds to constant false or null is not yet supported");
+    }
+  }
 
   auto [orderKeys, orderTypes] =
       dedupOrdering(aggregateExpr.ordering(), scope, applyTarget);


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/167

In v2, a subquery in an outer join's ON clause failed with "Subquery encountered in an expression position with no relational input above which to lift Apply". For example:

    SELECT o1.o_orderkey, count(*)
    FROM orders o1 RIGHT JOIN (...) o2
      ON o1.o_orderkey BETWEEN (SELECT avg(o_orderkey) FROM orders) - 10 AND ...
    GROUP BY o1.o_orderkey

An INNER join lifts a condition subquery into a Filter above the join, but doing that over an outer join would change its semantics. Instead, lift the subquery onto the left input: an uncorrelated subquery becomes a cross join there, and the condition references its result. This handles LEFT/RIGHT/FULL joins for uncorrelated and left-correlated subqueries.

A subquery correlated to the right input can't be lifted onto the left, so it now fails with a clear "not supported" message rather than an opaque missing-column error. Presto and DuckDB reject this construct as well.

Differential Revision: D113322229
