### PR TITLE
fix(optimizer): Narrow partition listing in subquery fold (#1656)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -488,16 +488,29 @@ class TableLayout {
     return {};
   }
 
-  /// Returns an iterator into the list of discrete values of the specified
-  /// columns. The union of these values covers all rows of the table. Each
-  /// value corresponds to at least one row in the table. If 'columns' doesn't
-  /// contain all 'discretePredicateColumns', the results may contains duplicate
-  /// values.
+  /// Returns an iterator over the discrete values of the specified columns. The
+  /// union of these values covers all rows the listing produces; each value
+  /// corresponds to at least one row. If 'columns' doesn't contain all
+  /// 'discretePredicateColumns', the results may contain duplicate values.
   ///
+  /// The listing is restricted to the filters pushed into 'tableHandle', which
+  /// must constrain only 'discretePredicateColumns' -- the listing produces
+  /// only those columns, so a filter on any other column is meaningless here
+  /// and is rejected. Filters the connector could not push (e.g. those
+  /// createTableHandle reports as rejected) are the caller's responsibility to
+  /// apply over the returned values.
+  ///
+  /// @param session Connector session for the current query.
   /// @param columns A subset of 'discretePredicateColumns'. Must not be empty.
   /// Must not contain duplicates.
+  /// @param tableHandle Handle for the table, carrying the pushed filters that
+  /// restrict the listing (built via createTableHandle). Its filters must
+  /// reference only 'discretePredicateColumns'.
   virtual std::unique_ptr<DiscretePredicates> discretePredicates(
-      [[maybe_unused]] const std::vector<const Column*>& columns) const {
+      [[maybe_unused]] const ConnectorSessionPtr& session,
+      [[maybe_unused]] const std::vector<const Column*>& columns,
+      [[maybe_unused]] velox::connector::ConnectorTableHandlePtr tableHandle)
+      const {
     return nullptr;
   }
 

--- a/axiom/connectors/hive/HiveMetadataConfig.h
+++ b/axiom/connectors/hive/HiveMetadataConfig.h
@@ -36,6 +36,12 @@ class HiveMetadataConfig {
   /// not specified.
   static constexpr const char* kLocalFileFormat = "hive_local_file_format";
 
+  /// Session property: the maximum number of partitions a discrete-predicate
+  /// listing (see TableLayout::discretePredicates) may return before the
+  /// connector fails the query. Unset means unlimited.
+  static constexpr const char* kMaxPartitionsPerDiscretePredicates =
+      "hive_max_partitions_per_discrete_predicates";
+
   std::string localDataPath() const;
 
   std::string localFileFormat() const;

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -314,6 +314,27 @@ FilteredTableStats estimateStatsFromPartitionStats(
       totalRows, std::move(columnStats), std::move(rejectedFilterIndices)};
 }
 
+// Iterates over a precomputed set of partition-key tuples.
+class HiveDiscretePredicates : public DiscretePredicates {
+ public:
+  HiveDiscretePredicates(
+      std::vector<const Column*> columns,
+      std::vector<velox::Variant> values)
+      : DiscretePredicates(std::move(columns)), values_{std::move(values)} {}
+
+  std::vector<velox::Variant> next() override {
+    if (atEnd_) {
+      return {};
+    }
+    atEnd_ = true;
+    return std::move(values_);
+  }
+
+ private:
+  bool atEnd_{false};
+  std::vector<velox::Variant> values_;
+};
+
 } // namespace
 
 std::shared_ptr<SplitSource> LocalHiveSplitManager::getSplitSource(
@@ -732,8 +753,8 @@ LocalHiveTableLayout::co_metadataCounts(
     for (const auto* column : groupingKeyColumns) {
       auto it = partition.partitionKeys.find(column->name());
       if (it == partition.partitionKeys.end()) {
-        // The value is not available (e.g. a partition column beyond the first
-        // level, which is not parsed today).
+        // The grouping column is not a partition key, so the count cannot be
+        // answered from partition metadata.
         co_return std::nullopt;
       }
       groupKey += it->second;
@@ -770,6 +791,90 @@ LocalHiveTableLayout::co_metadataCounts(
   }
 
   co_return groups;
+}
+
+std::span<const Column* const> LocalHiveTableLayout::discretePredicateColumns()
+    const {
+  return hivePartitionColumns();
+}
+
+std::unique_ptr<DiscretePredicates> LocalHiveTableLayout::discretePredicates(
+    const ConnectorSessionPtr& session,
+    const std::vector<const Column*>& columns,
+    velox::connector::ConnectorTableHandlePtr tableHandle) const {
+  if (hivePartitionColumns().empty()) {
+    return nullptr;
+  }
+
+  std::optional<int64_t> maxPartitions;
+  if (session != nullptr) {
+    if (auto value = session->property(
+            HiveMetadataConfig::kMaxPartitionsPerDiscretePredicates)) {
+      maxPartitions = folly::to<int64_t>(*value);
+    }
+  }
+
+  auto hiveHandle =
+      std::dynamic_pointer_cast<const velox::connector::hive::HiveTableHandle>(
+          tableHandle);
+  VELOX_CHECK_NOT_NULL(hiveHandle);
+  const auto& subfieldFilters = hiveHandle->subfieldFilters();
+
+  folly::F14FastMap<std::string_view, const Column*> partitionColumnsByName;
+  for (const auto* column : hivePartitionColumns()) {
+    partitionColumnsByName.emplace(column->name(), column);
+  }
+
+  std::vector<velox::Variant> rows;
+  for (const auto& partition : partitionStats_) {
+    bool matched{true};
+    for (const auto& [subfield, filter] : subfieldFilters) {
+      auto columnIt = partitionColumnsByName.find(subfield.baseName());
+      // The listing enumerates only partition columns, so every pushed filter
+      // must be on one (guaranteed by the caller's discrete-column
+      // precondition).
+      VELOX_CHECK(
+          columnIt != partitionColumnsByName.end(),
+          "discretePredicates got a filter on non-partition column '{}'",
+          subfield.baseName());
+      auto valueIt = partition.partitionKeys.find(subfield.baseName());
+      VELOX_CHECK(
+          valueIt != partition.partitionKeys.end(),
+          "Partition is missing a value for partition column '{}'",
+          subfield.baseName());
+      if (!testPartitionValue(
+              *filter, valueIt->second, *columnIt->second->type())) {
+        matched = false;
+        break;
+      }
+    }
+    if (!matched) {
+      continue;
+    }
+
+    std::vector<velox::Variant> values;
+    values.reserve(columns.size());
+    for (const auto* column : columns) {
+      auto valueIt = partition.partitionKeys.find(column->name());
+      VELOX_CHECK(
+          valueIt != partition.partitionKeys.end(),
+          "Partition is missing a value for partition column '{}'",
+          column->name());
+      values.push_back(
+          HiveTableLayout::partitionValueToVariant(
+              valueIt->second, *column->type()));
+    }
+    rows.push_back(velox::Variant::row(std::move(values)));
+
+    if (maxPartitions.has_value()) {
+      VELOX_USER_CHECK_LE(
+          static_cast<int64_t>(rows.size()),
+          *maxPartitions,
+          "Discrete-predicate listing exceeds the max-partitions limit");
+    }
+  }
+
+  return std::make_unique<HiveDiscretePredicates>(columns, std::move(rows));
 }
 
 LocalHiveTableLayout* LocalTable::makeDefaultLayout(
@@ -1221,6 +1326,64 @@ std::shared_ptr<LocalTable> createTableFromSchema(
       name, schema, options, connector, std::move(hiveMetadataConfig));
 }
 
+// Parses a Hive partition directory named '<expectedColumn>=<value>'. Returns
+// the value.
+std::string parsePartitionValue(
+    const fs::path& dir,
+    std::string_view expectedColumn) {
+  const auto dirName = dir.filename().string();
+  const auto prefix = std::string(expectedColumn) + "=";
+  VELOX_USER_CHECK(
+      dirName.starts_with(prefix),
+      "Expected a '{}=<value>' partition directory, found: {}",
+      expectedColumn,
+      dirName);
+  return dirName.substr(prefix.size());
+}
+
+// Descends the partition directory tree one level per declared partition
+// column, reading the per-partition '.stats' file at each leaf into
+// 'allPartitionStats'. See loadTableWithWriteTimeStats for the layout contract.
+void collectPartitionStats(
+    const std::vector<std::string_view>& partitionColumnNames,
+    LocalTable& table,
+    std::vector<PartitionStats>& allPartitionStats,
+    const fs::path& dir,
+    size_t level,
+    folly::F14FastMap<std::string, std::string> partitionKeys) {
+  if (level == partitionColumnNames.size()) {
+    auto persisted = PersistedStats::read(dir.string());
+    VELOX_USER_CHECK(
+        persisted.has_value(),
+        "Partition directory is missing a .stats file: {}",
+        dir.string());
+    table.incrementNumRows(persisted->numRows);
+    allPartitionStats.push_back(
+        PartitionStats{
+            .partitionKeys = std::move(partitionKeys),
+            .numRows = persisted->numRows,
+            .columnStats = std::move(persisted->columns)});
+    return;
+  }
+
+  const auto& expectedColumn = partitionColumnNames[level];
+  for (const auto& entry : fs::directory_iterator(dir)) {
+    if (!entry.is_directory()) {
+      continue;
+    }
+    auto childKeys = partitionKeys;
+    childKeys.emplace(
+        expectedColumn, parsePartitionValue(entry.path(), expectedColumn));
+    collectPartitionStats(
+        partitionColumnNames,
+        table,
+        allPartitionStats,
+        entry.path(),
+        level + 1,
+        std::move(childKeys));
+  }
+}
+
 } // namespace
 
 // Loads persisted write-time stats from .stats files and stores them in the
@@ -1250,33 +1413,28 @@ void LocalHiveConnectorMetadata::loadTableWithWriteTimeStats(
     }
 
     allPartitionStats.push_back(std::move(partitionEntry));
-  } else {
-    // Partitioned table: read per-partition .stats files.
-    for (const auto& entry : std::filesystem::directory_iterator(tablePath)) {
-      if (!entry.is_directory()) {
-        continue;
-      }
-      auto persisted = PersistedStats::read(entry.path().string());
-      if (!persisted.has_value()) {
-        continue;
-      }
-
-      PartitionStats partitionEntry;
-      partitionEntry.numRows = persisted->numRows;
-      partitionEntry.columnStats = std::move(persisted->columns);
-
-      table->incrementNumRows(partitionEntry.numRows);
-
-      // Parse partition key=value pairs from directory name.
-      const auto dirName = entry.path().filename().string();
-      auto equalsPos = dirName.find('=');
-      if (equalsPos != std::string::npos) {
-        partitionEntry.partitionKeys[dirName.substr(0, equalsPos)] =
-            dirName.substr(equalsPos + 1);
-      }
-      allPartitionStats.push_back(std::move(partitionEntry));
+  } else if (!layout->hivePartitionColumns().empty()) {
+    // Partitioned table: the '.schema' declares the partition columns, and the
+    // data is laid out as one directory level per column, in declared order
+    // (e.g. ds=.../k=...). Descend exactly that many levels, validating each
+    // directory against the expected column, and read the per-partition
+    // '.stats' file at the leaf. Driving the depth from the schema guarantees
+    // every partition entry carries a value for every partition key.
+    std::vector<std::string_view> partitionColumnNames;
+    partitionColumnNames.reserve(layout->hivePartitionColumns().size());
+    for (const auto* column : layout->hivePartitionColumns()) {
+      partitionColumnNames.push_back(column->name());
     }
+    collectPartitionStats(
+        partitionColumnNames,
+        *table,
+        allPartitionStats,
+        tablePath,
+        /*level=*/0,
+        /*partitionKeys=*/{});
   }
+  // Otherwise the table is unpartitioned and has no persisted stats yet (e.g.
+  // right after a schema change); there is nothing to load.
 
   layout->setPartitionStats(std::move(allPartitionStats));
 }

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -184,6 +184,16 @@ class LocalHiveTableLayout : public HiveTableLayout {
       std::vector<std::string> columns,
       std::vector<velox::core::TypedExprPtr> filterConjuncts) const override;
 
+  std::span<const Column* const> discretePredicateColumns() const override;
+
+  /// Enumerates the partition-key tuples of 'columns' from persisted partition
+  /// metadata, keeping partitions that match the filters pushed into
+  /// 'tableHandle'.
+  std::unique_ptr<DiscretePredicates> discretePredicates(
+      const ConnectorSessionPtr& session,
+      const std::vector<const Column*>& columns,
+      velox::connector::ConnectorTableHandlePtr tableHandle) const override;
+
  private:
   // Configuration for local Hive metadata.
   std::shared_ptr<HiveMetadataConfig> hiveMetadataConfig_;

--- a/axiom/connectors/hive/README.md
+++ b/axiom/connectors/hive/README.md
@@ -27,6 +27,11 @@ a local directory.
   evaluates them during scan. This includes partition pruning (skipping
   entire files based on partition key values) and within-file filtering.
 - Table and column statistics for the optimizer (see [Statistics](#statistics)).
+- Discrete predicate (partition value) listing: the optimizer lists partition
+  key values to constant-fold aggregations over partition columns (e.g.
+  `SELECT max(ds) FROM t`) without scanning data. Filters on partition columns
+  narrow the listing. The `hive_max_partitions_per_discrete_predicates` session
+  property caps how many partitions a single listing may return.
 
 **Writes:**
 - `CREATE TABLE` with partitioning, bucketing, sort order, file format, and
@@ -40,10 +45,6 @@ a local directory.
 **Not supported:**
 - Transactions. Writes go directly into the table directory.
 - `ALTER TABLE`, `RENAME TABLE`.
-- Discrete predicate values. The optimizer uses these to constant-fold
-  aggregations over partition key columns (e.g. `SELECT max(ds) FROM t`
-  without scanning data). TODO: Implement `discretePredicateColumns` and
-  `discretePredicates` APIs to report partition key values.
 
 ## Usage
 
@@ -105,7 +106,9 @@ axiom_sql --data_path /tmp/tpch/sf0.1
 Each subdirectory under the data path is interpreted as a table. For
 unpartitioned tables, data files are placed directly in the table directory.
 For partitioned tables, data files are organized into subdirectories named
-`<partition_column>=<value>` (e.g. `ds=2024-01-01/`):
+`<partition_column>=<value>` (e.g. `ds=2024-01-01/`), nesting one directory
+level per partition column in the order declared in `.schema` (e.g.
+`ds=2024-01-01/hour=00/` for a table partitioned by `(ds, hour)`):
 
 ```
 /data/
@@ -133,6 +136,12 @@ partition and bucketing information, and file format. A `.stats` file with
 row counts and per-column statistics is also required. Both files are produced
 automatically by the write pipeline (`CREATE TABLE`, `INSERT INTO`) or by
 `LocalTableBuilder::build()` for externally created data.
+
+The `.schema` is the source of truth for partitioning. At load time the
+connector descends exactly one directory level per declared partition column,
+in declared order, and reads the leaf `.stats` file for each partition. A
+directory whose name does not match the expected partition column, or a leaf
+partition missing its `.stats` file, fails the load.
 
 ## .schema File Format
 

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -719,13 +719,17 @@ std::span<const Column* const> TestTableLayout::discretePredicateColumns()
 }
 
 std::unique_ptr<DiscretePredicates> TestTableLayout::discretePredicates(
-    [[maybe_unused]] const std::vector<const Column*>& columns) const {
+    [[maybe_unused]] const ConnectorSessionPtr& session,
+    [[maybe_unused]] const std::vector<const Column*>& columns,
+    [[maybe_unused]] velox::connector::ConnectorTableHandlePtr tableHandle)
+    const {
   if (discreteValueColumns_.empty()) {
     return nullptr;
   }
 
-  // TODO Add logic to prune 'discreteValues_' based on 'columns'.
-
+  // TODO: Prune 'discreteValues_' by 'columns' and by the filters in
+  // 'tableHandle'. For now, list all recorded values; the caller re-applies its
+  // filters over them.
   return std::make_unique<TestDiscretePredicates>(
       discreteValueColumns_, discreteValues_);
 }

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -137,7 +137,9 @@ class TestTableLayout : public TableLayout {
   std::span<const Column* const> discretePredicateColumns() const override;
 
   std::unique_ptr<DiscretePredicates> discretePredicates(
-      const std::vector<const Column*>& columns) const override;
+      const ConnectorSessionPtr& session,
+      const std::vector<const Column*>& columns,
+      velox::connector::ConnectorTableHandlePtr tableHandle) const override;
 
   velox::connector::ColumnHandlePtr createColumnHandle(
       const ConnectorSessionPtr& session,

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -409,33 +409,47 @@ std::vector<velox::RowVectorPtr> runConstantPlan(
   return results;
 }
 
-std::unique_ptr<connector::DiscretePredicates> allDiscreteColumns(
-    const ColumnVector& columns,
-    const connector::TableLayout& layout) {
-  const auto& discreteColumns = layout.discretePredicateColumns();
-  if (discreteColumns.empty()) {
-    return {nullptr, {}};
-  }
-
-  folly::F14FastMap<std::string_view, const connector::Column*>
-      discreteColumnMap;
-  for (const auto* column : discreteColumns) {
-    discreteColumnMap.emplace(column->name(), column);
-  }
-
+// A table layout whose discrete-predicate columns cover 'columns', paired with
+// the matching connector columns. 'layout' is nullptr if no layout qualifies.
+struct DiscreteLayout {
+  const connector::TableLayout* layout{nullptr};
   std::vector<const connector::Column*> connectorColumns;
-  connectorColumns.reserve(columns.size());
+};
 
-  for (auto* column : columns) {
-    auto it = discreteColumnMap.find(column->schemaColumn()->name());
-    if (it == discreteColumnMap.end()) {
-      return {nullptr, {}};
+// Finds the first layout of 'baseTable' whose discrete-predicate columns cover
+// every base-table column.
+DiscreteLayout findDiscreteLayout(const BaseTable& baseTable) {
+  const auto& columns = baseTable.columns;
+  for (auto* layout : baseTable.schemaTable->connectorTable->layouts()) {
+    const auto& discreteColumns = layout->discretePredicateColumns();
+    if (discreteColumns.empty()) {
+      continue;
     }
 
-    connectorColumns.emplace_back(it->second);
+    folly::F14FastMap<std::string_view, const connector::Column*>
+        discreteColumnMap;
+    for (const auto* column : discreteColumns) {
+      discreteColumnMap.emplace(column->name(), column);
+    }
+
+    std::vector<const connector::Column*> connectorColumns;
+    connectorColumns.reserve(columns.size());
+    bool covered{true};
+    for (auto* column : columns) {
+      auto it = discreteColumnMap.find(column->schemaColumn()->name());
+      if (it == discreteColumnMap.end()) {
+        covered = false;
+        break;
+      }
+      connectorColumns.emplace_back(it->second);
+    }
+
+    if (covered) {
+      return {layout, std::move(connectorColumns)};
+    }
   }
 
-  return layout.discretePredicates(connectorColumns);
+  return {};
 }
 
 velox::RowTypePtr toRowType(const ColumnVector& columns) {
@@ -496,19 +510,12 @@ lp::ValuesNodePtr tryFoldConstantDt(
     }
   }
 
-  // Check if aggregation uses only 'discretePredicate' columns.
+  // The fold works only when every base-table column is a discrete-predicate
+  // (e.g. partition) column. The listing enumerates those columns, so the
+  // table's filters reference only them and can be pushed into the listing.
   auto* baseTable = dt->tables[0]->as<BaseTable>();
-
-  std::unique_ptr<connector::DiscretePredicates> discretePredicates;
-
-  for (auto* layout : baseTable->schemaTable->connectorTable->layouts()) {
-    if (auto predicates = allDiscreteColumns(baseTable->columns, *layout)) {
-      discretePredicates = std::move(predicates);
-      break;
-    }
-  }
-
-  if (discretePredicates == nullptr) {
+  auto discreteLayout = findDiscreteLayout(*baseTable);
+  if (discreteLayout.layout == nullptr) {
     return nullptr;
   }
 
@@ -528,6 +535,22 @@ lp::ValuesNodePtr tryFoldConstantDt(
     return nullptr;
   }
 
+  // Refresh the table handle so it reflects the conjuncts distributed above;
+  // its pushed filters restrict the listing to matching rows.
+  auto* optimization = queryCtx()->optimization();
+  auto& toVelox = optimization->toVelox();
+  toVelox.filterUpdated(baseTable);
+  const ToVelox::LeafTableData* leaf = toVelox.leafData(baseTable->id());
+  VELOX_CHECK_NOT_NULL(leaf);
+
+  auto session = optimization->optimizerSession()->toConnectorSession(
+      discreteLayout.layout->connectorId());
+  auto discretePredicates = discreteLayout.layout->discretePredicates(
+      session, discreteLayout.connectorColumns, leaf->handle);
+  if (discretePredicates == nullptr) {
+    return nullptr;
+  }
+
   // Create and run Velox plan.
   const auto values = toValues(*discretePredicates);
   auto* valuesTable =
@@ -537,16 +560,14 @@ lp::ValuesNodePtr tryFoldConstantDt(
 
   RelationOpPtr plan = make<Values>(*valuesTable, valuesTable->columns);
 
+  // Re-apply the table's filters: the connector may not have pushed every
+  // conjunct into the listing.
   if (!baseTable->columnFilters.empty() || !baseTable->filter.empty()) {
-    auto combinedFilters = baseTable->columnFilters;
-    if (!baseTable->filter.empty()) {
-      combinedFilters.reserve(
-          baseTable->columnFilters.size() + baseTable->filter.size());
-      combinedFilters.insert(
-          combinedFilters.end(),
-          baseTable->filter.begin(),
-          baseTable->filter.end());
-    }
+    ExprVector combinedFilters = baseTable->columnFilters;
+    combinedFilters.insert(
+        combinedFilters.end(),
+        baseTable->filter.begin(),
+        baseTable->filter.end());
     plan = make<Filter>(plan, combinedFilters);
   }
 
@@ -564,8 +585,7 @@ lp::ValuesNodePtr tryFoldConstantDt(
         /*redundantProject=*/false);
   }
 
-  auto& optimization = queryCtx()->optimization();
-  auto veloxPlan = optimization->toVelox().toVeloxPlan(
+  auto veloxPlan = toVelox.toVeloxPlan(
       plan, MultiFragmentPlan::Options::singleNode(), {}, {});
   auto results = runConstantPlan(veloxPlan, pool);
   if (results.empty()) {

--- a/axiom/optimizer/tests/HiveQueriesTestBase.h
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.h
@@ -126,9 +126,29 @@ class HiveQueriesTestBase : public QueryTestBase {
   /// populates it with data. Drops the table first if it already exists.
   void runCtas(const std::string& sql);
 
+  /// Matches a TableScan of 'tableName' without asserting anything about the
+  /// scan's filters.
   static velox::core::PlanMatcherBuilder matchHiveScan(
       const std::string& tableName) {
     return velox::core::PlanMatcherBuilder().tableScan(tableName);
+  }
+
+  /// Matches a Hive TableScan of 'tableName' that has exactly 'subfieldFilters'
+  /// pushed down and exactly 'remainingFilter' as its non-pushed filter -- an
+  /// empty 'remainingFilter' asserts the scan has no remaining filter. Use the
+  /// single-argument overload to match a scan regardless of its filters.
+  static velox::core::PlanMatcherBuilder matchHiveScan(
+      const std::string& tableName,
+      velox::common::SubfieldFilters subfieldFilters,
+      const std::string& remainingFilter = "") {
+    return velox::core::PlanMatcherBuilder().hiveScan(
+        tableName, std::move(subfieldFilters), remainingFilter);
+  }
+
+  /// Sets a Hive connector session property for subsequently planned queries.
+  void setHiveConnectorSession(const std::string& key, std::string value) {
+    setConnectorSession(
+        velox::exec::test::kHiveConnectorId, key, std::move(value));
   }
 
  private:

--- a/axiom/optimizer/tests/QueryTestBase.cpp
+++ b/axiom/optimizer/tests/QueryTestBase.cpp
@@ -127,9 +127,10 @@ logical_plan::LogicalPlanNodePtr QueryTestBase::parseSelect(
 namespace {
 OptimizerSessionPtr makeOptimizerSession(
     const std::string& queryId,
-    OptimizerOptions options) {
+    OptimizerOptions options,
+    connector::ConnectorProperties connectorProperties) {
   return std::make_shared<OptimizerSession>(
-      queryId, "test", std::move(options), connector::ConnectorProperties{});
+      queryId, "test", std::move(options), std::move(connectorProperties));
 }
 
 runner::RunnerSessionPtr makeRunnerSession(const std::string& queryId) {
@@ -215,7 +216,9 @@ PlanCost QueryTestBase::optimizationCost(
       connector::ConnectorMetadataRegistry::global()};
   Optimization opt(
       makeOptimizerSession(
-          queryCtx->queryId(), optimizerOptions.value_or(optimizerOptions_)),
+          queryCtx->queryId(),
+          optimizerOptions.value_or(optimizerOptions_),
+          connectorSessionProperties_),
       makeRunnerSession(queryCtx->queryId()),
       *logicalPlan,
       schemaResolver,
@@ -249,7 +252,8 @@ void QueryTestBase::verifyOptimization(
   Optimization optimization(
       makeOptimizerSession(
           veloxQueryCtx->queryId(),
-          optimizerOptions.value_or(optimizerOptions_)),
+          optimizerOptions.value_or(optimizerOptions_),
+          connectorSessionProperties_),
       makeRunnerSession(veloxQueryCtx->queryId()),
       logicalPlan,
       schemaResolver,
@@ -317,7 +321,9 @@ optimizer::PlanAndStats QueryTestBase::planVelox(
   };
 
   auto session = makeOptimizerSession(
-      queryCtx->queryId(), optimizerOptions.value_or(optimizerOptions_));
+      queryCtx->queryId(),
+      optimizerOptions.value_or(optimizerOptions_),
+      connectorSessionProperties_);
 
   optimizer::PlanAndStats planAndStats;
   if (useV2_) {

--- a/axiom/optimizer/tests/QueryTestBase.h
+++ b/axiom/optimizer/tests/QueryTestBase.h
@@ -276,6 +276,24 @@ class QueryTestBase : public velox::exec::test::HiveConnectorTestBase {
 
   OptimizerOptions optimizerOptions_;
 
+  /// Sets connector session property 'key'='value' for 'connectorId', applied
+  /// to the OptimizerSession of subsequently planned queries.
+  void setConnectorSession(
+      const std::string& connectorId,
+      const std::string& key,
+      std::string value) {
+    connectorSessionProperties_[connectorId][key] = std::move(value);
+  }
+
+  /// Clears all connector session properties set via setConnectorSession.
+  void clearConnectorSession() {
+    connectorSessionProperties_.clear();
+  }
+
+  // Per-connector session properties passed to the OptimizerSession. Tests set
+  // entries via setConnectorSession; empty by default.
+  connector::ConnectorProperties connectorSessionProperties_;
+
   // When true, `optimize()` routes through the v2 optimizer pipeline instead of
   // v1. Lets one fixture run the same tests through either optimizer (e.g. set
   // from a TEST_P parameter). Default false = v1.

--- a/axiom/optimizer/tests/SubqueryTest.cpp
+++ b/axiom/optimizer/tests/SubqueryTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <folly/ScopeGuard.h>
+#include "axiom/connectors/hive/HiveMetadataConfig.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
@@ -288,6 +290,100 @@ TEST_F(SubqueryTest, foldable) {
     auto matcher = makeMatcher("ds in ('2025-11-03', '2025-10-29')");
 
     AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // A filter on the non-discrete column 'a' prevents the fold: the subquery is
+  // evaluated normally rather than by listing discrete values.
+  {
+    auto logicalPlan = parseSql(
+        "SELECT * FROM t WHERE ds = (SELECT max(ds) FROM t WHERE a > 5)");
+    auto plan = toSingleNodePlan(logicalPlan);
+    auto matcher = matchScan("t")
+                       .hashJoinInner(matchScan("t")
+                                          .aliases({"ds", "a"})
+                                          .filter("a > 5")
+                                          .aggregation()
+                                          .build())
+                       .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+}
+
+// Folds a scalar max() over Hive partition metadata: narrowing by a filter on
+// the aggregated partition key or on another partition key, declining when a
+// non-partition column is filtered, and enforcing the max-partitions session
+// property.
+TEST_F(SubqueryTest, foldableHivePartitions) {
+  // Partition keys 'ds' and 'k' (ds='1' maps to k=1, other ds to k=0) and data
+  // column 'x'. Three partitions: (ds='0',k=0), (ds='1',k=1), (ds='2',k=0).
+  runCtas(
+      "CREATE TABLE pt WITH (partitioned_by = ARRAY['ds', 'k']) AS "
+      "SELECT "
+      "     n_nationkey AS x, "
+      "     CAST(n_nationkey % 3 AS VARCHAR) AS ds, "
+      "     CAST(IF(n_nationkey % 3 = 1, 1, 0) AS INTEGER) AS k "
+      "FROM nation");
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("pt");
+  };
+
+  // max(ds) folds to the greatest partition value.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt)");
+    AXIOM_ASSERT_PLAN(plan, matchHiveScan("pt", test::eq("ds", "2")).build());
+  }
+
+  // A filter on the aggregated partition key narrows the listing.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt WHERE ds < '2')");
+    AXIOM_ASSERT_PLAN(plan, matchHiveScan("pt", test::eq("ds", "1")).build());
+  }
+
+  // A filter on a different partition key narrows the listing: only ds='1' has
+  // k > 0, so max(ds) folds to '1'.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt WHERE k > 0)");
+    AXIOM_ASSERT_PLAN(plan, matchHiveScan("pt", test::eq("ds", "1")).build());
+  }
+
+  // A filter on the non-partition column 'x' prevents the fold: the subquery is
+  // evaluated normally rather than by listing partitions.
+  {
+    auto plan = toSingleNodePlan(
+        "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt WHERE x > 0)");
+    auto matcher =
+        matchHiveScan("pt")
+            .hashJoinInner(matchHiveScan("pt", test::gt("x", int64_t{0}))
+                               .aggregation()
+                               .build())
+            .build();
+    AXIOM_ASSERT_PLAN(plan, matcher);
+  }
+
+  // The max-partitions session property bounds the listing: the un-narrowed
+  // listing (3 partitions) exceeds a limit of 2 and fails, while a partition
+  // filter narrows it under the limit and still folds.
+  {
+    setHiveConnectorSession(
+        connector::hive::HiveMetadataConfig::
+            kMaxPartitionsPerDiscretePredicates,
+        "2");
+    SCOPE_EXIT {
+      clearConnectorSession();
+    };
+
+    VELOX_ASSERT_THROW(
+        toSingleNodePlan(
+            "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt)"),
+        "(3 vs. 2) Discrete-predicate listing exceeds the max-partitions "
+        "limit");
+
+    auto plan = toSingleNodePlan(
+        "SELECT x FROM pt WHERE ds = (SELECT max(ds) FROM pt WHERE ds < '2')");
+    AXIOM_ASSERT_PLAN(plan, matchHiveScan("pt", test::eq("ds", "1")).build());
   }
 }
 


### PR DESCRIPTION
Summary:

A scalar subquery the optimizer evaluates from partition metadata could fail during planning. For example:

    SELECT ... FROM t WHERE ds = (SELECT max(ds) FROM t WHERE ds >= '...' AND k = '...')

The optimizer computes such a subquery by listing the table's partition values. It listed every partition and ignored the subquery's own filters, so a table with more partitions than the connector allows failed instead of folding.

`discretePredicates` now receives the table handle carrying the subquery's pushed filters. The fold builds that handle from the subquery's filters before listing, so the connector enumerates only matching partitions. Any conjunct the connector cannot push is re-applied over the returned values.

Implements `discretePredicates` for the local Hive connector, which was previously a no-op, and adds a `hive_max_partitions_per_discrete_predicates` session property that fails the listing once it grows past the limit. Separately, LocalHive now loads partition stats from nested multi-level partition directories, not only single-level ones.

Differential Revision: D113548436
