### PR TITLE
fix(plan): Coerced set-op and USING columns get fresh ids

### DIFF
--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1381,7 +1381,9 @@ void PlanBuilder::addJoinUsingProjection(
   exprs.reserve(joinOutputType->size());
   auto newOutputMapping = std::make_shared<NameMappings>();
 
-  // Emit USING columns first (one copy each).
+  // Emit USING columns first (one copy each). A column cast to the common type
+  // produces a new value and gets a fresh id; a passthrough keeps its source
+  // id.
   for (size_t i = 0; i < usingColumns.size(); ++i) {
     const auto& column = usingColumns[i];
     auto leftColumnType = joinOutputType->findChild(column.leftId);
@@ -1399,16 +1401,16 @@ void PlanBuilder::addJoinUsingProjection(
               SpecialForm::kCoalesce,
               std::vector<ExprPtr>{leftRef, rightRef}));
       outputNames.push_back(newName(column.name));
-    } else if (joinType == JoinType::kRight) {
-      // Use the right side's column for RIGHT joins.
-      exprs.push_back(
-          makeCoercedRef(rightColumnType, column.rightId, commonTypes[i]));
-      outputNames.push_back(column.rightId);
     } else {
-      // Pass through the left side's column for INNER/LEFT joins.
-      exprs.push_back(
-          makeCoercedRef(leftColumnType, column.leftId, commonTypes[i]));
-      outputNames.push_back(column.leftId);
+      // INNER/LEFT use the left column; RIGHT uses the right column.
+      const auto& sourceId =
+          joinType == JoinType::kRight ? column.rightId : column.leftId;
+      const auto& sourceType =
+          joinType == JoinType::kRight ? rightColumnType : leftColumnType;
+      exprs.push_back(makeCoercedRef(sourceType, sourceId, commonTypes[i]));
+      const bool coerced =
+          commonTypes[i] != nullptr && !sourceType->equivalent(*commonTypes[i]);
+      outputNames.push_back(coerced ? newName(column.name) : sourceId);
     }
 
     newOutputMapping->add(column.name, outputNames.back());
@@ -1493,7 +1495,8 @@ PlanBuilder& PlanBuilder::setOperation(
   nodes.push_back(std::move(node_));
   nodes.push_back(other.node_);
 
-  setOperationImpl(op, std::move(nodes));
+  // *this is the left branch, so its mapping supplies the output names.
+  setOperationImpl(op, std::move(nodes), outputMapping_);
   return *this;
 }
 
@@ -1504,8 +1507,6 @@ PlanBuilder& PlanBuilder::setOperation(
   VELOX_USER_CHECK_GE(
       inputs.size(), 2, "Set operation requires at least 2 inputs");
 
-  outputMapping_ = inputs.front().outputMapping_;
-
   std::vector<LogicalPlanNodePtr> nodes;
   nodes.reserve(inputs.size());
   for (const auto& builder : inputs) {
@@ -1513,77 +1514,116 @@ PlanBuilder& PlanBuilder::setOperation(
     nodes.push_back(builder.node_);
   }
 
-  setOperationImpl(op, std::move(nodes));
+  setOperationImpl(op, std::move(nodes), inputs.front().outputMapping_);
   return *this;
+}
+
+namespace {
+
+// Maps the first branch's names to the set operation's actual output ids, which
+// may differ from 'firstBranchIds' where a column was coerced.
+std::shared_ptr<NameMappings> remapSetOutputMapping(
+    const std::vector<std::string>& firstBranchIds,
+    const std::vector<std::string>& outputIds,
+    const NameMappings& firstBranchMapping) {
+  auto mapping = std::make_shared<NameMappings>();
+  for (size_t i = 0; i < outputIds.size(); ++i) {
+    const auto& oldId = firstBranchIds[i];
+    const auto& newId = outputIds[i];
+    const std::vector<NameMappings::QualifiedName> names =
+        firstBranchMapping.reverseLookup(oldId);
+    for (const auto& name : names) {
+      mapping->add(name, newId);
+    }
+    if (const auto* userName = firstBranchMapping.userName(oldId)) {
+      mapping->addUserName(newId, *userName);
+    }
+    if (!names.empty() && firstBranchMapping.isHidden(oldId)) {
+      mapping->markHidden(newId);
+    }
+  }
+  return mapping;
+}
+
+} // namespace
+
+void PlanBuilder::coerceSetInputs(std::vector<LogicalPlanNodePtr>& nodes) {
+  // Find the common supertype for each column across all branches.
+  const auto& firstRowType = nodes[0]->outputType();
+  auto targetTypes = firstRowType->children();
+
+  for (size_t i = 1; i < nodes.size(); ++i) {
+    const auto& rowType = nodes[i]->outputType();
+
+    VELOX_USER_CHECK_EQ(
+        firstRowType->size(),
+        rowType->size(),
+        "Output schemas of all inputs to a Set operation must have same number of columns");
+
+    for (uint32_t j = 0; j < firstRowType->size(); ++j) {
+      const auto& currentType = targetTypes[j];
+      const auto& nextType = rowType->childAt(j);
+
+      if (currentType->equivalent(*nextType)) {
+        continue;
+      }
+
+      auto commonType = coercer_->leastCommonSuperType(currentType, nextType);
+      VELOX_USER_CHECK_NOT_NULL(
+          commonType,
+          "Output schemas of all inputs to a Set operation must match: {} vs. {} at {}.{}",
+          currentType->toSummaryString(),
+          nextType->toSummaryString(),
+          j,
+          firstRowType->nameOf(j));
+
+      targetTypes[j] = commonType;
+    }
+  }
+
+  for (auto& node : nodes) {
+    const auto& inputRowType = node->outputType();
+    auto outputNames = inputRowType->names();
+    std::vector<ExprPtr> exprs;
+    exprs.reserve(inputRowType->size());
+
+    bool needsCast = false;
+    for (uint32_t i = 0; i < inputRowType->size(); ++i) {
+      const auto& inputType = inputRowType->childAt(i);
+      const auto& targetType = targetTypes[i];
+      if (inputType->equivalent(*targetType)) {
+        exprs.push_back(makeInputRef(inputType, inputRowType->nameOf(i)));
+      } else {
+        needsCast = true;
+        exprs.push_back(
+            makeCoercedRef(inputType, inputRowType->nameOf(i), targetType));
+        outputNames[i] = newName(inputRowType->nameOf(i));
+      }
+    }
+
+    if (needsCast) {
+      node = std::make_shared<ProjectNode>(
+          nextId(), std::move(node), std::move(outputNames), std::move(exprs));
+    }
+  }
 }
 
 void PlanBuilder::setOperationImpl(
     SetOperation op,
-    std::vector<LogicalPlanNodePtr> nodes) {
+    std::vector<LogicalPlanNodePtr> nodes,
+    const std::shared_ptr<NameMappings>& firstBranchMapping) {
+  // The set operation's output ids are the first branch's; capture them before
+  // coercion may replace some.
+  const auto firstBranchIds = nodes[0]->outputType()->names();
+
   if (coercer_ != nullptr) {
-    // Apply type coercion: find common supertype for each column.
-    const auto firstRowType = nodes[0]->outputType();
-    auto targetTypes = firstRowType->children();
-
-    for (size_t i = 1; i < nodes.size(); ++i) {
-      const auto& rowType = nodes[i]->outputType();
-
-      VELOX_USER_CHECK_EQ(
-          firstRowType->size(),
-          rowType->size(),
-          "Output schemas of all inputs to a Set operation must have same number of columns");
-
-      for (uint32_t j = 0; j < firstRowType->size(); ++j) {
-        const auto& currentType = targetTypes[j];
-        const auto& nextType = rowType->childAt(j);
-
-        if (currentType->equivalent(*nextType)) {
-          continue;
-        }
-
-        auto commonType = coercer_->leastCommonSuperType(currentType, nextType);
-        VELOX_USER_CHECK_NOT_NULL(
-            commonType,
-            "Output schemas of all inputs to a Set operation must match: {} vs. {} at {}.{}",
-            currentType->toSummaryString(),
-            nextType->toSummaryString(),
-            j,
-            firstRowType->nameOf(j));
-
-        targetTypes[j] = commonType;
-      }
-    }
-
-    auto targetRowType =
-        velox::ROW(folly::copy(firstRowType->names()), std::move(targetTypes));
-
-    // Add cast projections where needed.
-    for (auto& node : nodes) {
-      const auto& inputRowType = node->outputType();
-      bool needsCast = false;
-      std::vector<ExprPtr> exprs;
-      exprs.reserve(inputRowType->size());
-
-      for (uint32_t i = 0; i < inputRowType->size(); ++i) {
-        const auto& inputType = inputRowType->childAt(i);
-        const auto& targetType = targetRowType->childAt(i);
-        if (!inputType->equivalent(*targetType)) {
-          needsCast = true;
-          exprs.push_back(
-              makeCoercedRef(inputType, inputRowType->nameOf(i), targetType));
-        } else {
-          exprs.push_back(makeInputRef(inputType, inputRowType->nameOf(i)));
-        }
-      }
-
-      if (needsCast) {
-        node = std::make_shared<ProjectNode>(
-            nextId(), std::move(node), inputRowType->names(), std::move(exprs));
-      }
-    }
+    coerceSetInputs(nodes);
   }
 
   node_ = std::make_shared<SetNode>(nextId(), std::move(nodes), op);
+
+  outputMapping_ = remapSetOutputMapping(
+      firstBranchIds, node_->outputType()->names(), *firstBranchMapping);
 }
 
 PlanBuilder& PlanBuilder::sort(const std::vector<std::string>& sortingKeys) {

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -871,8 +871,18 @@ class PlanBuilder {
       const std::vector<velox::TypePtr>& commonTypes);
 
   // Shared implementation for both setOperation overloads. Applies type
-  // coercions if enabled and creates the SetNode.
-  void setOperationImpl(SetOperation op, std::vector<LogicalPlanNodePtr> nodes);
+  // coercions if enabled, creates the SetNode, and builds the output mapping
+  // from 'firstBranchMapping' (the left branch's, whose names the set operation
+  // adopts).
+  void setOperationImpl(
+      SetOperation op,
+      std::vector<LogicalPlanNodePtr> nodes,
+      const std::shared_ptr<NameMappings>& firstBranchMapping);
+
+  // Adds a cast projection to each set-operation branch whose column types
+  // differ from the common target type. A coerced column gets a fresh id so no
+  // id denotes two types.
+  void coerceSetInputs(std::vector<LogicalPlanNodePtr>& nodes);
 
   std::string nextId() {
     return planNodeIdGenerator_->next();

--- a/axiom/logical_plan/tests/PlanBuilderTest.cpp
+++ b/axiom/logical_plan/tests/PlanBuilderTest.cpp
@@ -305,6 +305,7 @@ TEST_F(PlanBuilderTest, setOperationTypeCoercion) {
         startMatcher()
             .project()
             .setOperation(SetOperation::kUnionAll, startMatcher().build())
+            .project()
             .build();
     ASSERT_TRUE(matcher->match(plan)) << plan->toString();
   }
@@ -393,7 +394,7 @@ TEST_F(PlanBuilderTest, joinUsingTypeCoercion) {
         ROW({"c0", "c1", "c1_1"}, {BIGINT(), VARCHAR(), VARCHAR()}));
 
     auto matcher =
-        startMatcher().join(startMatcher().build()).project().build();
+        startMatcher().join(startMatcher().build()).project().project().build();
     ASSERT_TRUE(matcher->match(plan)) << plan->toString();
   }
 
@@ -497,7 +498,7 @@ TEST_F(PlanBuilderTest, joinUsingTypeCoercion) {
             {BIGINT(), VARCHAR(), REAL(), DOUBLE()}));
 
     auto matcher =
-        startMatcher().join(startMatcher().build()).project().build();
+        startMatcher().join(startMatcher().build()).project().project().build();
     ASSERT_TRUE(matcher->match(plan)) << plan->toString();
   }
 }

--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -30,6 +30,27 @@ SELECT a + b AS x, a + b AS y, count(a + b) AS z FROM t GROUP BY 1, 2
 -- Dedup: identical FILTER masks.
 SELECT sum(a) FILTER (WHERE b > 0), sum(a) FILTER (WHERE b < 0), sum(a) FILTER (WHERE b > 0) FROM t
 ----
+-- Constant-true FILTER masks nothing.
+SELECT sum(a) FILTER (WHERE true), count(a) FILTER (WHERE true) FROM t
+----
+-- FILTER with an expression that evaluates to true masks nothing.
+SELECT sum(a) FILTER (WHERE 1 = 1) FROM t
+----
+-- Constant-false FILTER: aggregate sees the empty set (count 0, sum null).
+SELECT count(a) FILTER (WHERE false), sum(a) FILTER (WHERE false) FROM t
+----
+-- FILTER with an expression that evaluates to false: empty-set aggregate.
+SELECT count(a) FILTER (WHERE 1 = 0), sum(a) FILTER (WHERE 1 = 0) FROM t
+----
+-- Constant-null FILTER behaves like false: empty-set aggregate.
+SELECT count(a) FILTER (WHERE cast(null AS boolean)) FROM t
+----
+-- Empty-set FILTER with GROUP BY: one row per group, count 0 each.
+SELECT b, count(a) FILTER (WHERE false) FROM t GROUP BY b
+----
+-- Mixed: an unmasked aggregate alongside an empty-set one.
+SELECT sum(a), count(a) FILTER (WHERE 1 = 0) FROM t
+----
 -- Dedup: column ORDER BY keys within aggregates.
 SELECT array_agg(a ORDER BY a, a), array_agg(b ORDER BY b, a, b, a) FROM t
 ----

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -982,3 +982,25 @@ WITH t(x) AS (VALUES (1), (2)),
 SELECT t.x, g.m
 FROM t
 INNER JOIN LATERAL (SELECT u.a AS m FROM u) g ON g.m IN (SELECT t.x)
+----
+-- Uncorrelated scalar subquery in an outer join's ON condition.
+-- error_v1: Unsupported subqueries in the ON clause of a LEFT or RIGHT join
+-- duckdb: VALUES (1, 10), (2, null)
+SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
+LEFT JOIN (VALUES 10, 20) r(a)
+  ON r.a = l.a + (SELECT max(x) FROM (VALUES 8, 9) s(x))
+----
+-- Scalar subquery in an outer join's ON condition correlated to the left input.
+-- error_v1: Failed to place a table
+-- duckdb: VALUES (1, 15), (2, 15)
+SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
+LEFT JOIN (VALUES 10, 15, 20) r(a)
+  ON r.a = (SELECT max(x) FROM (VALUES 10, 15) s(x) WHERE x > l.a)
+----
+-- Scalar subquery in an outer join's ON condition correlated to the right input
+-- is unsupported.
+-- error_v1: Unsupported subqueries in the ON clause of a LEFT or RIGHT join
+-- error_v2: Correlated subquery referencing the right side of an outer join's ON clause is not supported
+SELECT l.a, r.a FROM (VALUES 1, 2) l(a)
+LEFT JOIN (VALUES 10, 15, 20) r(a)
+  ON l.a = (SELECT max(x) FROM (VALUES 10, 15) s(x) WHERE x > r.a)

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1949,6 +1949,24 @@ velox::core::JoinType toVeloxJoinType(lp::JoinType type) {
   VELOX_UNREACHABLE();
 }
 
+// True if a subquery lifted onto the left input correlates to a column of
+// 'right'. Such a correlation can't be satisfied by an Apply on the left input.
+bool correlatesToRight(NodeCP lifted, NodeCP leftBeforeLift, NodeCP right) {
+  const PlanObjectSet rightColumns =
+      PlanObjectSet::fromObjects(right->outputColumns());
+  for (NodeCP node = lifted; node != leftBeforeLift; node = node->inputs()[0]) {
+    if (node->nodeType() != NodeType::kApply) {
+      continue;
+    }
+    for (ColumnCP column : node->as<Apply>()->correlationColumns()) {
+      if (rightColumns.contains(column)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 Translated Translator::translateJoin(
     const lp::JoinNode& join,
     const LpNameSet& required) {
@@ -2038,8 +2056,19 @@ Translated Translator::translateJoin(
 
   JoinCondition::Split split;
   if (join.condition() != nullptr) {
+    // Lift a subquery in the condition onto the left input; the condition then
+    // references the lifted result column.
+    NodeCP leftBeforeLift = left.node;
     ExprCP condition =
-        translateExpr(*join.condition(), merged, /*applyTarget=*/nullptr);
+        translateExpr(*join.condition(), merged, /*applyTarget=*/&left.node);
+    // A subquery correlated to the right input, lifted onto the left,
+    // references a column the left can't provide.
+    if (correlatesToRight(left.node, leftBeforeLift, right.node)) {
+      VELOX_NYI(
+          "Correlated subquery referencing the right side of an outer join's "
+          "ON clause is not supported");
+    }
+
     split = JoinCondition::splitEquiKeys(
         ExprFactory::flattenAnd(condition),
         PlanObjectSet::fromObjects(left.node->outputColumns()),

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -446,6 +446,24 @@ class Translator {
   Translated translateAggregate(
       const lp::AggregateNode& aggregate,
       const LpNameSet& required);
+  // Lowers GROUPING SETS / ROLLUP / CUBE to a GroupId plus a plain aggregate
+  // keyed on an explicit group-id column. Returns the aggregation node.
+  NodeCP lowerGroupingSets(
+      const lp::AggregateNode& aggregate,
+      const ExprVector& groupingKeys,
+      AggregateCallVector aggregates,
+      const ColumnVector& outputColumns,
+      NodeCP currentInput,
+      Scope& newScope);
+  // The result of an aggregate over the empty set (constant false/null FILTER):
+  // the aggregate's empty-input value from the function registry.
+  ExprCP emptySetResult(const optimizer::Aggregate* call);
+  // Wraps 'node' in a Project appending 'columns' (each defined by the matching
+  // expr) to its outputs. Returns 'node' unchanged when 'columns' is empty.
+  NodeCP appendConstantColumns(
+      NodeCP node,
+      const ColumnVector& columns,
+      const ExprVector& exprs);
   Translated translateValues(
       const lp::ValuesNode& values,
       const LpNameSet& required);
@@ -1025,15 +1043,10 @@ const optimizer::Aggregate* Translator::toAggregateCall(
   ExprCP condition = aggregateExpr.filter() != nullptr
       ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
       : nullptr;
-  if (condition != nullptr && condition->is(PlanType::kLiteralExpr)) {
-    if (isConstantTrue(condition)) {
-      condition = nullptr;
-    } else {
-      // A false or null mask means empty-set aggregation, which is not yet
-      // supported.
-      VELOX_NYI(
-          "Aggregate FILTER that folds to constant false or null is not yet supported");
-    }
+  // Drop a constant-true FILTER (it masks nothing). A false or null mask stays
+  // as a literal condition, folded to the empty-set result during assembly.
+  if (condition != nullptr && isConstantTrue(condition)) {
+    condition = nullptr;
   }
 
   auto [orderKeys, orderTypes] =
@@ -1311,25 +1324,61 @@ Translated Translator::translateSample(
   VELOX_UNREACHABLE();
 }
 
+ExprCP Translator::emptySetResult(const optimizer::Aggregate* call) {
+  std::vector<const velox::Type*> argTypes;
+  argTypes.reserve(call->args().size());
+  for (ExprCP arg : call->args()) {
+    argTypes.push_back(arg->value().type);
+  }
+  velox::Variant emptyValue =
+      FunctionRegistry::instance()->aggregateResultForEmptyInput(
+          call->name(), argTypes);
+  return emptyValue.isNull()
+      ? static_cast<ExprCP>(builder_.makeNull(call->value().type))
+      : builder_.makeLiteral(std::move(emptyValue), call->value().type);
+}
+
+NodeCP Translator::appendConstantColumns(
+    NodeCP node,
+    const ColumnVector& columns,
+    const ExprVector& exprs) {
+  if (columns.empty()) {
+    return node;
+  }
+  ExprVector projectExprs;
+  ColumnVector projectColumns;
+  const auto& nodeOutputs = node->outputColumns();
+  projectExprs.reserve(nodeOutputs.size() + columns.size());
+  projectColumns.reserve(nodeOutputs.size() + columns.size());
+  for (ColumnCP column : nodeOutputs) {
+    projectExprs.push_back(column);
+    projectColumns.push_back(column);
+  }
+  appendAll(projectExprs, exprs);
+  appendAll(projectColumns, columns);
+  return builder_.make<Project>(
+      {node, std::move(projectExprs), std::move(projectColumns)});
+}
+
 Translated Translator::translateAggregate(
     const lp::AggregateNode& aggregate,
     const LpNameSet& required) {
   const auto& names = aggregate.outputNames();
   const auto& groupingKeyExpressions = aggregate.groupingKeys();
+  const auto numGroupingKeys = groupingKeyExpressions.size();
   const auto& groupingSets = aggregate.groupingSets();
   const auto& aggregateExpressions = aggregate.aggregates();
   const size_t groupIdSlots = groupingSets.empty() ? 0 : 1;
   VELOX_CHECK_EQ(
       names.size(),
-      groupingKeyExpressions.size() + aggregateExpressions.size() +
-          groupIdSlots);
+      numGroupingKeys + aggregateExpressions.size() + groupIdSlots);
 
   // Decide which aggregates to keep (output not in `required`). Grouping keys
   // and groupId always stay: dropping them would change group cardinality.
   std::vector<size_t> keptAggregateIndices;
   keptAggregateIndices.reserve(aggregateExpressions.size());
   for (size_t i = 0; i < aggregateExpressions.size(); ++i) {
-    if (required.contains(names[groupingKeyExpressions.size() + i])) {
+    if (required.contains(names[numGroupingKeys + i])) {
       keptAggregateIndices.push_back(i);
     }
   }
@@ -1344,22 +1393,21 @@ Translated Translator::translateAggregate(
   Translated input = translateNode(*aggregate.onlyInput(), childRequired);
 
   ExprVector groupingKeys;
-  groupingKeys.reserve(groupingKeyExpressions.size());
+  groupingKeys.reserve(numGroupingKeys);
   ColumnVector outputColumns;
   outputColumns.reserve(
-      groupingKeyExpressions.size() + keptAggregateIndices.size() +
-      groupIdSlots);
+      numGroupingKeys + keptAggregateIndices.size() + groupIdSlots);
   Scope newScope;
   // Grouping-sets case keeps positional alignment between groupingKeys and
   // the set indices; only the simple GROUP BY case can dedup safely here.
   const bool canDedupGroupingKeys = groupingSets.empty();
   folly::F14FastSet<ColumnCP> seenGroupingOutputs;
   if (canDedupGroupingKeys) {
-    seenGroupingOutputs.reserve(groupingKeyExpressions.size());
+    seenGroupingOutputs.reserve(numGroupingKeys);
   }
 
   NodeCP currentInput = input.node;
-  for (size_t i = 0; i < groupingKeyExpressions.size(); ++i) {
+  for (size_t i = 0; i < numGroupingKeys; ++i) {
     ExprCP keyExpr =
         translateExpr(*groupingKeyExpressions[i], input.scope, &currentInput);
     // Reuse the input column when the grouping key is a column reference:
@@ -1384,6 +1432,12 @@ Translated Translator::translateAggregate(
     outputColumns.push_back(column);
   }
 
+  // Aggregates whose FILTER folded to constant false/null see the empty set;
+  // their output is the aggregate's empty-input value, materialized by a
+  // Project above the aggregation.
+  ColumnVector foldedColumns;
+  ExprVector foldedExprs;
+
   AggregateCallVector aggregates;
   aggregates.reserve(keptAggregateIndices.size());
   folly::F14FastMap<const optimizer::Aggregate*, ColumnCP> aggregateToOutput;
@@ -1391,7 +1445,18 @@ Translated Translator::translateAggregate(
   for (size_t idx : keptAggregateIndices) {
     const auto* aggregateCall =
         toAggregateCall(*aggregateExpressions[idx], input.scope, &currentInput);
-    const auto& aggregateName = names[groupingKeyExpressions.size() + idx];
+    const auto& aggregateName = names[numGroupingKeys + idx];
+    // A remaining literal condition can only be false or null: fold to the
+    // empty-set result.
+    if (aggregateCall->condition() != nullptr &&
+        aggregateCall->condition()->is(PlanType::kLiteralExpr)) {
+      auto* column = Column::createForSymbol(
+          toName(aggregateName), aggregateCall->value());
+      foldedColumns.push_back(column);
+      foldedExprs.push_back(emptySetResult(aggregateCall));
+      newScope[aggregateName] = column;
+      continue;
+    }
     if (auto it = aggregateToOutput.find(aggregateCall);
         it != aggregateToOutput.end()) {
       newScope[aggregateName] = it->second;
@@ -1411,8 +1476,32 @@ Translated Translator::translateAggregate(
         .groupingKeys = std::move(groupingKeys),
         .aggregates = std::move(aggregates),
         .outputColumns = std::move(outputColumns)});
-    return {aggNode, std::move(newScope)};
+    return {
+        appendConstantColumns(aggNode, foldedColumns, foldedExprs),
+        std::move(newScope)};
   }
+
+  NodeCP aggNode = lowerGroupingSets(
+      aggregate,
+      groupingKeys,
+      std::move(aggregates),
+      outputColumns,
+      currentInput,
+      newScope);
+  return {
+      appendConstantColumns(aggNode, foldedColumns, foldedExprs),
+      std::move(newScope)};
+}
+
+NodeCP Translator::lowerGroupingSets(
+    const lp::AggregateNode& aggregate,
+    const ExprVector& groupingKeys,
+    AggregateCallVector aggregates,
+    const ColumnVector& outputColumns,
+    NodeCP currentInput,
+    Scope& newScope) {
+  const auto& names = aggregate.outputNames();
+  const auto& groupingSets = aggregate.groupingSets();
 
   // GROUPING SETS / ROLLUP / CUBE lower to GroupId + a plain aggregate keyed on
   // an explicit group-id column: a mechanical translation that lets physical
@@ -1541,7 +1630,7 @@ Translated Translator::translateAggregate(
       .step = AggregateStep::kSingle,
       .groupId = aggGroupId,
       .globalGroupingSets = std::move(globalGroupingSets)});
-  return {aggNode, std::move(newScope)};
+  return aggNode;
 }
 
 std::optional<std::vector<velox::Variant>> Translator::foldExprRowsToVariants(

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1025,6 +1025,16 @@ const optimizer::Aggregate* Translator::toAggregateCall(
   ExprCP condition = aggregateExpr.filter() != nullptr
       ? translateExpr(*aggregateExpr.filter(), scope, applyTarget)
       : nullptr;
+  if (condition != nullptr && condition->is(PlanType::kLiteralExpr)) {
+    if (isConstantTrue(condition)) {
+      condition = nullptr;
+    } else {
+      // A false or null mask means empty-set aggregation, which is not yet
+      // supported.
+      VELOX_NYI(
+          "Aggregate FILTER that folds to constant false or null is not yet supported");
+    }
+  }
 
   auto [orderKeys, orderTypes] =
       dedupOrdering(aggregateExpr.ordering(), scope, applyTarget);


### PR DESCRIPTION
Summary:
Under the v2 optimizer, a UNION ALL requiring numeric type coercion failed. For example:

    SELECT 0, 0 UNION ALL SELECT 1.0, 0

failed with `Wrong type of input column`. v1 was unaffected.

The coercion Project reused the input column's id for its CAST output, so one id named two columns of different types (INTEGER below, DOUBLE above). The logical plan is meant to use unique symbols, and v2 relies on that. Coerced set-operation columns now get a fresh id, and the set operation rebuilds its output mapping from the SetNode's output ids, since coercion can change the first branch's ids.

JOIN ... USING on a cross-type key built the same malformed plan — a coerced key reusing its input id. It happened not to fail in v2 but violated the same invariant, so it gets the same fix, matching the FULL-join path that already allocated a fresh id.

Differential Revision: D113323141


