### PR TITLE
test: Deflake drainTimeout and executionTimeout (#1655)

### DIFF
--- a/axiom/cli/tests/SqlQueryRunnerTest.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTest.cpp
@@ -96,14 +96,19 @@ TEST_F(SqlQueryRunnerTest, runSingleStatement) {
 TEST_F(SqlQueryRunnerTest, executionTimeout) {
   // A six-way cross join over 25 rows produces 25^6 = ~244M rows, far more than
   // can be processed within the 10ms deadline, and the max of the concatenated
-  // values cannot be short-circuited. So the run is still executing when the
-  // deadline elapses and the query fails with a timeout user error.
+  // values cannot be short-circuited, so the run is still executing when the
+  // deadline elapses and fails with a timeout user error. A single worker keeps
+  // the plan to one fragment with no exchange: cancelling a multi-stage query
+  // can leave a LocalExchangeSource pinning its memory pool until process exit
+  // (the arbitrator then aborts), and a single-fragment plan avoids that.
   testConnector_->addTable("t", ROW("s", VARCHAR()))
       ->addData(makeRowVector({makeFlatVector<std::string>(
           25, [](auto row) { return fmt::format("value_{:04d}", row); })}));
 
   SqlQueryRunner::RunOptions options;
   options.timeoutMicros = 10'000; // 10ms
+  options.numWorkers = 1;
+  options.numDrivers = 1;
   VELOX_ASSERT_THROW(
       runner_->run(
           "SELECT max(a.s || b.s || c.s || d.s || e.s || f.s) "

--- a/axiom/runner/tests/LocalRunnerTest.cpp
+++ b/axiom/runner/tests/LocalRunnerTest.cpp
@@ -17,6 +17,8 @@
 #include "axiom/runner/LocalRunner.h"
 #include <folly/CancellationToken.h>
 #include <folly/OperationCancelled.h>
+#include <folly/coro/AsyncGenerator.h>
+#include <folly/coro/Baton.h>
 #include <folly/coro/BlockingWait.h>
 #include <folly/coro/Task.h>
 #include <folly/coro/WithCancellation.h>
@@ -189,6 +191,41 @@ class ReapFailingLocalRunner : public LocalRunner {
   }
 };
 
+// A Runner whose execute() yields no batches and blocks until the awaiting
+// scope is cancelled, so drain()'s deadline is the only thing that ends the
+// run. Exercises the timeout deterministically, without depending on how long a
+// real query happens to take.
+class BlockingRunner : public Runner {
+ public:
+  folly::coro::AsyncGenerator<velox::RowVectorPtr> execute() override {
+    const auto token = co_await folly::coro::co_current_cancellation_token;
+    folly::coro::Baton baton;
+    folly::CancellationCallback unblock{token, [&baton] { baton.post(); }};
+    co_await baton;
+    // Surface the deadline the way LocalRunner surfaces a cancel, so drain()'s
+    // folly::coro::timeout classifies it as a timeout.
+    throw folly::OperationCancelled{};
+  }
+
+  folly::coro::Task<void> co_close() override {
+    co_return;
+  }
+
+  // Only execute() and co_close() are exercised by drain(); the rest of the
+  // Runner interface is required but unused here.
+  std::vector<velox::exec::TaskStats> stats() const override {
+    VELOX_UNREACHABLE();
+  }
+
+  const std::vector<optimizer::ExecutableFragment>& fragments() const override {
+    VELOX_UNREACHABLE();
+  }
+
+  State state() const override {
+    VELOX_UNREACHABLE();
+  }
+};
+
 TEST_F(LocalRunnerTest, count) {
   auto join = makeJoinPlan();
   auto localRunner = makeRunner(join);
@@ -327,15 +364,13 @@ TEST_F(LocalRunnerTest, error) {
 }
 
 // drain(..., timeoutMicros) fails with a user error when execution overruns the
-// cooperative deadline.
+// cooperative deadline. BlockingRunner blocks until the deadline cancels it, so
+// the timeout is the sole exit and the test is deterministic regardless of
+// platform or query speed.
 TEST_F(LocalRunnerTest, drainTimeout) {
-  auto join = makeJoinPlan();
-  auto localRunner = makeRunner(join);
-
-  // A 1us deadline is far shorter than the join over kNumRows can complete in,
-  // so the run is still executing when the deadline elapses.
+  BlockingRunner runner;
   VELOX_ASSERT_THROW(
-      localRunner->drain([](velox::RowVectorPtr) {}, /*timeoutMicros=*/1),
+      runner.drain([](velox::RowVectorPtr) {}, /*timeoutMicros=*/1'000),
       "exceeded maximum time limit");
 }
 


### PR DESCRIPTION
Summary:

Two axiom timeout tests raced real query execution against the deadline and
flaked on the OSS CI:

- `LocalRunnerTest.drainTimeout` asserts that `drain(..., timeoutMicros)` fails
  with a deadline user error, but it drove a real `makeJoinPlan()` query whose
  only output is a `finalAggregation count(1)` -- a single result batch emitted
  at the very end. On a fast runner (the macOS release CI in particular) that
  batch is ready before the drain first suspends, so the deadline's cancellation
  is never observed at a suspension point: `drain()` returns normally and the
  `EXPECT_THROW` fails. Linux only passed because it lost that race less often.
  Replace the real query with a `BlockingRunner` whose `execute()` yields no
  batches and blocks until the awaiting scope is cancelled, so the deadline is
  the sole exit -- deterministic regardless of platform or query speed.

- `SqlQueryRunnerTest.executionTimeout` ran a six-way cross join (25^6 ~ 244M
  rows) that distributes across workers, so cancelling it on the deadline could
  leave a `LocalExchangeSource` pinning its memory pool until process exit, where
  `SharedArbitrator::shutdown()` aborts with "alive participants" (seen on the
  macOS debug build). Run it on a single worker: the plan is one fragment with
  no exchange (verified via EXPLAIN), so no exchange source is created, while
  244M rows still overrun the 10ms deadline.

Reviewed By: xiaoxmeng

Differential Revision: D113470546


