### PR TITLE
fix(explain): Collapse cross-column OR onto one column (#1654)

### DIFF
--- a/axiom/cli/tests/ExplainIoTest.cpp
+++ b/axiom/cli/tests/ExplainIoTest.cpp
@@ -513,6 +513,135 @@ TEST_P(ExplainIoTest, columnConstraints) {
           "   WHERE ds = '2026-03-17' OR length(ds) > 3"),
       noConstraints);
 
+  // A disjunction constraining two columns in every branch collapses onto one
+  // of them (ds), unioning its per-branch values; region is not emitted and the
+  // footprint is not a ds x region product.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE (ds = '2026-03-17' AND region = 'us') "
+          "      OR (ds = '2026-03-18' AND region = 'eu')"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // A branch that does not constrain ds makes ds ineligible; region is
+  // constrained in both branches, so the disjunction collapses onto region.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE (ds = '2026-03-17' AND region = 'us') OR region = 'eu'"),
+      makeTable(makeConstraint(
+          "region",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {
+                "low": {"value": "eu", "bound": "EXACTLY"},
+                "high": {"value": "eu", "bound": "EXACTLY"}
+              },
+              {
+                "low": {"value": "us", "bound": "EXACTLY"},
+                "high": {"value": "us", "bound": "EXACTLY"}
+              }
+            ]
+          })")));
+
+  // A disjunction of ranges collapses to the union of the branches' ranges.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE (ds >= '2026-03-01' AND region = 'x') "
+          "      OR (ds >= '2026-03-10' AND region = 'y')"),
+      makeTable(makeConstraint(
+          "ds",
+          "VARCHAR",
+          R"({
+            "nullsAllowed": false,
+            "ranges": [
+              {"low": {"value": "2026-03-01", "bound": "EXACTLY"}}
+            ]
+          })")));
+
+  // No column is constrained in every branch, so nothing collapses.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE (ds = '2026-03-17' AND region = 'us') OR n = 1"),
+      noConstraints);
+
+  // Two independent cross-column disjunctions collapse onto two different
+  // columns: the first onto ds, the second onto n.
+  ASSERT_EQ(
+      getJson(
+          "EXPLAIN (TYPE IO) "
+          "SELECT * FROM t "
+          "   WHERE ((ds = '2026-03-17' AND region = 'us') "
+          "       OR (ds = '2026-03-18' AND region = 'eu')) "
+          "     AND ((n = 1 AND b = true) OR (n = 2 AND b = false))"),
+      normalizeJson(R"({
+        "inputTableColumnInfos": [{
+          "table": {
+            "catalog": "test",
+            "schemaTable": {"schema": "default", "table": "t"}
+          },
+          "columnConstraints": [
+            {
+              "columnName": "ds",
+              "typeSignature": "VARCHAR",
+              "domain": {
+                "nullsAllowed": false,
+                "ranges": [
+                  {
+                    "low": {"value": "2026-03-17", "bound": "EXACTLY"},
+                    "high": {"value": "2026-03-17", "bound": "EXACTLY"}
+                  },
+                  {
+                    "low": {"value": "2026-03-18", "bound": "EXACTLY"},
+                    "high": {"value": "2026-03-18", "bound": "EXACTLY"}
+                  }
+                ]
+              }
+            },
+            {
+              "columnName": "n",
+              "typeSignature": "BIGINT",
+              "domain": {
+                "nullsAllowed": false,
+                "ranges": [
+                  {
+                    "low": {"value": 1, "bound": "EXACTLY"},
+                    "high": {"value": 1, "bound": "EXACTLY"}
+                  },
+                  {
+                    "low": {"value": 2, "bound": "EXACTLY"},
+                    "high": {"value": 2, "bound": "EXACTLY"}
+                  }
+                ]
+              }
+            }
+          ]
+        }]
+      })"));
+
   // Constraints on both explain_io columns.
   ASSERT_EQ(
       getJson(
@@ -556,8 +685,7 @@ TEST_P(ExplainIoTest, columnConstraints) {
   ASSERT_EQ(
       getJson(
           "EXPLAIN (TYPE IO) "
-          "SELECT * FROM t "
-          "   WHERE ds > '2026-03-01'"),
+          "SELECT * FROM t WHERE ds > '2026-03-01'"),
       makeTable(makeConstraint(
           "ds",
           "VARCHAR",

--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -209,6 +209,16 @@ TableLayout::findColumn(std::string_view name) const {
   return nullptr;
 }
 
+std::vector<std::string> Table::ioColumnPriority() const {
+  std::vector<std::string> priority;
+  for (const auto* column : allColumns()) {
+    if (column->includeInExplainIo()) {
+      priority.push_back(column->name());
+    }
+  }
+  return priority;
+}
+
 // static
 ConnectorMetadata* FOLLY_NULLABLE
 ConnectorMetadata::tryMetadata(std::string_view connectorId) {

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -776,6 +776,13 @@ class Table : public std::enable_shared_from_this<Table> {
     return options_;
   }
 
+  /// Returns this table's `includeInExplainIo` columns ordered finest- to
+  /// coarsest-grained (e.g. an hourly ts before a daily ds). A best-effort
+  /// estimate, not a guarantee, so a wrong order costs tightness, never
+  /// correctness. Defaults to declaration order; connectors override to reflect
+  /// their column granularity.
+  virtual std::vector<std::string> ioColumnPriority() const;
+
   /// Returns column handles whose value uniquely identifies a row for creating
   /// an update or delete record. These may be for example some connector
   /// specific opaque row id or primary key columns.

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -153,6 +153,27 @@ HiveTable::HiveTable(
               partitionColumnNames),
           std::move(options)) {}
 
+std::vector<std::string> HiveTable::ioColumnPriority() const {
+  const auto* hiveLayout = dynamic_cast<const HiveTableLayout*>(layouts()[0]);
+  VELOX_CHECK_NOT_NULL(hiveLayout);
+
+  bool hasDs = false;
+  bool hasTs = false;
+  for (const auto* column : hiveLayout->hivePartitionColumns()) {
+    hasDs |= column->name() == "ds";
+    hasTs |= column->name() == "ts";
+  }
+
+  // ts (hourly) is finer-grained than ds (daily), so list it first.
+  if (hasTs && hasDs) {
+    return {"ts", "ds"};
+  }
+  if (hasDs) {
+    return {"ds"};
+  }
+  return {};
+}
+
 namespace {
 std::vector<velox::TypePtr> extractPartitionKeyTypes(
     const std::vector<const Column*>& partitionedByColumns) {

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -113,6 +113,10 @@ class HiveTable : public Table {
       bool includeHiddenColumns,
       folly::F14FastMap<std::string, velox::Variant> options,
       std::vector<std::string> partitionColumnNames = {});
+
+  /// Recognizes the ds/ts partition convention and returns those columns
+  /// finest-grained first (ts before ds).
+  std::vector<std::string> ioColumnPriority() const override;
 };
 
 /// Describes a Hive table layout. Adds a file format and a list of

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -359,6 +359,7 @@ TEST_F(LocalHiveConnectorMetadataTest, createTable) {
   EXPECT_EQ(expected->hivePartitionColumns().size(), 1);
   EXPECT_EQ(expected->hivePartitionColumns()[0], expected->columns()[3]);
   EXPECT_TRUE(expected->hivePartitionColumns()[0]->includeInExplainIo());
+  EXPECT_EQ(table->ioColumnPriority(), (std::vector<std::string>{"ds"}));
   // Non-partition columns should not be included in EXPLAIN IO.
   EXPECT_FALSE(expected->columns()[0]->includeInExplainIo());
   EXPECT_FALSE(expected->columns()[1]->includeInExplainIo());

--- a/axiom/optimizer/ExplainIo.cpp
+++ b/axiom/optimizer/ExplainIo.cpp
@@ -83,8 +83,10 @@ Domain columnDomain(ColumnCP column, const ExprVector& columnFilters) {
       continue;
     }
 
-    // columnFilters are single-column predicates. Check if this filter
-    // references the target column.
+    // Only single-column predicates map to a per-column domain.
+    if (filterExpr->columns().size() != 1) {
+      continue;
+    }
     if (!filterExpr->columns().contains(column)) {
       continue;
     }
@@ -99,6 +101,124 @@ Domain columnDomain(ColumnCP column, const ExprVector& columnFilters) {
   return domain;
 }
 
+// The tightest Domain implied by 'expr' for 'column': OR unites branches, AND
+// intersects, an atom on 'column' converts via exprToDomain, anything else is
+// all(). Hence all() unless every disjunct constrains 'column'.
+Domain projectToColumn(ExprCP expr, ColumnCP column) {
+  if (expr->is(PlanType::kCallExpr)) {
+    const auto* call = expr->as<Call>();
+    if (call->name() == SpecialFormCallNames::kAnd) {
+      Domain domain = Domain::all();
+      for (auto* arg : call->args()) {
+        domain = domain.intersect(projectToColumn(arg, column));
+      }
+      return domain;
+    }
+    if (call->name() == SpecialFormCallNames::kOr) {
+      Domain domain = Domain::none();
+      for (auto* arg : call->args()) {
+        domain = domain.unite(projectToColumn(arg, column));
+      }
+      return domain;
+    }
+  }
+
+  const auto& columns = expr->columns();
+  if (columns.size() == 1 && columns.contains(column)) {
+    if (auto domain = exprToDomain(expr)) {
+      return *domain;
+    }
+  }
+  return Domain::all();
+}
+
+// An includeInExplainIo column paired with its connector metadata.
+struct IoColumn {
+  ColumnCP column{nullptr};
+  const connector::Column* connectorColumn{nullptr};
+};
+
+// The base table's includeInExplainIo columns, ordered with the
+// ioColumnPriority columns first (finest-grained first) and the rest in
+// declaration order.
+std::vector<IoColumn> ioColumnsOf(
+    BaseTableCP baseTable,
+    const connector::Table& connectorTable) {
+  std::vector<IoColumn> declared;
+  for (auto* column : baseTable->columns) {
+    const auto* schemaColumn = column->schemaColumn();
+    if (!schemaColumn) {
+      continue;
+    }
+    const auto* connectorColumn =
+        connectorTable.findColumn(schemaColumn->name());
+    VELOX_CHECK_NOT_NULL(connectorColumn);
+    if (connectorColumn->includeInExplainIo()) {
+      declared.push_back({column, connectorColumn});
+    }
+  }
+
+  const auto priority = connectorTable.ioColumnPriority();
+  std::vector<IoColumn> ordered;
+  ordered.reserve(declared.size());
+  for (const auto& name : priority) {
+    for (const auto& ioColumn : declared) {
+      if (ioColumn.connectorColumn->name() == name) {
+        ordered.push_back(ioColumn);
+        break;
+      }
+    }
+  }
+  for (const auto& ioColumn : declared) {
+    const auto& name = ioColumn.connectorColumn->name();
+    if (std::find(priority.begin(), priority.end(), name) == priority.end()) {
+      ordered.push_back(ioColumn);
+    }
+  }
+  return ordered;
+}
+
+// Chooses the IO column to collapse a single cross-column 'filter' onto: the
+// first (finest-grained) 'ioColumns' entry it constrains in every disjunct.
+// Returns that column and the projected domain, or nullopt.
+std::optional<std::pair<ColumnCP, Domain>> chooseColumnForFilter(
+    const std::vector<IoColumn>& ioColumns,
+    ExprCP filter) {
+  for (const auto& ioColumn : ioColumns) {
+    auto domain = projectToColumn(filter, ioColumn.column);
+    if (!domain.isAll()) {
+      return std::make_pair(ioColumn.column, std::move(domain));
+    }
+  }
+  return std::nullopt;
+}
+
+// Per-column domains implied by the multi-column filters. Each filter collapses
+// onto its own best column, so different filters may target different columns;
+// a column targeted by several filters intersects their domains.
+folly::F14FastMap<ColumnCP, Domain> collapseCrossColumnFilters(
+    const std::vector<IoColumn>& ioColumns,
+    const ExprVector& filters) {
+  folly::F14FastMap<ColumnCP, Domain> byColumn;
+  for (auto* filter : filters) {
+    if (filter->columns().size() <= 1) {
+      continue;
+    }
+    auto chosen = chooseColumnForFilter(ioColumns, filter);
+    if (!chosen) {
+      continue;
+    }
+
+    auto it = byColumn.find(chosen->first);
+    if (it == byColumn.end()) {
+      byColumn.emplace(chosen->first, std::move(chosen->second));
+    } else {
+      it->second = it->second.intersect(chosen->second);
+    }
+  }
+  return byColumn;
+}
+
 // Per-column domains for a single table. Maps connector column name to Domain.
 using ColumnDomainMap = folly::F14FastMap<std::string, Domain>;
 
@@ -109,21 +229,12 @@ std::optional<ColumnDomainMap> computeColumnDomains(
     BaseTableCP baseTable,
     const ExprVector& filters) {
   const auto* connectorTable = baseTable->schemaTable->connectorTable;
+  const auto ioColumns = ioColumnsOf(baseTable, *connectorTable);
+  const auto collapseByColumn = collapseCrossColumnFilters(ioColumns, filters);
+
   ColumnDomainMap domains;
-
-  for (auto* column : baseTable->columns) {
-    auto* schemaColumn = column->schemaColumn();
-    if (!schemaColumn) {
-      continue;
-    }
-
-    auto* connectorColumn = connectorTable->findColumn(schemaColumn->name());
-    VELOX_CHECK_NOT_NULL(connectorColumn);
-    if (!connectorColumn->includeInExplainIo()) {
-      continue;
-    }
-
-    const auto typeKind = connectorColumn->type()->kind();
+  for (const auto& ioColumn : ioColumns) {
+    const auto typeKind = ioColumn.connectorColumn->type()->kind();
     VELOX_USER_CHECK(
         typeKind == velox::TypeKind::VARCHAR ||
             typeKind == velox::TypeKind::BOOLEAN ||
@@ -134,15 +245,19 @@ std::optional<ColumnDomainMap> computeColumnDomains(
         "Unsupported type for EXPLAIN IO column. "
         "Only VARCHAR, BOOLEAN, and integer types are supported: {}.{} {}",
         baseTable->schemaTable->name(),
-        connectorColumn->name(),
-        connectorColumn->type()->toString());
+        ioColumn.connectorColumn->name(),
+        ioColumn.connectorColumn->type()->toString());
 
-    auto domain = columnDomain(column, filters);
+    auto domain = columnDomain(ioColumn.column, filters);
+    if (auto it = collapseByColumn.find(ioColumn.column);
+        it != collapseByColumn.end()) {
+      domain = domain.intersect(it->second);
+    }
     if (domain.isNone()) {
       return std::nullopt;
     }
 
-    domains.emplace(connectorColumn->name(), std::move(domain));
+    domains.emplace(ioColumn.connectorColumn->name(), std::move(domain));
   }
 
   return domains;
@@ -289,7 +404,13 @@ std::string explainIo(
   std::vector<std::pair<BaseTableCP, ExprVector>> tableFilters;
   tableFilters.reserve(baseTables.size());
   for (auto* baseTable : baseTables) {
-    tableFilters.emplace_back(baseTable, baseTable->columnFilters);
+    // baseTable->filter holds the multi-column residual conjuncts (cross-column
+    // disjunctions); combine them with the single-column columnFilters.
+    ExprVector filters = baseTable->columnFilters;
+    for (auto* conjunct : baseTable->filter) {
+      filters.push_back(conjunct);
+    }
+    tableFilters.emplace_back(baseTable, std::move(filters));
   }
   return explainIo(tableFilters, std::move(outputTable));
 }


### PR DESCRIPTION
Summary:

EXPLAIN (TYPE IO) dropped a disjunction that spans more than one partition column, so the reported footprint widened to the whole table. For example:

    SELECT ... FROM t
    WHERE (ds = '2026-07-16' AND ts = '2026-07-17+06:00:99')
       OR (ds = '2026-07-17' AND ts = '2026-07-18+06:00:99')

reported every partition instead of the two the predicate selects.

Such a disjunction has no per-column domain. It can still be collapsed onto a single column that every branch constrains. The union of that column's per-branch values is implied by the predicate. The optimizer projects the OR onto the connector's preferred column (the finest-grained partition key) and reports `ts IN (...)`. The projection is purely logical and makes no metastore calls. The full predicate stays as the residual filter.

A disjunction whose branches constrain different columns, such as `ds = a OR ts = b`, still has no common column and reports no constraint, as before.

Differential Revision: D113443999
