### PR TITLE
test: Add typed getOnlyResult<T>() to TestResult

### DIFF
--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -73,6 +73,12 @@ struct TestResult {
     VELOX_CHECK_EQ(result->childrenSize(), 1);
     return result->childAt(0)->variantAt(0);
   }
+
+  /// Typed accessor for the single scalar result. Throws if it is null.
+  template <typename T>
+  T getOnlyResult() const {
+    return getOnlyResult().template value<T>();
+  }
 };
 
 class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {


### PR DESCRIPTION
Summary: Adds a `getOnlyResult<T>()` overload that returns the single scalar result already converted to `T`, so a test writes `getOnlyResult<int64_t>()` instead of `getOnlyResult().value<int64_t>()`.

Differential Revision: D113346484


