### PR TITLE
feat(cli): Async cancellable SqlQueryRunner::co_run() (#1652)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -17,10 +17,15 @@
 #include "axiom/cli/SqlQueryRunner.h"
 #include <fmt/ranges.h>
 #include <folly/CancellationToken.h>
+#include <folly/OperationCancelled.h>
 #include <folly/container/F14Map.h>
+#include <folly/coro/AsyncGenerator.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Coroutine.h>
+#include <folly/coro/Invoke.h>
+#include <folly/coro/Task.h>
 #include <folly/coro/Timeout.h>
+#include <folly/coro/WithCancellation.h>
 #include <folly/system/HardwareConcurrency.h>
 #include <algorithm>
 #include <cmath>
@@ -329,14 +334,6 @@ connector::ConnectorProperties collectConnectorProperties(
   return result;
 }
 
-int64_t countRows(const std::vector<velox::RowVectorPtr>& results) {
-  int64_t numRows{0};
-  for (const auto& rowVector : results) {
-    numRows += rowVector->size();
-  }
-  return numRows;
-}
-
 // Fires the start callback if set, swallowing exceptions.
 void onStart(
     const sql::SqlQueryRunner::RunOptions& options,
@@ -464,20 +461,26 @@ std::string SqlQueryRunner::dropTable(
   }
 }
 
-std::string SqlQueryRunner::call(
+folly::coro::Task<std::string> SqlQueryRunner::co_call(
     std::string_view queryId,
     const presto::CallStatement& statement) {
   // Fold each bound argument expression to a value.
-  std::vector<velox::Variant> arguments;
-  arguments.reserve(statement.arguments().size());
+  std::vector<velox::Variant> boundArguments;
+  boundArguments.reserve(statement.arguments().size());
   for (const auto& argument : statement.arguments()) {
-    arguments.push_back(
+    boundArguments.push_back(
         optimizer::ConstantExprEvaluator::evaluateConstantExpr(*argument));
   }
 
-  folly::coro::blockingWait(statement.procedure()->execute(
-      makeConnectorSession(queryId, statement.connectorId()), arguments));
-  return "CALL";
+  // Procedure implementations may retain references to their call arguments in
+  // a lazy coroutine, so procedure, session, and boundArguments must all
+  // outlive the awaited task; hold them in named locals rather than awaiting a
+  // temporary.
+  auto procedure = statement.procedure();
+  auto session = makeConnectorSession(queryId, statement.connectorId());
+  auto task = procedure->execute(session, boundArguments);
+  co_await std::move(task);
+  co_return "CALL";
 }
 
 std::string SqlQueryRunner::addColumn(
@@ -562,8 +565,26 @@ std::string messageTemplateOf(const std::exception& e) {
 SqlQueryRunner::SqlResult SqlQueryRunner::run(
     std::string_view sql,
     const RunOptions& options) {
-  auto runOptions = options;
-  runOptions.queryId = options.queryId.value_or(queryIdGenerator_());
+  return folly::coro::blockingWait(
+      folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
+        SqlResult result;
+        auto generator = co_run(std::string(sql), options);
+        while (auto chunk = co_await generator.next()) {
+          if (chunk->message.has_value()) {
+            result.message = std::move(chunk->message);
+          }
+          if (chunk->batch != nullptr) {
+            result.results.push_back(std::move(chunk->batch));
+          }
+        }
+        co_return result;
+      }));
+}
+
+folly::coro::AsyncGenerator<SqlQueryRunner::SqlResultChunk>
+SqlQueryRunner::co_run(std::string sql, RunOptions options) {
+  auto runOptions = std::move(options);
+  runOptions.queryId = runOptions.queryId.value_or(queryIdGenerator_());
   const auto& catalog =
       runOptions.defaultConnectorId.value_or(defaultConnectorId_);
   const auto& schema = runOptions.defaultSchema.value_or(defaultSchema_);
@@ -589,6 +610,7 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
     onComplete(runOptions, completionInfo);
   };
 
+  int64_t numOutputRows{0};
   try {
     presto::SqlStatementPtr statement;
     uint64_t parseCpuNanos;
@@ -623,16 +645,29 @@ SqlQueryRunner::SqlResult SqlQueryRunner::run(
         QueryRuntimeStats::kPermissionCheckWallNanos,
         std::chrono::microseconds(completionInfo.timing.checkPermission));
 
-    auto result = runUnchecked(
+    auto generator = co_runUnchecked(
         *statement,
         runOptions,
         completionInfo.timing,
         completionInfo.planString,
         completionInfo.runtimeStats);
+    while (auto chunk = co_await generator.next()) {
+      if (chunk->batch != nullptr) {
+        numOutputRows += chunk->batch->size();
+      }
+      co_yield std::move(*chunk);
+    }
 
-    completionInfo.numOutputRows = countRows(result.results);
+    completionInfo.numOutputRows = numOutputRows;
     finalize();
-    return result;
+  } catch (const folly::OperationCancelled&) {
+    // Cancellation from the awaiting scope's token (any async path -- the drain
+    // or a CALL procedure) is a benign stop: record no errorInfo, mark it
+    // cancelled so telemetry can tell it apart from an empty success, finalize,
+    // and surface the dedicated type so the caller reports it distinctly.
+    completionInfo.cancelled = true;
+    finalize();
+    throw QueryCancelledError{};
   } catch (const velox::VeloxException& e) {
     completionInfo.errorInfo = ErrorInfo{
         .message = e.what(),
@@ -759,10 +794,25 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     const RunOptions& options) {
   QueryTiming timing;
   std::string planString;
-  return runUnchecked(sqlStatement, options, timing, planString);
+  return folly::coro::blockingWait(
+      folly::coro::co_invoke([&]() -> folly::coro::Task<SqlResult> {
+        SqlResult result;
+        auto generator =
+            co_runUnchecked(sqlStatement, options, timing, planString);
+        while (auto chunk = co_await generator.next()) {
+          if (chunk->message.has_value()) {
+            result.message = std::move(chunk->message);
+          }
+          if (chunk->batch != nullptr) {
+            result.results.push_back(std::move(chunk->batch));
+          }
+        }
+        co_return result;
+      }));
 }
 
-SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
+folly::coro::AsyncGenerator<SqlQueryRunner::SqlResultChunk>
+SqlQueryRunner::co_runUnchecked(
     const presto::SqlStatement& sqlStatement,
     const RunOptions& options,
     QueryTiming& timing,
@@ -796,12 +846,12 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
     } else if (statement->isCreateTable()) {
       const auto* create = statement->as<presto::CreateTableStatement>();
       createTable(queryId, *create, /*explain=*/true);
-      return {
-          .message = fmt::format(
-              "CREATE TABLE {}{}.{}",
-              create->ifNotExists() ? "IF NOT EXISTS " : "",
-              create->connectorId(),
-              create->tableName())};
+      co_yield SqlResultChunk{fmt::format(
+          "CREATE TABLE {}{}.{}",
+          create->ifNotExists() ? "IF NOT EXISTS " : "",
+          create->connectorId(),
+          create->tableName())};
+      co_return;
     } else if (statement->isDropTable()) {
       const auto* drop = statement->as<presto::DropTableStatement>();
       if (!drop->ifExists()) {
@@ -812,24 +862,24 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
             drop->connectorId(),
             drop->tableName());
       }
-      return {
-          .message = fmt::format(
-              "DROP TABLE {}{}.{}",
-              drop->ifExists() ? "IF EXISTS " : "",
-              drop->connectorId(),
-              drop->tableName())};
+      co_yield SqlResultChunk{fmt::format(
+          "DROP TABLE {}{}.{}",
+          drop->ifExists() ? "IF EXISTS " : "",
+          drop->connectorId(),
+          drop->tableName())};
+      co_return;
     } else if (statement->isAddColumn()) {
       const auto* add = statement->as<presto::AddColumnStatement>();
       addColumn(queryId, *add, /*explain=*/true);
-      return {
-          .message = fmt::format(
-              "ALTER TABLE {}{}.{} ADD COLUMN {}{} {}",
-              add->ifTableExists() ? "IF EXISTS " : "",
-              add->connectorId(),
-              add->tableName(),
-              add->ifNotExists() ? "IF NOT EXISTS " : "",
-              add->columnName(),
-              add->columnType()->toString())};
+      co_yield SqlResultChunk{fmt::format(
+          "ALTER TABLE {}{}.{} ADD COLUMN {}{} {}",
+          add->ifTableExists() ? "IF EXISTS " : "",
+          add->connectorId(),
+          add->tableName(),
+          add->ifNotExists() ? "IF NOT EXISTS " : "",
+          add->columnName(),
+          add->columnType()->toString())};
+      co_return;
     } else if (statement->isCall()) {
       // EXPLAIN must be side-effect-free: echo the resolved call without
       // invoking the procedure.
@@ -843,87 +893,56 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
         arguments.push_back(argument->toString());
       }
 
-      return {
-          .message = fmt::format(
-              "CALL {}.{}({})",
-              call->connectorId(),
-              call->procedureName(),
-              fmt::join(arguments, ", "))};
+      co_yield SqlResultChunk{fmt::format(
+          "CALL {}.{}({})",
+          call->connectorId(),
+          call->procedureName(),
+          fmt::join(arguments, ", "))};
+      co_return;
     } else {
       VELOX_NYI("Unsupported EXPLAIN query: {}", statement->kindName());
     }
 
     if (explain->type() == presto::ExplainStatement::Type::kIo) {
-      std::optional<CatalogSchemaTableName> outputTable =
-          explainIoOutputTable(*statement, *logicalPlan);
-
-      auto queryCtx = newQuery(options);
-      PhaseTimer phaseTimer(
-          timing.optimize,
-          runtimeStats.get(),
-          QueryRuntimeStats::kOptimizeWallNanos,
-          QueryRuntimeStats::kOptimizeCpuNanos);
-
-      if (useOptimizerV2_) {
-        auto resolver = orDefaultSchemaResolver(schemaResolver);
-        OptimizerContext optimizerContext(optimizerPool_.get());
-        velox::exec::SimpleExpressionEvaluator evaluator(
-            queryCtx.get(), optimizerPool_.get());
-        auto session = makeOptimizerSession(
-            queryCtx->queryId(),
-            collectConnectorProperties(*sessionConfig_),
-            /*explain=*/true);
-        return {
-            .message =
-                optimizer::v2::Optimizer(
-                    *logicalPlan, *resolver, *session, evaluator, queryCtx)
-                    .explainIo(std::move(outputTable))};
-      } else {
-        std::string text;
-        optimize(
-            logicalPlan,
-            queryCtx,
-            options,
-            [&](const auto& dt) {
-              text = optimizer::explainIo(&dt, outputTable);
-              return false; // Stop optimization.
-            },
-            nullptr,
-            schemaResolver,
-            /*explain=*/true,
-            runtimeStats);
-        return {.message = std::move(text)};
-      }
+      co_yield SqlResultChunk{runExplainIo(
+          *statement,
+          logicalPlan,
+          options,
+          timing,
+          schemaResolver,
+          runtimeStats)};
+      co_return;
     }
 
     if (explain->isAnalyze()) {
-      return {
-          .message = runExplainAnalyze(
-              logicalPlan, options, timing, runtimeStats, schemaResolver)};
-    } else {
-      return {
-          .message = runExplain(
-              logicalPlan,
-              explain->type(),
-              explain->format(),
-              options,
-              timing,
-              runtimeStats,
-              schemaResolver)};
+      co_yield SqlResultChunk{co_await co_runExplainAnalyze(
+          logicalPlan, options, timing, runtimeStats, schemaResolver)};
+      co_return;
     }
+    co_yield SqlResultChunk{runExplain(
+        logicalPlan,
+        explain->type(),
+        explain->format(),
+        options,
+        timing,
+        runtimeStats,
+        schemaResolver)};
+    co_return;
   }
 
   if (sqlStatement.isCreateTable()) {
     const auto* create = sqlStatement.as<presto::CreateTableStatement>();
     auto table = createTable(queryId, *create);
     if (!table) {
-      return {
-          .message = fmt::format(
-              "Table already exists: {}.{}",
-              create->connectorId(),
-              create->tableName())};
+      co_yield SqlResultChunk{fmt::format(
+          "Table already exists: {}.{}",
+          create->connectorId(),
+          create->tableName())};
+      co_return;
     }
-    return {.message = fmt::format("Created table: {}", create->tableName())};
+    co_yield SqlResultChunk{
+        fmt::format("Created table: {}", create->tableName())};
+    co_return;
   }
 
   if (sqlStatement.isCreateTableAsSelect()) {
@@ -934,69 +953,96 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
         connector::ConnectorMetadataRegistry::global());
     schema->setTargetTable(ctas->connectorId(), ctas->tableName(), table);
 
-    return runLogicalPlan(
-        ctas->plan(), options, timing, planString, schema, runtimeStats);
+    // Materialize the plan into a named local: co_runLogicalPlan takes it by
+    // const& and is a lazy generator, so a temporary would dangle by the time
+    // the first batch is pulled.
+    auto plan = ctas->plan();
+    auto generator = co_runLogicalPlan(
+        plan, options, timing, planString, schema, runtimeStats);
+    while (auto batch = co_await generator.next()) {
+      co_yield SqlResultChunk{std::move(*batch)};
+    }
+    co_return;
   }
 
   if (sqlStatement.isInsert()) {
     const auto* insert = sqlStatement.as<presto::InsertStatement>();
-    return runLogicalPlan(
-        insert->plan(), options, timing, planString, nullptr, runtimeStats);
+    auto plan = insert->plan();
+    auto generator = co_runLogicalPlan(
+        plan, options, timing, planString, nullptr, runtimeStats);
+    while (auto batch = co_await generator.next()) {
+      co_yield SqlResultChunk{std::move(*batch)};
+    }
+    co_return;
   }
 
   if (sqlStatement.isDropTable()) {
     const auto* drop = sqlStatement.as<presto::DropTableStatement>();
 
-    return {.message = dropTable(queryId, *drop)};
+    co_yield SqlResultChunk{dropTable(queryId, *drop)};
+    co_return;
   }
 
   if (sqlStatement.isAddColumn()) {
     const auto* add = sqlStatement.as<presto::AddColumnStatement>();
 
-    return {.message = addColumn(queryId, *add)};
+    co_yield SqlResultChunk{addColumn(queryId, *add)};
+    co_return;
   }
 
   if (sqlStatement.isCreateSchema()) {
     const auto* create = sqlStatement.as<presto::CreateSchemaStatement>();
-    return {.message = createSchema(queryId, *create)};
+    co_yield SqlResultChunk{createSchema(queryId, *create)};
+    co_return;
   }
 
   if (sqlStatement.isDropSchema()) {
     const auto* drop = sqlStatement.as<presto::DropSchemaStatement>();
-    return {.message = dropSchema(queryId, *drop)};
+    co_yield SqlResultChunk{dropSchema(queryId, *drop)};
+    co_return;
   }
 
   if (sqlStatement.isCall()) {
     const auto* call = sqlStatement.as<presto::CallStatement>();
-    return {.message = this->call(queryId, *call)};
+    co_yield SqlResultChunk{co_await co_call(queryId, *call)};
+    co_return;
   }
 
   if (sqlStatement.isShowStatsForQuery()) {
-    return {.results = runShowStatsForQuery(sqlStatement, options)};
+    auto results = runShowStatsForQuery(sqlStatement, options);
+    for (auto& batch : results) {
+      co_yield SqlResultChunk{std::move(batch)};
+    }
+    co_return;
   }
 
   if (sqlStatement.isShowSession()) {
-    return showSession(
+    auto generator = co_showSession(
         *sqlStatement.as<presto::ShowSessionStatement>(),
         options,
         timing,
         planString);
+    while (auto batch = co_await generator.next()) {
+      co_yield SqlResultChunk{std::move(*batch)};
+    }
+    co_return;
   }
 
   if (sqlStatement.isSetSession()) {
     const auto* setSession = sqlStatement.as<presto::SetSessionStatement>();
     const auto& name = setSession->name();
     sessionConfig_->set(name, setSession->value());
-    return {
-        .message =
-            fmt::format("Session '{}' set to '{}'", name, setSession->value())};
+    co_yield SqlResultChunk{
+        fmt::format("Session '{}' set to '{}'", name, setSession->value())};
+    co_return;
   }
 
   if (sqlStatement.isResetSession()) {
     const auto* resetSession = sqlStatement.as<presto::ResetSessionStatement>();
     const auto& name = resetSession->name();
     sessionConfig_->reset(name);
-    return {.message = fmt::format("Session '{}' reset", name)};
+    co_yield SqlResultChunk{fmt::format("Session '{}' reset", name)};
+    co_return;
   }
 
   if (sqlStatement.isUse()) {
@@ -1010,17 +1056,20 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runUnchecked(
         connectorId);
     defaultConnectorId_ = connectorId;
     defaultSchema_ = use->schema();
-    return {
-        .message =
-            fmt::format("Using {}.{}", defaultConnectorId_, use->schema())};
+    co_yield SqlResultChunk{
+        fmt::format("Using {}.{}", defaultConnectorId_, use->schema())};
+    co_return;
   }
 
   VELOX_CHECK(sqlStatement.isSelect());
 
   const auto logicalPlan = sqlStatement.as<presto::SelectStatement>()->plan();
 
-  return runLogicalPlan(
+  auto generator = co_runLogicalPlan(
       logicalPlan, options, timing, planString, nullptr, runtimeStats);
+  while (auto batch = co_await generator.next()) {
+    co_yield SqlResultChunk{std::move(*batch)};
+  }
 }
 
 std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
@@ -1072,6 +1121,52 @@ std::shared_ptr<velox::core::QueryCtx> SqlQueryRunner::newQuery(
       /*spillExecutor=*/nullptr,
       queryId,
       options.tokenProvider);
+}
+
+std::string SqlQueryRunner::runExplainIo(
+    const presto::SqlStatement& statement,
+    const logical_plan::LogicalPlanNodePtr& logicalPlan,
+    const RunOptions& options,
+    QueryTiming& timing,
+    std::shared_ptr<connector::SchemaResolver> schemaResolver,
+    std::shared_ptr<QueryRuntimeStats> runtimeStats) {
+  std::optional<CatalogSchemaTableName> outputTable =
+      explainIoOutputTable(statement, *logicalPlan);
+
+  auto queryCtx = newQuery(options);
+  PhaseTimer phaseTimer(
+      timing.optimize,
+      runtimeStats.get(),
+      QueryRuntimeStats::kOptimizeWallNanos,
+      QueryRuntimeStats::kOptimizeCpuNanos);
+
+  if (useOptimizerV2_) {
+    auto resolver = orDefaultSchemaResolver(schemaResolver);
+    OptimizerContext optimizerContext(optimizerPool_.get());
+    velox::exec::SimpleExpressionEvaluator evaluator(
+        queryCtx.get(), optimizerPool_.get());
+    auto session = makeOptimizerSession(
+        queryCtx->queryId(),
+        collectConnectorProperties(*sessionConfig_),
+        /*explain=*/true);
+    optimizer::v2::Optimizer optimizer(
+        *logicalPlan, *resolver, *session, evaluator, queryCtx);
+    return optimizer.explainIo(std::move(outputTable));
+  }
+  std::string text;
+  optimize(
+      logicalPlan,
+      queryCtx,
+      options,
+      [&](const auto& dt) {
+        text = optimizer::explainIo(&dt, outputTable);
+        return false; // Stop optimization.
+      },
+      nullptr,
+      std::move(schemaResolver),
+      /*explain=*/true,
+      std::move(runtimeStats));
+  return text;
 }
 
 std::string SqlQueryRunner::runExplain(
@@ -1239,6 +1334,105 @@ std::string printPlanWithStats(
       });
 }
 
+// Drives the runner under the awaiting scope's cancellation and an optional
+// deadline, yielding each result batch as it is produced and reaping via
+// co_close() once the stream ends. The deadline (folly::FutureTimeout) becomes
+// a VELOX_USER_FAIL; an external cancel re-raises folly::OperationCancelled for
+// co_run() to normalize; a genuine execution error propagates as itself.
+// A consumer that stops early must cancel via the token; silently destroying
+// this generator mid-stream skips the shielded reap and leaks the Velox task.
+folly::coro::AsyncGenerator<velox::RowVectorPtr> co_drainQuery(
+    runner::Runner& runner,
+    int64_t timeoutMicros) {
+  std::exception_ptr error;
+  bool cancelled{false};
+  bool timedOut{false};
+  // generator is kept in this coroutine's frame so its AsyncGenerator producer
+  // (execute()) outlives the per-batch timeout and the shielded co_close()
+  // reap. External cancellation flows in ambiently through the awaiting scope's
+  // token.
+  auto generator = runner.execute();
+  // Absolute deadline for the whole drain: folly::coro::timeout can't wrap a
+  // loop that co_yields, so each next() is bounded by the time remaining, which
+  // still caps total execution time (matching the pre-streaming behavior).
+  std::optional<std::chrono::steady_clock::time_point> deadline;
+  if (timeoutMicros > 0) {
+    deadline = std::chrono::steady_clock::now() +
+        std::chrono::microseconds(timeoutMicros);
+  }
+  try {
+    while (true) {
+      if (deadline) {
+        // folly::coro::timeout -> folly::futures::sleep takes microseconds, so
+        // round the remaining time up to microseconds once and reuse it for the
+        // guard and the pull. ceil (not duration_cast) avoids truncating a
+        // positive sub-microsecond remainder to zero, which would time out
+        // early.
+        const auto remaining = std::chrono::ceil<std::chrono::microseconds>(
+            *deadline - std::chrono::steady_clock::now());
+        if (remaining.count() <= 0) {
+          timedOut = true;
+          break;
+        }
+        auto batch = co_await folly::coro::timeout(generator.next(), remaining);
+        if (!batch) {
+          break;
+        }
+        co_yield std::move(*batch);
+      } else {
+        auto batch = co_await generator.next();
+        if (!batch) {
+          break;
+        }
+        co_yield std::move(*batch);
+      }
+    }
+  } catch (const folly::FutureTimeout&) {
+    timedOut = true;
+  } catch (const folly::OperationCancelled&) {
+    cancelled = true;
+  } catch (...) {
+    // Any failure (std::exception or not) still hits the shielded reap below,
+    // so capture it and follow the error path.
+    error = std::current_exception();
+  }
+  // Reap regardless, shielded from the caller's cancellation so a
+  // cancelled scope still winds the run down. A reap failure must not
+  // mask the original stop reason: if the drain already timed out,
+  // cancelled, or failed, keep that and let the reap error be secondary.
+  try {
+    co_await folly::coro::co_withCancellation(
+        folly::CancellationToken{}, runner.co_close());
+  } catch (const std::exception& e) {
+    if (!timedOut && !cancelled && !error) {
+      throw;
+    }
+    LOG(WARNING) << "co_close() failed during reap, surfacing the "
+                    "original stop reason instead: "
+                 << e.what();
+  } catch (...) {
+    // A non-std exception must not mask the original stop reason either.
+    if (!timedOut && !cancelled && !error) {
+      throw;
+    }
+    LOG(WARNING) << "co_close() failed during reap with a non-standard "
+                    "exception, surfacing the original stop reason instead";
+  }
+  if (timedOut) {
+    VELOX_USER_FAIL(
+        "Query exceeded maximum time limit of {:.2f}s",
+        timeoutMicros / 1'000'000.0);
+  }
+  if (cancelled) {
+    // Re-raise after the shielded reap; co_run() normalizes it to the dedicated
+    // QueryCancelledError so every async path reports cancellation uniformly.
+    throw folly::OperationCancelled{};
+  }
+  if (error) {
+    std::rethrow_exception(error);
+  }
+}
+
 } // namespace
 
 connector::ConnectorSessionPtr SqlQueryRunner::makeConnectorSession(
@@ -1269,7 +1463,7 @@ std::unique_ptr<runner::ProgressReporter> SqlQueryRunner::startProgressReporter(
       options.progressReportIntervalMs);
 }
 
-std::string SqlQueryRunner::runExplainAnalyze(
+folly::coro::Task<std::string> SqlQueryRunner::co_runExplainAnalyze(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const RunOptions& options,
     QueryTiming& timing,
@@ -1309,15 +1503,17 @@ std::string SqlQueryRunner::runExplainAnalyze(
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
     // Executed for its runtime stats (printed below); the result batches are
-    // not used, so discard them instead of accumulating the whole result set.
-    runner->drain([](velox::RowVectorPtr) {}, options.timeoutMicros);
+    // not used, so drain and discard them.
+    auto generator = co_drainQuery(*runner, options.timeoutMicros);
+    while (co_await generator.next()) {
+    }
   }
 
   std::stringstream out;
   out << printPlanWithStats(
       *runner, planAndStats.prediction, options.debugMode);
 
-  return out.str();
+  co_return out.str();
 }
 
 std::shared_ptr<optimizer::OptimizerSession>
@@ -1473,7 +1669,7 @@ std::shared_ptr<runner::LocalRunner> SqlQueryRunner::makeLocalRunner(
       runtimeStats);
 }
 
-SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
+folly::coro::AsyncGenerator<velox::RowVectorPtr> SqlQueryRunner::co_showSession(
     const presto::ShowSessionStatement& statement,
     const RunOptions& options,
     QueryTiming& timing,
@@ -1517,10 +1713,19 @@ SqlQueryRunner::SqlResult SqlQueryRunner::showSession(
             "like", lp::Col("Name"), lp::Lit(statement.likePattern().value())));
   }
 
-  return runLogicalPlan(builder.build(), options, timing, planString);
+  // Materialize the built plan into a local before the await: `build()` returns
+  // by value, and binding that temporary to co_runLogicalPlan's `const&`
+  // parameter would leave it dangling once GCC destroys co_await-operand
+  // temporaries at the suspension point.
+  auto plan = builder.build();
+  auto generator = co_runLogicalPlan(plan, options, timing, planString);
+  while (auto batch = co_await generator.next()) {
+    co_yield std::move(*batch);
+  }
 }
 
-SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
+folly::coro::AsyncGenerator<velox::RowVectorPtr>
+SqlQueryRunner::co_runLogicalPlan(
     const logical_plan::LogicalPlanNodePtr& logicalPlan,
     const RunOptions& options,
     QueryTiming& timing,
@@ -1528,8 +1733,6 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
     std::shared_ptr<facebook::axiom::connector::SchemaResolver> schemaResolver,
     std::shared_ptr<QueryRuntimeStats> runtimeStats) {
   auto queryCtx = newQuery(options);
-
-  SqlResult result;
 
   optimizer::PlanAndStats planAndStats;
   {
@@ -1565,14 +1768,11 @@ SqlQueryRunner::SqlResult SqlQueryRunner::runLogicalPlan(
         QueryRuntimeStats::kExecuteCpuNanos);
     auto progress =
         startProgressReporter(*runner, queryCtx->queryId(), options);
-    runner->drain(
-        [&](velox::RowVectorPtr batch) {
-          result.results.push_back(std::move(batch));
-        },
-        options.timeoutMicros);
+    auto generator = co_drainQuery(*runner, options.timeoutMicros);
+    while (auto batch = co_await generator.next()) {
+      co_yield std::move(*batch);
+    }
   }
-
-  return result;
 }
 
 namespace {

--- a/axiom/cli/SqlQueryRunner.h
+++ b/axiom/cli/SqlQueryRunner.h
@@ -15,6 +15,9 @@
  */
 #pragma once
 
+#include <folly/CancellationToken.h>
+#include <folly/coro/AsyncGenerator.h>
+#include <folly/coro/Task.h>
 #include <folly/executors/CPUThreadPoolExecutor.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <chrono>
@@ -86,6 +89,17 @@ struct ErrorInfo {
   std::string errorSource;
 };
 
+/// Thrown by co_run() when a query is stopped by an external cancellation. A
+/// dedicated type lets a client report a cancellation distinctly (e.g. the CLI
+/// prints "Query cancelled.") by catching the type rather than matching on a
+/// message or error code.
+class QueryCancelledError : public std::exception {
+ public:
+  const char* what() const noexcept override {
+    return "Query was cancelled";
+  }
+};
+
 /// Returns a format template (placeholders, not substituted values) for
 /// grouping similar failures. A VeloxException with no explicit template
 /// synthesizes "Check failed: <expr>" from its failing expression (mirroring
@@ -118,6 +132,11 @@ struct QueryCompletionInfo {
 
   /// Contains error details when the query fails; std::nullopt on success.
   std::optional<ErrorInfo> errorInfo;
+
+  /// True when the query was stopped by an external cancellation. A cancelled
+  /// query is not an error, so it carries no errorInfo -- this flag lets a
+  /// telemetry consumer tell cancellation apart from a successful empty result.
+  bool cancelled{false};
 
   /// Serialized Velox execution plan.
   std::string planString;
@@ -255,19 +274,107 @@ class SqlQueryRunner {
     QueryCompletionCallback onComplete;
   };
 
+  /// One increment of a streamed query result, yielded by co_run(). Exactly one
+  /// field is set: `message` (yielded once) for statements that return a status
+  /// line (DDL/session/EXPLAIN); `batch` (yielded once per result batch) for a
+  /// row-producing statement (SELECT/INSERT/CTAS). Modeled like SqlResult so
+  /// the same explicit-move rule applies.
+  struct SqlResultChunk {
+    SqlResultChunk() = default;
+
+    explicit SqlResultChunk(std::optional<std::string> message)
+        : message{std::move(message)} {}
+
+    explicit SqlResultChunk(facebook::velox::RowVectorPtr batch)
+        : batch{std::move(batch)} {}
+
+    SqlResultChunk(const SqlResultChunk&) = default;
+    SqlResultChunk& operator=(const SqlResultChunk&) = default;
+
+    // Explicit move, mirroring SqlResult: GCC 12 elides the aggregate move
+    // across a co_yield, leaving the chunk referring to storage in the
+    // destroyed coroutine frame.
+    SqlResultChunk(SqlResultChunk&& other) noexcept
+        : message{std::move(other.message)}, batch{std::move(other.batch)} {}
+
+    SqlResultChunk& operator=(SqlResultChunk&& other) noexcept {
+      message = std::move(other.message);
+      batch = std::move(other.batch);
+      return *this;
+    }
+
+    ~SqlResultChunk() = default;
+
+    std::optional<std::string> message;
+    facebook::velox::RowVectorPtr batch;
+  };
+
   /// Results of running a query. SELECT queries return a vector of results.
   /// Other queries return a message. SELECT query that returns no rows returns
   /// std::nullopt message and empty vector of results.
   struct SqlResult {
+    SqlResult() = default;
+
+    explicit SqlResult(
+        std::optional<std::string> message,
+        std::vector<facebook::velox::RowVectorPtr> results = {})
+        : message{std::move(message)}, results{std::move(results)} {}
+
+    explicit SqlResult(std::vector<facebook::velox::RowVectorPtr> results)
+        : results{std::move(results)} {}
+
+    SqlResult(const SqlResult&) = default;
+    SqlResult& operator=(const SqlResult&) = default;
+
+    // GCC 12 may otherwise elide the aggregate move across a co_await, leaving
+    // the result referring to storage in the destroyed child coroutine frame.
+    SqlResult(SqlResult&& other) noexcept
+        : message{std::move(other.message)},
+          results{std::move(other.results)} {}
+
+    SqlResult& operator=(SqlResult&& other) noexcept {
+      message = std::move(other.message);
+      results = std::move(other.results);
+      return *this;
+    }
+
+    ~SqlResult() = default;
+
     std::optional<std::string> message;
     std::vector<facebook::velox::RowVectorPtr> results;
   };
 
   /// Runs a single SQL statement with full lifecycle: generates a query ID,
-  /// fires onStart, parses, checks permissions, executes, fires onComplete,
-  /// and returns the result. On failure, fires onComplete with error telemetry
-  /// then re-throws.
-  virtual SqlResult run(std::string_view sql, const RunOptions& options);
+  /// fires onStart, parses, checks permissions, executes, fires onComplete.
+  /// Yields the result incrementally as SqlResultChunks -- one message chunk
+  /// for a statement that returns a status line, one chunk per result batch for
+  /// a row-producing statement -- so a caller can consume rows as they arrive.
+  /// On failure, fires onComplete with error telemetry then re-throws from the
+  /// consumer's next().
+  ///
+  /// The canonical async entry point. A caller in a coroutine context loops
+  /// this (while (auto chunk = co_await gen.next())); run() is a synchronous
+  /// convenience that drains it into a SqlResult. To cancel, compose a token
+  /// onto the consumption with folly::coro::co_withCancellation; a cancelled
+  /// query surfaces a QueryCancelledError. Cancellation applies to query
+  /// execution (the result drain) and takes effect once execution begins.
+  ///
+  /// Cleanup contract (mirrors runner::Runner::execute()): the consumer must
+  /// drive this to a terminal state -- either drain it fully (pull until next()
+  /// returns empty) or, to stop early, cancel via the token and keep pulling
+  /// until the cancellation surfaces. Reaching a terminal state runs the
+  /// shielded runner reap (co_close()). Dropping the generator while it is
+  /// suspended does NOT reap and aborts -- exactly as dropping an execute()
+  /// generator does -- because LocalRunner asserts on destroy-before-close
+  /// rather than running blocking teardown on an executor thread.
+  virtual folly::coro::AsyncGenerator<SqlResultChunk> co_run(
+      std::string sql,
+      RunOptions options);
+
+  /// Synchronous convenience over co_run(), for tests and simple synchronous
+  /// entry points. Blocks the calling thread, so it must NOT be called from a
+  /// Velox executor thread or within a coroutine (co_await co_run() there).
+  SqlResult run(std::string_view sql, const RunOptions& options);
 
   /// Runs a single parsed SQL statement without lifecycle hooks (no permission
   /// check, no callbacks). Use run(string_view, RunOptions) for the full
@@ -358,7 +465,9 @@ class SqlQueryRunner {
       std::string_view queryId,
       const presto::DropSchemaStatement& statement);
 
-  std::string call(
+  /// Constant-folds the CALL statement's bound arguments and awaits the
+  /// procedure's execute(); returns "CALL".
+  folly::coro::Task<std::string> co_call(
       std::string_view queryId,
       const presto::CallStatement& statement);
 
@@ -402,7 +511,18 @@ class SqlQueryRunner {
       std::shared_ptr<facebook::axiom::connector::SchemaResolver>
           schemaResolver = nullptr);
 
-  std::string runExplainAnalyze(
+  // Optimizes 'logicalPlan' and renders EXPLAIN (TYPE IO) output. Synchronous
+  // (no execution), so it is kept out of the co_run() coroutine chain.
+  std::string runExplainIo(
+      const presto::SqlStatement& statement,
+      const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
+      const RunOptions& options,
+      QueryTiming& timing,
+      std::shared_ptr<facebook::axiom::connector::SchemaResolver>
+          schemaResolver,
+      std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats);
+
+  folly::coro::Task<std::string> co_runExplainAnalyze(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       const RunOptions& options,
       QueryTiming& timing,
@@ -460,7 +580,7 @@ class SqlQueryRunner {
 
   // Runs a parsed SQL statement, writing optimize/execute timing into 'timing'
   // and the serialized Velox plan into 'planString'.
-  SqlResult runUnchecked(
+  folly::coro::AsyncGenerator<SqlResultChunk> co_runUnchecked(
       const presto::SqlStatement& statement,
       const RunOptions& options,
       QueryTiming& timing,
@@ -468,15 +588,16 @@ class SqlQueryRunner {
       std::shared_ptr<facebook::axiom::QueryRuntimeStats> runtimeStats =
           nullptr);
 
-  SqlResult showSession(
+  folly::coro::AsyncGenerator<facebook::velox::RowVectorPtr> co_showSession(
       const presto::ShowSessionStatement& statement,
       const RunOptions& options,
       QueryTiming& timing,
       std::string& planString);
 
-  // Optimizes and executes a logical plan. Writes timing and plan string
-  // directly into the passed-in references so values survive exceptions.
-  SqlResult runLogicalPlan(
+  // Optimizes and executes a logical plan, yielding each result batch as it is
+  // produced. Writes timing and plan string directly into the passed-in
+  // references so values survive exceptions.
+  folly::coro::AsyncGenerator<facebook::velox::RowVectorPtr> co_runLogicalPlan(
       const facebook::axiom::logical_plan::LogicalPlanNodePtr& logicalPlan,
       const RunOptions& options,
       QueryTiming& timing,

--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -15,15 +15,17 @@
  */
 
 #include "axiom/cli/SqlQueryRunner.h"
+#include <folly/CancellationToken.h>
+#include <folly/coro/BlockingWait.h>
 #include <folly/coro/Task.h>
+#include <folly/coro/WithCancellation.h>
 #include <folly/dynamic.h>
 #include <folly/executors/FunctionScheduler.h>
 #include <folly/init/Init.h>
-#include <folly/json.h>
+#include <folly/synchronization/Baton.h>
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 #include <stdexcept>
-#include <thread>
 #include "axiom/cli/QueryIdGenerator.h"
 #include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
 #include "axiom/connectors/tests/TestConnector.h"
@@ -115,6 +117,178 @@ TEST_F(SqlQueryRunnerTest, executionTimeout) {
           "FROM t a, t b, t c, t d, t e, t f",
           options),
       "exceeded maximum time limit");
+}
+
+TEST_F(SqlQueryRunnerTest, externalCancellation) {
+  // A token cancelled before co_run() is observed as the query starts executing
+  // -- the runner trips its cancellation callback before producing any output
+  // -- so the outcome is deterministic regardless of the table contents.
+  // co_run() surfaces the cancellation as a dedicated QueryCancelledError so a
+  // client can report a user cancel plainly.
+  testConnector_->addTable("t", ROW("c", BIGINT()));
+  SqlQueryRunner::RunOptions options;
+  folly::CancellationSource source;
+  source.requestCancellation();
+
+  // onComplete still fires for a cancellation, marking it distinctly: cancelled
+  // is true and errorInfo is unset, so telemetry can tell it apart from a
+  // successful empty result (which would also carry no errorInfo).
+  std::optional<QueryCompletionInfo> completion;
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    completion = info;
+  };
+
+  // Cancellation is composed structurally onto the co_run() consumption.
+  EXPECT_THROW(
+      folly::coro::blockingWait(
+          folly::coro::co_withCancellation(
+              source.getToken(),
+              folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+                auto generator =
+                    runner_->co_run("SELECT count(*) FROM t", options);
+                while (co_await generator.next()) {
+                }
+              }))),
+      QueryCancelledError);
+
+  ASSERT_TRUE(completion.has_value());
+  EXPECT_TRUE(completion->cancelled);
+  EXPECT_FALSE(completion->errorInfo.has_value());
+}
+
+TEST_F(SqlQueryRunnerTest, coRunYieldsChunks) {
+  // co_run() is a generator: a SELECT yields batch chunks (no message); a
+  // statement that returns a status line yields a single message chunk.
+  auto collect = [&](std::string_view sql) {
+    return folly::coro::blockingWait(
+        folly::coro::co_invoke(
+            [&]() -> folly::coro::Task<
+                      std::vector<SqlQueryRunner::SqlResultChunk>> {
+              std::vector<SqlQueryRunner::SqlResultChunk> chunks;
+              auto generator = runner_->co_run(std::string(sql), {});
+              while (auto chunk = co_await generator.next()) {
+                chunks.push_back(std::move(*chunk));
+              }
+              co_return chunks;
+            }));
+  };
+
+  auto selectChunks = collect("SELECT 1");
+  ASSERT_EQ(selectChunks.size(), 1);
+  EXPECT_FALSE(selectChunks[0].message.has_value());
+  ASSERT_NE(selectChunks[0].batch, nullptr);
+  test::assertEqualVectors(
+      selectChunks[0].batch, makeRowVector({makeFlatVector<int32_t>({1})}));
+
+  auto explainChunks = collect("EXPLAIN (TYPE LOGICAL) SELECT 1");
+  ASSERT_EQ(explainChunks.size(), 1);
+  EXPECT_TRUE(explainChunks[0].message.has_value());
+  EXPECT_EQ(explainChunks[0].batch, nullptr);
+}
+
+TEST_F(SqlQueryRunnerTest, coRunRowCountAcrossChunks) {
+  // A multi-row SELECT is delivered as one or more batch chunks; the row count
+  // summed across chunks and the reported numOutputRows both match the input.
+  constexpr int64_t kNumRows = 2500;
+  testConnector_->addTable("t", ROW("c", BIGINT()))
+      ->addData(makeRowVector({makeFlatVector<int64_t>(
+          kNumRows, [](auto row) { return static_cast<int64_t>(row); })}));
+
+  std::optional<QueryCompletionInfo> completion;
+  SqlQueryRunner::RunOptions options;
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    completion = info;
+  };
+
+  int64_t totalRows = 0;
+  folly::coro::blockingWait(
+      folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+        auto generator = runner_->co_run("SELECT c FROM t", options);
+        while (auto chunk = co_await generator.next()) {
+          EXPECT_FALSE(chunk->message.has_value());
+          if (chunk->batch != nullptr) {
+            totalRows += chunk->batch->size();
+          }
+        }
+      }));
+
+  EXPECT_EQ(totalRows, kNumRows);
+  ASSERT_TRUE(completion.has_value());
+  EXPECT_EQ(completion->numOutputRows, kNumRows);
+  EXPECT_FALSE(completion->cancelled);
+  EXPECT_FALSE(completion->errorInfo.has_value());
+}
+
+TEST_F(SqlQueryRunnerTest, coRunCancelMidStream) {
+  // Cancelling after a batch, while the query is still producing rows, surfaces
+  // QueryCancelledError and still reaps (onComplete marks cancelled, no
+  // errorInfo). numWorkers=1 keeps it single-fragment so cancel does not leave
+  // a LocalExchangeSource pinned.
+  testConnector_->addTable("t", ROW("s", VARCHAR()))
+      ->addData(makeRowVector({makeFlatVector<std::string>(
+          25, [](auto row) { return fmt::format("value_{:04d}", row); })}));
+
+  std::optional<QueryCompletionInfo> completion;
+  SqlQueryRunner::RunOptions options;
+  options.numWorkers = 1;
+  options.numDrivers = 1;
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    completion = info;
+  };
+
+  folly::CancellationSource source;
+  EXPECT_THROW(
+      folly::coro::blockingWait(
+          folly::coro::co_withCancellation(
+              source.getToken(),
+              folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+                // A six-way cross join streams ~244M rows, so the query is
+                // still producing long after the first batch.
+                auto generator = runner_->co_run(
+                    "SELECT a.s FROM t a, t b, t c, t d, t e, t f", options);
+                bool cancelled = false;
+                while (auto chunk = co_await generator.next()) {
+                  if (!cancelled) {
+                    source.requestCancellation();
+                    cancelled = true;
+                  }
+                }
+              }))),
+      QueryCancelledError);
+
+  ASSERT_TRUE(completion.has_value());
+  EXPECT_TRUE(completion->cancelled);
+  EXPECT_FALSE(completion->errorInfo.has_value());
+}
+
+TEST_F(SqlQueryRunnerTest, coRunErrorSurfacesFromGenerator) {
+  // A runtime error during execution surfaces from the consumer's next() and
+  // still fires onComplete with errorInfo (not cancelled).
+  testConnector_->addTable("t", ROW("c", BIGINT()))
+      ->addData(makeRowVector({makeFlatVector<int64_t>(
+          2500, [](auto row) { return static_cast<int64_t>(row); })}));
+
+  std::optional<QueryCompletionInfo> completion;
+  SqlQueryRunner::RunOptions options;
+  options.onComplete = [&](const QueryCompletionInfo& info) {
+    completion = info;
+  };
+
+  // Divides by zero at c == 2000 (not constant-foldable), erroring during
+  // execution after earlier rows have streamed.
+  EXPECT_THROW(
+      folly::coro::blockingWait(
+          folly::coro::co_invoke([&]() -> folly::coro::Task<void> {
+            auto generator =
+                runner_->co_run("SELECT 1 / (c - 2000) FROM t", options);
+            while (co_await generator.next()) {
+            }
+          })),
+      VeloxException);
+
+  ASSERT_TRUE(completion.has_value());
+  EXPECT_FALSE(completion->cancelled);
+  EXPECT_TRUE(completion->errorInfo.has_value());
 }
 
 TEST_F(SqlQueryRunnerTest, currentUser) {
@@ -569,8 +743,8 @@ TEST_F(SqlQueryRunnerTest, multiStatementTimingPerStatement) {
 TEST_F(SqlQueryRunnerTest, totalTimingIncludesAllPhases) {
   QueryCompletionInfo captured;
 
-  // Inject a permission check that sleeps 10ms to create a measurable gap
-  // between parse and execute timers.
+  // Inject a permission check that consumes ~10ms of wall time to create a
+  // measurable gap in the permission-check timer.
   auto runner = makeRunner(
       "test_timing",
       {},
@@ -580,8 +754,10 @@ TEST_F(SqlQueryRunnerTest, totalTimingIncludesAllPhases) {
           std::optional<std::string_view> /*schema*/,
           const auto& /*views*/,
           const auto& /*referencedTables*/) {
-        // NOLINTNEXTLINE(facebook-hte-BadCall-sleep_for)
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        // Block ~10ms without a fixed sleep: an unposted baton times out after
+        // the wall-clock interval, giving the timer a nonzero span to record.
+        folly::Baton<> gate;
+        gate.try_wait_for(std::chrono::milliseconds(10));
         return std::shared_ptr<facebook::velox::filesystems::TokenProvider>{};
       });
 


### PR DESCRIPTION
Summary:

Introduces `co_run()`, the async form of `SqlQueryRunner::run()`, so a caller in a coroutine context drives a query without blocking a thread. `co_run()` is a `folly::coro::AsyncGenerator` that yields the result incrementally -- one message chunk for a status-line statement, one chunk per result batch for a row-producing query -- so a caller can render rows as they arrive. `run()` becomes a synchronous convenience that drains the generator into a materialized `SqlResult` for tests and simple entry points.

The execution chain is coroutines end to end: `co_run` -> `co_runUnchecked` -> `co_runLogicalPlan` / `co_call` -> `co_drainQuery`, which drives the runner's `execute()` generator and reaps via `co_close()` instead of `blockingWait`-ing it. Public methods take owned params (`std::string`, `RunOptions` by value), and `SqlResult` / `SqlResultChunk` have explicit move constructors, so a lazy coroutine never holds a dangling reference across a suspension point.

Cancellation is structured: a caller composes a token onto the consumption (`folly::coro::co_withCancellation`) and `co_drainQuery` observes it ambiently, surfacing an external cancel as `QueryCancelledError` and the execution deadline as a user error. The consumer owns wind-down, mirroring `runner::Runner::execute()`: drive to completion or cancel and keep pulling so the shielded `co_close()` runs; dropping the generator mid-stream does not reap.

Reviewed By: xiaoxmeng

Differential Revision: D113414534


