### PR TITLE
fix(v2): Run UNION ALL in parallel, not through one task (#1661)

### DIFF
--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -4707,6 +4707,8 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
 
   auto renames = std::move(renames_);
   bool isFirstInput = true;
+  // Output column names, taken from the first leg; every leg aligns 1:1.
+  std::vector<Name> outputNames;
 
   auto translateUnionInput = [&](const lp::LogicalPlanNode& input) {
     renames_ = renames;
@@ -4728,41 +4730,41 @@ void ToGraph::translateUnion(const lp::SetNode& set) {
     auto* newDt = std::exchange(currentDt_, setDt);
 
     const auto& type = input.outputType();
-
-    if (isFirstInput) {
-      // This is the first input of a union tree.
-      for (auto i : usedChannels(input)) {
-        const auto& name = type->nameOf(i);
-
-        ExprCP inner = translateColumn(name);
-        newDt->exprs.push_back(inner);
-
-        // The top dt has the same columns as all the unioned dts.
-        const auto* columnName = toName(name);
-        auto* outer =
-            make<Column>(columnName, setDt, inner->value(), columnName);
-        setDt->columns.push_back(outer);
-        newDt->columns.push_back(outer);
+    for (auto i : usedChannels(input)) {
+      newDt->exprs.push_back(translateColumn(type->nameOf(i)));
+      if (isFirstInput) {
+        outputNames.push_back(toName(type->nameOf(i)));
       }
-
-      isFirstInput = false;
-    } else {
-      for (auto i : usedChannels(input)) {
-        ExprCP inner = translateColumn(type->nameOf(i));
-        newDt->exprs.push_back(inner);
-      }
-
-      // Same outward facing columns as the top dt of union.
-      newDt->columns = setDt->columns;
     }
-
+    isFirstInput = false;
     setDt->unionInputs.push_back(newDt);
   };
 
   translateSetOperationInput(set, shouldFlatten, translateUnionInput);
 
+  // Build the union's output columns after all legs are translated so each
+  // column's NDV is the max of the legs' NDVs: a lower bound on the true union
+  // NDV, order-independent, and known as long as any leg has one. Type and
+  // bounds come from the first leg, which every leg matches by position.
+  for (size_t i = 0; i < outputNames.size(); ++i) {
+    std::optional<float> cardinality;
+    for (const auto* child : setDt->unionInputs) {
+      const auto legNdv = child->exprs[i]->value().cardinality;
+      if (legNdv.has_value()) {
+        cardinality =
+            cardinality.has_value() ? std::max(*cardinality, *legNdv) : *legNdv;
+      }
+    }
+    Value value = setDt->unionInputs[0]->exprs[i]->value();
+    value.cardinality = cardinality;
+    setDt->columns.push_back(
+        make<Column>(outputNames[i], setDt, value, outputNames[i]));
+  }
+
+  // The top dt and every unioned dt expose the same outward-facing columns.
   setDt->outputColumns = setDt->columns;
   for (auto* child : setDt->unionInputs) {
+    child->columns = setDt->columns;
     child->outputColumns = setDt->columns;
   }
 

--- a/axiom/optimizer/tests/MetadataCountsTest.cpp
+++ b/axiom/optimizer/tests/MetadataCountsTest.cpp
@@ -173,7 +173,6 @@ TEST_F(MetadataCountsTest, unionAll) {
       toSingleNodePlan(
           "SELECT approx_count_star() as x FROM t UNION ALL SELECT sum(a) FROM t"),
       matchValues(makeRowVector({makeFlatVector<int64_t>({25})}))
-          .project()
           .localPartition({
               matchHiveScan("t")
                   .aliases({"a"})

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -1014,11 +1014,13 @@ class ShuffleBoundaryMatcher : public PlanMatcher {
       std::shared_ptr<PlanMatcher> producerMatcher,
       std::optional<ShuffleType> type = std::nullopt,
       std::vector<std::string> keys = {},
-      std::optional<bool> replicateNullsAndAny = std::nullopt)
+      std::optional<bool> replicateNullsAndAny = std::nullopt,
+      std::optional<axiom::optimizer::FragmentType> producerType = std::nullopt)
       : producerMatcher_(std::move(producerMatcher)),
         type_(type),
         keys_(std::move(keys)),
-        replicateNullsAndAny_(replicateNullsAndAny) {
+        replicateNullsAndAny_(replicateNullsAndAny),
+        producerType_(producerType) {
     VELOX_CHECK(
         keys_.empty() || type == ShuffleType::kPartitioned ||
             type == ShuffleType::kOrdered,
@@ -1047,6 +1049,8 @@ class ShuffleBoundaryMatcher : public PlanMatcher {
   const std::vector<std::string> keys_;
   // Set only for kPartitioned (enforced by the constructor).
   const std::optional<bool> replicateNullsAndAny_;
+  // When set, the expected type of the producer fragment this boundary closes.
+  const std::optional<axiom::optimizer::FragmentType> producerType_;
 };
 
 // Returns the producer fragment for the given Exchange node, or nullptr if not
@@ -1195,6 +1199,14 @@ PlanMatcher::MatchResult ShuffleBoundaryMatcher::match(
   EXPECT_TRUE(producerFragment != nullptr)
       << "Could not find producer fragment for Exchange " << plan->id();
   AXIOM_TEST_RETURN_IF_FAILURE
+
+  if (producerType_.has_value()) {
+    EXPECT_EQ(producerFragment->type, *producerType_)
+        << "Producer fragment type mismatch: expected "
+        << fmt::format("{}", *producerType_) << ", got "
+        << fmt::format("{}", producerFragment->type);
+    AXIOM_TEST_RETURN_IF_FAILURE
+  }
 
   const auto& fragmentPlan = producerFragment->fragment.planNode;
   const auto* partitionedOutput = fragmentPlan->as<PartitionedOutputNode>();
@@ -2184,10 +2196,31 @@ PlanMatcherBuilder& PlanMatcherBuilder::shuffle(
   return *this;
 }
 
+PlanMatcherBuilder& PlanMatcherBuilder::shuffle(
+    const std::vector<std::string>& keys,
+    axiom::optimizer::FragmentType producer) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
+      matcher_, ShuffleType::kPartitioned, keys, std::nullopt, producer);
+  return *this;
+}
+
 PlanMatcherBuilder& PlanMatcherBuilder::shuffleMerge() {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ =
       std::make_shared<ShuffleBoundaryMatcher>(matcher_, ShuffleType::kOrdered);
+  return *this;
+}
+
+PlanMatcherBuilder& PlanMatcherBuilder::shuffleMerge(
+    axiom::optimizer::FragmentType producer) {
+  VELOX_USER_CHECK_NOT_NULL(matcher_);
+  matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
+      matcher_,
+      ShuffleType::kOrdered,
+      std::vector<std::string>{},
+      std::nullopt,
+      producer);
   return *this;
 }
 
@@ -2199,24 +2232,44 @@ PlanMatcherBuilder& PlanMatcherBuilder::shuffleMerge(
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::broadcast() {
+PlanMatcherBuilder& PlanMatcherBuilder::broadcast(
+    std::optional<axiom::optimizer::FragmentType> producer) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
-      matcher_, ShuffleType::kBroadcast);
+      matcher_,
+      ShuffleType::kBroadcast,
+      std::vector<std::string>{},
+      std::nullopt,
+      producer);
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::arbitrary() {
+PlanMatcherBuilder& PlanMatcherBuilder::arbitrary(
+    std::optional<axiom::optimizer::FragmentType> producer) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
-      matcher_, ShuffleType::kArbitrary);
+      matcher_,
+      ShuffleType::kArbitrary,
+      std::vector<std::string>{},
+      std::nullopt,
+      producer);
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::gather() {
+PlanMatcherBuilder& PlanMatcherBuilder::gather(
+    std::optional<axiom::optimizer::FragmentType> producer) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ =
-      std::make_shared<ShuffleBoundaryMatcher>(matcher_, ShuffleType::kGather);
+  VELOX_USER_CHECK(
+      producer != axiom::optimizer::FragmentType::kSingle &&
+          producer != axiom::optimizer::FragmentType::kCoordinator,
+      "A gather collapses multiple producer tasks to one; a single-task "
+      "producer (kSingle / kCoordinator) indicates a redundant funnel");
+  matcher_ = std::make_shared<ShuffleBoundaryMatcher>(
+      matcher_,
+      ShuffleType::kGather,
+      std::vector<std::string>{},
+      std::nullopt,
+      producer);
   return *this;
 }
 
@@ -2541,14 +2594,15 @@ PlanMatcherBuilder& PlanMatcherBuilder::fragmentWidth(int32_t width) {
   return *this;
 }
 
-PlanMatcherBuilder& PlanMatcherBuilder::fragmentType(
+PlanMatcherBuilder& PlanMatcherBuilder::output(
     axiom::optimizer::FragmentType type) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
   matcher_ = std::make_shared<BucketedAssertionMatcher>(
       matcher_, [type](const axiom::optimizer::ExecutableFragment& fragment) {
         EXPECT_EQ(fragment.type, type)
-            << "Expected fragment.type == " << static_cast<int32_t>(type)
-            << " but got " << static_cast<int32_t>(fragment.type);
+            << "Output fragment type mismatch: expected "
+            << fmt::format("{}", type) << ", got "
+            << fmt::format("{}", fragment.type);
       });
   return *this;
 }

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -521,6 +521,12 @@ class PlanMatcherBuilder {
       const std::vector<std::string>& keys,
       bool replicateNullsAndAny = false);
 
+  /// Like shuffle(keys), additionally asserting the type of the producer
+  /// fragment this boundary closes.
+  PlanMatcherBuilder& shuffle(
+      const std::vector<std::string>& keys,
+      axiom::optimizer::FragmentType producer);
+
   /// Marks a shuffle boundary with partition keys (see shuffle(keys,
   /// replicateNullsAndAny)) only when 'condition' is true; otherwise a no-op.
   PlanMatcherBuilder& shuffleIf(
@@ -537,6 +543,10 @@ class PlanMatcherBuilder {
   /// Cannot be used with match(PlanNodePtr) - use match(MultiFragmentPlan).
   PlanMatcherBuilder& shuffleMerge();
 
+  /// Like shuffleMerge(), additionally asserting the type of the producer
+  /// fragment this boundary closes.
+  PlanMatcherBuilder& shuffleMerge(axiom::optimizer::FragmentType producer);
+
   /// Like `shuffleMerge()`, additionally verifying the MergeExchange's sort
   /// ordering. Each entry is an ORDER BY expression with optional direction,
   /// e.g. "c" or "c DESC NULLS FIRST". Supports symbol rewriting from the
@@ -544,16 +554,27 @@ class PlanMatcherBuilder {
   PlanMatcherBuilder& shuffleMerge(const std::vector<std::string>& ordering);
 
   /// Matches a broadcast shuffle boundary in a distributed plan.
-  /// Verifies that PartitionedOutputNode::isBroadcast() is true.
-  PlanMatcherBuilder& broadcast();
+  /// Verifies that PartitionedOutputNode::isBroadcast() is true. When
+  /// 'producer' is set, also asserts the type of the producer fragment this
+  /// boundary closes.
+  PlanMatcherBuilder& broadcast(
+      std::optional<axiom::optimizer::FragmentType> producer = std::nullopt);
 
   /// Matches an arbitrary (round-robin) shuffle boundary in a distributed plan.
-  /// Verifies that PartitionedOutputNode::isArbitrary() is true.
-  PlanMatcherBuilder& arbitrary();
+  /// Verifies that PartitionedOutputNode::isArbitrary() is true. When
+  /// 'producer' is set, also asserts the type of the producer fragment this
+  /// boundary closes.
+  PlanMatcherBuilder& arbitrary(
+      std::optional<axiom::optimizer::FragmentType> producer = std::nullopt);
 
   /// Matches a gather shuffle boundary in a distributed plan.
-  /// Verifies that PartitionedOutputNode::numPartitions() == 1.
-  PlanMatcherBuilder& gather();
+  /// Verifies that PartitionedOutputNode::numPartitions() == 1. When 'producer'
+  /// is set, also asserts the type of the producer fragment this boundary
+  /// closes. A gather collapses multiple producer tasks to one, so a
+  /// single-task producer (kSingle / kCoordinator) is a redundant funnel and is
+  /// rejected.
+  PlanMatcherBuilder& gather(
+      std::optional<axiom::optimizer::FragmentType> producer = std::nullopt);
 
   /// Matches any Limit node regardless of offset, count, or partial/final step.
   PlanMatcherBuilder& limit();
@@ -772,8 +793,11 @@ class PlanMatcherBuilder {
   /// Asserts the current fragment has fragment.width == 'width'.
   PlanMatcherBuilder& fragmentWidth(int32_t width);
 
-  /// Asserts the current fragment has fragment.type == 'type'.
-  PlanMatcherBuilder& fragmentType(axiom::optimizer::FragmentType type);
+  /// Asserts the type of the root (output) fragment. Use as the final call in
+  /// the chain: it binds to the plan's output fragment, which has no closing
+  /// boundary to carry the type. Producer fragments carry their type on the
+  /// boundary that closes them (see gather / arbitrary / broadcast / shuffle).
+  PlanMatcherBuilder& output(axiom::optimizer::FragmentType type);
 
   /// Builds and returns the constructed PlanMatcher.
   /// @throws VeloxUserError if matcher is empty.

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -24,23 +24,22 @@ using namespace velox;
 
 // Tests for UNION ALL fragment planning. Each test covers one
 // leg-combination case and verifies both single-node and distributed
-// plans. See axiom/optimizer/docs/UnionAllPlanning.md for the design.
-//
-// TODO: Verify fragment types (kSource, kFixed N, kSingle) on the
-// distributed plans. Today the matchers only check exchange topology
-// (count + kind via .arbitrary() / .gather() / .shuffle(keys)). Adding
-// per-fragment type/width assertions to AXIOM_ASSERT_DISTRIBUTED_PLAN
-// is a follow-up.
+// plans, run under both optimizers. See
+// axiom/optimizer/docs/UnionAllPlanning.md for the design. Distributed
+// matchers carry the producer fragment type on the boundary that closes each
+// fragment (gather / arbitrary / shuffle / shuffleMerge).
 //
 // TODO: Extend PlanMatcher to allow specifying symbol aliases in
 // tableScan like other methods (singleAggregation, project, etc.).
 // Then we can use the same column names in SQL across tables and
 // reference them via aliases in matchers, instead of giving each table
 // a distinct column name to avoid internal disambiguation renames.
-class UnionAllTest : public test::QueryTestBase {
+class UnionAllTest : public test::QueryTestBase,
+                     public ::testing::WithParamInterface<bool> {
  protected:
   void SetUp() override {
     QueryTestBase::SetUp();
+    useV2_ = GetParam();
 
     // t and u have different column names ('a' and 'b') to avoid the
     // optimizer's internal column-disambiguation rename ('u.a' → 'a_0')
@@ -54,7 +53,7 @@ class UnionAllTest : public test::QueryTestBase {
 
 // Two scans (kSource + kSource) co-locate in one fragment with a
 // LocalPartition. No remote exchanges.
-TEST_F(UnionAllTest, twoScans) {
+TEST_P(UnionAllTest, twoScans) {
   auto logicalPlan = parseSelect("FROM t UNION ALL FROM u", kTestConnectorId);
 
   {
@@ -66,7 +65,7 @@ TEST_F(UnionAllTest, twoScans) {
   {
     auto matcher = matchScan("t")
                        .localPartition(matchScan("u").project().build())
-                       .gather()
+                       .gather(FragmentType::kSource)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -74,7 +73,7 @@ TEST_F(UnionAllTest, twoScans) {
 
 // Two DISTINCTs (kFixed N + kFixed N) co-locate in one kFixed N fragment
 // with both incoming hash exchanges.
-TEST_F(UnionAllTest, twoDistincts) {
+TEST_P(UnionAllTest, twoDistincts) {
   auto logicalPlan = parseSelect(
       "SELECT DISTINCT a FROM t UNION ALL SELECT DISTINCT b FROM u",
       kTestConnectorId);
@@ -96,7 +95,7 @@ TEST_F(UnionAllTest, twoDistincts) {
                                            .distributedAggregation({"b"}, {})
                                            .project()
                                            .build())
-                       .gather()
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -104,7 +103,7 @@ TEST_F(UnionAllTest, twoDistincts) {
 
 // All single-task legs (kSingle + kSingle) co-locate in one kSingle
 // fragment.
-TEST_F(UnionAllTest, twoValues) {
+TEST_P(UnionAllTest, twoValues) {
   auto logicalPlan =
       parseSelect("VALUES 1, 2 UNION ALL VALUES 3", kTestConnectorId);
 
@@ -117,15 +116,17 @@ TEST_F(UnionAllTest, twoValues) {
   {
     // All-gather UnionAll output stays gather; no extra gather Repartition
     // needed.
-    auto matcher =
-        matchValues().localPartition(matchValues().project().build()).build();
+    auto matcher = matchValues()
+                       .localPartition(matchValues().project().build())
+                       .output(FragmentType::kSingle)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
 
 // Scan + Values (kSource + kSingle) — Values wrapped in arbitrary, scan
 // hosts the union fragment as kSource.
-TEST_F(UnionAllTest, scanAndValues) {
+TEST_P(UnionAllTest, scanAndValues) {
   auto logicalPlan = parseSelect("FROM t UNION ALL VALUES 1", kTestConnectorId);
 
   {
@@ -135,11 +136,18 @@ TEST_F(UnionAllTest, scanAndValues) {
   }
 
   {
-    auto matcher =
-        matchScan("t")
-            .localPartition(matchValues().project().arbitrary().build())
-            .gather()
-            .build();
+    // v2 renames the arbitrary-isolated Values leg on the exchange's consumer
+    // side (an extra project); v1 fuses the rename into the leg before the
+    // exchange. Which side to place it is future work.
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           matchValues()
+                               .project()
+                               .arbitrary(FragmentType::kSingle)
+                               .projectIf(useV2_)
+                               .build())
+                       .gather(FragmentType::kSource)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -147,7 +155,7 @@ TEST_F(UnionAllTest, scanAndValues) {
 // Scan + two Values (kSource + kSingle + kSingle) — both Values legs are
 // grouped into one kSingle sub-union and wrapped in a single arbitrary
 // exchange (one wrap regardless of how many kSingle inputs there are).
-TEST_F(UnionAllTest, scanAndTwoValues) {
+TEST_P(UnionAllTest, scanAndTwoValues) {
   auto logicalPlan = parseSelect(
       "FROM t UNION ALL VALUES 1 UNION ALL VALUES 2", kTestConnectorId);
 
@@ -166,9 +174,9 @@ TEST_F(UnionAllTest, scanAndTwoValues) {
                            matchValues()
                                .project()
                                .localPartition(matchValues().project().build())
-                               .arbitrary()
+                               .arbitrary(FragmentType::kSingle)
                                .build())
-                       .gather()
+                       .gather(FragmentType::kSource)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -176,7 +184,7 @@ TEST_F(UnionAllTest, scanAndTwoValues) {
 
 // DISTINCT + Values (kFixed N + kSingle) — DISTINCT hosts the union
 // fragment as kFixed N; Values wrapped in arbitrary.
-TEST_F(UnionAllTest, distinctAndValues) {
+TEST_P(UnionAllTest, distinctAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT DISTINCT a FROM t UNION ALL VALUES 1", kTestConnectorId);
 
@@ -189,12 +197,16 @@ TEST_F(UnionAllTest, distinctAndValues) {
   }
 
   {
-    auto matcher =
-        matchScan("t")
-            .distributedAggregation({"a"}, {})
-            .localPartition(matchValues().project().arbitrary().build())
-            .gather()
-            .build();
+    auto matcher = matchScan("t")
+                       .distributedAggregation({"a"}, {})
+                       .localPartition(
+                           matchValues()
+                               .project()
+                               .arbitrary(FragmentType::kSingle)
+                               .projectIf(useV2_)
+                               .build())
+                       .gather(FragmentType::kFixed)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -202,7 +214,7 @@ TEST_F(UnionAllTest, distinctAndValues) {
 // Scan + DISTINCT (kSource + kFixed N) — scan adapts to kFixed N; both
 // legs co-locate in one kFixed N fragment with the DISTINCT's hash exchange
 // feeding the same N tasks. No arbitrary wrap.
-TEST_F(UnionAllTest, scanAndDistinct) {
+TEST_P(UnionAllTest, scanAndDistinct) {
   auto logicalPlan = parseSelect(
       "SELECT DISTINCT a FROM t UNION ALL FROM u", kTestConnectorId);
 
@@ -218,7 +230,7 @@ TEST_F(UnionAllTest, scanAndDistinct) {
     auto matcher = matchScan("t")
                        .distributedAggregation({"a"}, {})
                        .localPartition(matchScan("u").project().build())
-                       .gather()
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -227,7 +239,7 @@ TEST_F(UnionAllTest, scanAndDistinct) {
 // Scan + DISTINCT + Values (kSource + kFixed N + kSingle) — scan + DISTINCT
 // co-locate in kFixed N fragment, kSingle Values wrapped in arbitrary into
 // the same fragment.
-TEST_F(UnionAllTest, scanAndDistinctAndValues) {
+TEST_P(UnionAllTest, scanAndDistinctAndValues) {
   auto logicalPlan = parseSelect(
       "FROM t "
       "UNION ALL SELECT DISTINCT b FROM u "
@@ -251,8 +263,12 @@ TEST_F(UnionAllTest, scanAndDistinctAndValues) {
                                 .distributedAggregation({"b"}, {})
                                 .project()
                                 .build(),
-                            matchValues().project().arbitrary().build()})
-                       .gather()
+                            matchValues()
+                                .project()
+                                .arbitrary(FragmentType::kSingle)
+                                .projectIf(useV2_)
+                                .build()})
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -268,7 +284,7 @@ TEST_F(UnionAllTest, scanAndDistinctAndValues) {
 // GROUP BY over two scans. Both scans co-locate in one kSource fragment per
 // twoScans; the GROUP BY's hash(a) shuffle goes above the union, with the
 // FINAL agg in a separate kFixed N fragment.
-TEST_F(UnionAllTest, groupByOverTwoScans) {
+TEST_P(UnionAllTest, groupByOverTwoScans) {
   auto logicalPlan = parseSelect(
       "SELECT a, COUNT(*) FROM (FROM t UNION ALL FROM u) GROUP BY a",
       kTestConnectorId);
@@ -285,7 +301,7 @@ TEST_F(UnionAllTest, groupByOverTwoScans) {
     auto matcher = matchScan("t")
                        .localPartition(matchScan("u").project().build())
                        .distributedAggregation({"a"}, {"count(*)"})
-                       .gather()
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -301,7 +317,7 @@ TEST_F(UnionAllTest, groupByOverTwoScans) {
 // through UnionAll's distribution, so it can't see that the union output
 // is hash(K). It adds an extra local hash partition above the union
 // before the FINAL agg.
-TEST_F(UnionAllTest, groupByOverTwoDistincts) {
+TEST_P(UnionAllTest, groupByOverTwoDistincts) {
   auto logicalPlan = parseSelect(
       "SELECT a, COUNT(*) FROM ("
       "  SELECT DISTINCT a FROM t UNION ALL SELECT DISTINCT b FROM u"
@@ -320,16 +336,21 @@ TEST_F(UnionAllTest, groupByOverTwoDistincts) {
   }
 
   {
-    auto matcher = matchScan("t")
-                       .distributedAggregation({"a"}, {})
-                       .localPartition(matchScan("u")
-                                           .distributedAggregation({"b"}, {})
-                                           .project()
-                                           .build())
-                       .localPartition({"a"})
-                       .singleAggregation({"a"}, {"count(*)"})
-                       .gather()
-                       .build();
+    // The two distinct legs co-partition on the union output key, so the GROUP
+    // BY runs in the union fragment with no remote shuffle. v2 does a local
+    // two-stage aggregation (partial → local HASH → final); v1 a single
+    // aggregation after the hash.
+    auto builder =
+        matchScan("t").distributedAggregation({"a"}, {}).localPartition(
+            matchScan("u").distributedAggregation({"b"}, {}).project().build());
+    if (useV2_) {
+      builder.partialAggregation({"a"}, {"count(*)"})
+          .localPartition({"a"})
+          .finalAggregation();
+    } else {
+      builder.localPartition({"a"}).singleAggregation({"a"}, {"count(*)"});
+    }
+    auto matcher = builder.gather(FragmentType::kFixed).build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -338,7 +359,7 @@ TEST_F(UnionAllTest, groupByOverTwoDistincts) {
 // in the same kSingle fragment. The query alias 'AS x(k)' doesn't propagate
 // to the agg's grouping key (which uses internal name 'c0'); a Project on
 // top renames 'c0' to 'k'.
-TEST_F(UnionAllTest, groupByOverTwoValues) {
+TEST_P(UnionAllTest, groupByOverTwoValues) {
   auto logicalPlan = parseSelect(
       "SELECT k, COUNT(*) FROM ("
       "  VALUES 1, 2 UNION ALL VALUES 3"
@@ -355,17 +376,20 @@ TEST_F(UnionAllTest, groupByOverTwoValues) {
   }
 
   {
-    // The union is kSingle (all-gather inputs); the GROUP BY's
-    // repartitionForAgg recognizes the gather distribution and skips the
-    // remote hash shuffle. Aggregation runs locally in the same fragment;
-    // an in-fragment LocalPartition[HASH] is added by ToVelox for
-    // multi-driver execution.
-    auto matcher = matchValues()
-                       .localPartition(matchValues().project().build())
-                       .localPartition({"c0"})
-                       .singleAggregation({"c0"}, {"count(*)"})
-                       .project()
-                       .build();
+    // The union is kSingle (all-gather inputs), so the GROUP BY runs entirely
+    // in that fragment with no remote shuffle. v2 does a local two-stage
+    // aggregation (partial → local HASH → final) to pre-aggregate before the
+    // intra-fragment exchange; v1 does a single aggregation after the hash.
+    auto builder =
+        matchValues().localPartition(matchValues().project().build());
+    if (useV2_) {
+      builder.partialAggregation({"c0"}, {"count(*)"})
+          .localPartition({"c0"})
+          .finalAggregation();
+    } else {
+      builder.localPartition({"c0"}).singleAggregation({"c0"}, {"count(*)"});
+    }
+    auto matcher = builder.project().output(FragmentType::kSingle).build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -373,7 +397,7 @@ TEST_F(UnionAllTest, groupByOverTwoValues) {
 // GROUP BY over scan + Values (kSource + kSingle). Same A4 layout (Values
 // wrapped in arbitrary, scan in kSource union); GROUP BY's hash shuffle
 // goes above the union.
-TEST_F(UnionAllTest, groupByOverScanAndValues) {
+TEST_P(UnionAllTest, groupByOverScanAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT a, COUNT(*) FROM ("
       "  FROM t UNION ALL VALUES 1"
@@ -389,12 +413,16 @@ TEST_F(UnionAllTest, groupByOverScanAndValues) {
   }
 
   {
-    auto matcher =
-        matchScan("t")
-            .localPartition(matchValues().project().arbitrary().build())
-            .distributedAggregation({"a"}, {"count(*)"})
-            .gather()
-            .build();
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           matchValues()
+                               .project()
+                               .arbitrary(FragmentType::kSingle)
+                               .projectIf(useV2_)
+                               .build())
+                       .distributedAggregation({"a"}, {"count(*)"})
+                       .gather(FragmentType::kFixed)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -408,7 +436,7 @@ TEST_F(UnionAllTest, groupByOverScanAndValues) {
 // FINAL agg would run in the same kFixed N fragment as the union. Today
 // the kSingle wrap uses arbitrary and the agg adds its own hash shuffle
 // above.
-TEST_F(UnionAllTest, groupByOverDistinctAndValues) {
+TEST_P(UnionAllTest, groupByOverDistinctAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT a, COUNT(*) FROM ("
       "  SELECT DISTINCT a FROM t UNION ALL VALUES 1"
@@ -425,13 +453,23 @@ TEST_F(UnionAllTest, groupByOverDistinctAndValues) {
   }
 
   {
-    auto matcher =
-        matchScan("t")
-            .distributedAggregation({"a"}, {})
-            .localPartition(matchValues().project().arbitrary().build())
-            .distributedSingleAggregation({"a"}, {"count(*)"})
-            .gather()
-            .build();
+    // The arbitrary-isolated Values leg renames on the exchange's consumer side
+    // in v2 (extra project). The union output is not hash(a) (the Values leg is
+    // arbitrary), so the GROUP BY shuffles: v2 does partial → shuffle → final,
+    // v1 a single aggregation after the shuffle.
+    auto builder =
+        matchScan("t").distributedAggregation({"a"}, {}).localPartition(
+            matchValues()
+                .project()
+                .arbitrary(FragmentType::kSingle)
+                .projectIf(useV2_)
+                .build());
+    if (useV2_) {
+      builder.distributedAggregation({"a"}, {"count(*)"});
+    } else {
+      builder.distributedSingleAggregation({"a"}, {"count(*)"});
+    }
+    auto matcher = builder.gather(FragmentType::kFixed).build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -440,7 +478,7 @@ TEST_F(UnionAllTest, groupByOverDistinctAndValues) {
 // per A6 in kFixed N union (scan adapts to fixed width). GROUP BY's hash
 // shuffle goes above the union (scan rows aren't hash(K), so output is
 // mixed and a shuffle is needed).
-TEST_F(UnionAllTest, groupByOverScanAndDistinct) {
+TEST_P(UnionAllTest, groupByOverScanAndDistinct) {
   auto logicalPlan = parseSelect(
       "SELECT a, COUNT(*) FROM ("
       "  FROM t UNION ALL SELECT DISTINCT b FROM u"
@@ -464,7 +502,7 @@ TEST_F(UnionAllTest, groupByOverScanAndDistinct) {
                                            .project()
                                            .build())
                        .distributedAggregation({"a"}, {"count(*)"})
-                       .gather()
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -473,7 +511,7 @@ TEST_F(UnionAllTest, groupByOverScanAndDistinct) {
 // GROUP BY over scan + DISTINCT + Values (kSource + kFixed N + kSingle).
 // scan + DISTINCT co-locate in kFixed N, Values wrapped in arbitrary. GROUP
 // BY's hash shuffle goes above the union.
-TEST_F(UnionAllTest, groupByOverScanAndDistinctAndValues) {
+TEST_P(UnionAllTest, groupByOverScanAndDistinctAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT a, COUNT(*) FROM ("
       "  FROM t "
@@ -500,9 +538,13 @@ TEST_F(UnionAllTest, groupByOverScanAndDistinctAndValues) {
                                 .distributedAggregation({"b"}, {})
                                 .project()
                                 .build(),
-                            matchValues().project().arbitrary().build()})
+                            matchValues()
+                                .project()
+                                .arbitrary(FragmentType::kSingle)
+                                .projectIf(useV2_)
+                                .build()})
                        .distributedAggregation({"a"}, {"count(*)"})
-                       .gather()
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -524,7 +566,7 @@ TEST_F(UnionAllTest, groupByOverScanAndDistinctAndValues) {
 // ORDER BY over two scans. Both scans co-locate in one kSource fragment
 // per A1; that fragment's OrderBy is split into PARTIAL+LocalMerge with a
 // merge exchange to the final kSingle fragment.
-TEST_F(UnionAllTest, orderByOverTwoScans) {
+TEST_P(UnionAllTest, orderByOverTwoScans) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (FROM t UNION ALL FROM u) ORDER BY a", kTestConnectorId);
 
@@ -541,7 +583,7 @@ TEST_F(UnionAllTest, orderByOverTwoScans) {
                        .localPartition(matchScan("u").project().build())
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
-                       .shuffleMerge()
+                       .shuffleMerge(FragmentType::kSource)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -554,7 +596,7 @@ TEST_F(UnionAllTest, orderByOverTwoScans) {
 // TODO: The optimizer always emits a separate kSingle final fragment, even
 // when the union is already kSingle. The OrderBy is split into PARTIAL +
 // LocalMerge + MergeExchange + (no extra OrderBy) — one unnecessary gather.
-TEST_F(UnionAllTest, orderByOverTwoValues) {
+TEST_P(UnionAllTest, orderByOverTwoValues) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (VALUES 1 UNION ALL VALUES 2) ORDER BY 1",
       kTestConnectorId);
@@ -568,12 +610,20 @@ TEST_F(UnionAllTest, orderByOverTwoValues) {
   }
 
   {
-    auto matcher = matchValues()
+    // The union is kSingle, so v2 sorts entirely in that fragment. v1 always
+    // splits into a partial sort + merge exchange to a separate kSingle final
+    // fragment -- a known v1 suboptimality (an unnecessary gather) that v2
+    // avoids.
+    auto builder = matchValues()
                        .localPartition(matchValues().project().build())
                        .orderBy({"c0 ASC NULLS LAST"})
-                       .localMerge()
-                       .shuffleMerge()
-                       .build();
+                       .localMerge();
+    if (useV2_) {
+      builder.output(FragmentType::kSingle);
+    } else {
+      builder.shuffleMerge();
+    }
+    auto matcher = builder.build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -581,7 +631,7 @@ TEST_F(UnionAllTest, orderByOverTwoValues) {
 // ORDER BY over two DISTINCTs. Both DISTINCTs co-locate in kFixed N per A2;
 // the ORDER BY's PARTIAL runs there with a gather (merge exchange) to the
 // kSingle final fragment.
-TEST_F(UnionAllTest, orderByOverTwoDistincts) {
+TEST_P(UnionAllTest, orderByOverTwoDistincts) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM ("
       "  SELECT DISTINCT a FROM t UNION ALL SELECT DISTINCT b FROM u"
@@ -608,7 +658,7 @@ TEST_F(UnionAllTest, orderByOverTwoDistincts) {
                                            .build())
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
-                       .shuffleMerge()
+                       .shuffleMerge(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -623,7 +673,7 @@ TEST_F(UnionAllTest, orderByOverTwoDistincts) {
 // kSingle fragment). Today: Values wrapped in arbitrary into the kSource
 // union fragment with the scan; gather above. Same gather count, but extra
 // arbitrary exchange that the design avoids.
-TEST_F(UnionAllTest, orderByOverScanAndValues) {
+TEST_P(UnionAllTest, orderByOverScanAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (FROM t UNION ALL VALUES 1) ORDER BY a", kTestConnectorId);
 
@@ -636,13 +686,17 @@ TEST_F(UnionAllTest, orderByOverScanAndValues) {
   }
 
   {
-    auto matcher =
-        matchScan("t")
-            .localPartition(matchValues().project().arbitrary().build())
-            .orderBy({"a ASC NULLS LAST"})
-            .localMerge()
-            .shuffleMerge()
-            .build();
+    auto matcher = matchScan("t")
+                       .localPartition(
+                           matchValues()
+                               .project()
+                               .arbitrary(FragmentType::kSingle)
+                               .projectIf(useV2_)
+                               .build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge(FragmentType::kSource)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
@@ -650,7 +704,7 @@ TEST_F(UnionAllTest, orderByOverScanAndValues) {
 // ORDER BY over DISTINCT + Values. Same TODO as orderByOverScanAndValues:
 // Values wrapped in arbitrary into the kFixed N union fragment with the
 // DISTINCT, instead of co-located in the kSingle final.
-TEST_F(UnionAllTest, orderByOverDistinctAndValues) {
+TEST_P(UnionAllTest, orderByOverDistinctAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (SELECT DISTINCT a FROM t UNION ALL VALUES 1) ORDER BY a",
       kTestConnectorId);
@@ -665,21 +719,25 @@ TEST_F(UnionAllTest, orderByOverDistinctAndValues) {
   }
 
   {
-    auto matcher =
-        matchScan("t")
-            .distributedAggregation({"a"}, {})
-            .localPartition(matchValues().project().arbitrary().build())
-            .orderBy({"a ASC NULLS LAST"})
-            .localMerge()
-            .shuffleMerge()
-            .build();
+    auto matcher = matchScan("t")
+                       .distributedAggregation({"a"}, {})
+                       .localPartition(
+                           matchValues()
+                               .project()
+                               .arbitrary(FragmentType::kSingle)
+                               .projectIf(useV2_)
+                               .build())
+                       .orderBy({"a ASC NULLS LAST"})
+                       .localMerge()
+                       .shuffleMerge(FragmentType::kFixed)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
 
 // ORDER BY over scan + DISTINCT. Both legs co-locate in kFixed N per A6;
 // gather above to kSingle final.
-TEST_F(UnionAllTest, orderByOverScanAndDistinct) {
+TEST_P(UnionAllTest, orderByOverScanAndDistinct) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (FROM t UNION ALL SELECT DISTINCT b FROM u) ORDER BY a",
       kTestConnectorId);
@@ -702,7 +760,7 @@ TEST_F(UnionAllTest, orderByOverScanAndDistinct) {
                                            .build())
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
-                       .shuffleMerge()
+                       .shuffleMerge(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -715,7 +773,7 @@ TEST_F(UnionAllTest, orderByOverScanAndDistinct) {
 // parallel fragment) instead of C's rule (Values co-located in the kSingle
 // final fragment). Same gather count, but extra arbitrary exchange that the
 // design avoids.
-TEST_F(UnionAllTest, orderByOverScanAndDistinctAndValues) {
+TEST_P(UnionAllTest, orderByOverScanAndDistinctAndValues) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM ("
       "  FROM t "
@@ -741,10 +799,14 @@ TEST_F(UnionAllTest, orderByOverScanAndDistinctAndValues) {
                                 .distributedAggregation({"b"}, {})
                                 .project()
                                 .build(),
-                            matchValues().project().arbitrary().build()})
+                            matchValues()
+                                .project()
+                                .arbitrary(FragmentType::kSingle)
+                                .projectIf(useV2_)
+                                .build()})
                        .orderBy({"a ASC NULLS LAST"})
                        .localMerge()
-                       .shuffleMerge()
+                       .shuffleMerge(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -764,7 +826,7 @@ TEST_F(UnionAllTest, orderByOverScanAndDistinctAndValues) {
 // fragment with a BROADCAST output above; the join's desired hash(c) is
 // dropped because no leg produces it natively (treated as a hint, not a
 // requirement, when no leg matches).
-TEST_F(UnionAllTest, broadcastJoinBuildOverUnion) {
+TEST_P(UnionAllTest, broadcastJoinBuildOverUnion) {
   testConnector_->addTable("v", ROW("c", BIGINT()))
       ->setStats(10, {{"c", {.numDistinct = 10}}});
 
@@ -775,12 +837,16 @@ TEST_F(UnionAllTest, broadcastJoinBuildOverUnion) {
       kTestConnectorId);
 
   {
+    // v2 merges the equi-join keys (a = c) into one equivalence column, so the
+    // join outputs only `a` and a project reconstructs `c` (= a) for the
+    // output; v1 keeps both keys in the join output.
     auto matcher =
         matchScan("t")
             .hashJoin(matchScan("v")
                           .localPartition(
                               matchScan("u").filter("b < 0").project().build())
                           .build())
+            .projectIf(useV2_)
             .build();
     AXIOM_ASSERT_PLAN(toSingleNodePlan(logicalPlan), matcher);
   }
@@ -791,9 +857,10 @@ TEST_F(UnionAllTest, broadcastJoinBuildOverUnion) {
             .hashJoin(matchScan("v")
                           .localPartition(
                               matchScan("u").filter("b < 0").project().build())
-                          .broadcast()
+                          .broadcast(FragmentType::kSource)
                           .build())
-            .gather()
+            .projectIf(useV2_)
+            .gather(FragmentType::kSource)
             .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
@@ -803,7 +870,7 @@ TEST_F(UnionAllTest, broadcastJoinBuildOverUnion) {
 // and probe get hash-partitioned on the join key. The union legs co-locate
 // in one kSource fragment with a single hash output (B1 pattern). Distinct
 // column names ('a', 'c', 'b') avoid the optimizer's disambiguation rename.
-TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
+TEST_P(UnionAllTest, shuffledJoinBuildOverUnion) {
   testConnector_->addTable("v", ROW("c", BIGINT()))
       ->setStats(100'000, {{"c", {.numDistinct = 1'000}}});
 
@@ -820,12 +887,14 @@ TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
   }
 
   {
-    auto matcher = matchScan("v")
-                       .localPartition(matchScan("u").project().build())
-                       .shuffle({"c"})
-                       .hashJoin(matchScan("t").shuffle({"a"}).build())
-                       .gather()
-                       .build();
+    auto matcher =
+        matchScan("v")
+            .localPartition(matchScan("u").project().build())
+            .shuffle({"c"}, FragmentType::kSource)
+            .hashJoin(
+                matchScan("t").shuffle({"a"}, FragmentType::kSource).build())
+            .gather(FragmentType::kFixed)
+            .build();
     // Cap the broadcast size limit low so the union build stays hash
     // partitioned (the scenario under test) rather than the small probe being
     // broadcast.
@@ -847,7 +916,7 @@ TEST_F(UnionAllTest, shuffledJoinBuildOverUnion) {
 // streaming aggregation would emit one group per leg per key. The per-leg
 // ORDER BYs are dropped by the dead-sort optimization (their order is
 // unobservable past the order-destroying UNION ALL).
-TEST_F(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
+TEST_P(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
   auto logicalPlan = parseSelect(
       "SELECT a, count(*) FROM ("
       "  (SELECT a FROM t ORDER BY a)"
@@ -868,11 +937,13 @@ TEST_F(UnionAllTest, groupByOverUnionAllWithOrderedLegs) {
     auto matcher = matchScan("t")
                        .localPartition(matchScan("u").project().build())
                        .distributedAggregation({"a"}, {"count(*)"})
-                       .gather()
+                       .gather(FragmentType::kFixed)
                        .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }
+
+AXIOM_INSTANTIATE_V1_V2(UnionAllTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -95,6 +95,16 @@ std::vector<velox::core::FieldAccessTypedExprPtr> toFieldAccessList(
   return out;
 }
 
+// Output names of 'columns', in order.
+std::vector<std::string> namesOf(const ColumnVector& columns) {
+  std::vector<std::string> names;
+  names.reserve(columns.size());
+  for (ColumnCP column : columns) {
+    names.push_back(column->outputName());
+  }
+  return names;
+}
+
 std::vector<velox::core::FieldAccessTypedExprPtr> toFieldAccessList(
     const ExprVector& exprs,
     std::string_view role) {
@@ -535,16 +545,10 @@ class Emitter {
 velox::core::PlanNodePtr Emitter::projectToColumns(
     const ColumnVector& keepColumns,
     velox::core::PlanNodePtr input) {
-  std::vector<std::string> names;
-  std::vector<velox::core::TypedExprPtr> exprs;
-  names.reserve(keepColumns.size());
-  exprs.reserve(keepColumns.size());
-  for (ColumnCP column : keepColumns) {
-    names.emplace_back(column->outputName());
-    exprs.push_back(toFieldAccess(column));
-  }
-  return std::make_shared<velox::core::ProjectNode>(
-      nextId(), std::move(names), std::move(exprs), std::move(input));
+  // Select `keepColumns` under their own output names: a rename projection onto
+  // themselves.
+  return wrapWithRenameProject(
+      std::move(input), keepColumns, namesOf(keepColumns));
 }
 
 velox::RowTypePtr Emitter::makeRowType(const ColumnVector& columns) const {
@@ -717,15 +721,12 @@ velox::core::PlanNodePtr Emitter::emitFilter(const Filter& filter) {
 
 velox::core::PlanNodePtr Emitter::emitProject(const Project& project) {
   velox::core::PlanNodePtr input = emit(project.input());
-  const auto& columns = project.outputColumns();
-  std::vector<std::string> names;
-  names.reserve(columns.size());
-  for (ColumnCP column : columns) {
-    names.push_back(column->outputName());
-  }
   auto typedExprs = exprEmitter_.toTypedExprs(project.exprs());
   return std::make_shared<velox::core::ProjectNode>(
-      nextId(), std::move(names), std::move(typedExprs), std::move(input));
+      nextId(),
+      namesOf(project.outputColumns()),
+      std::move(typedExprs),
+      std::move(input));
 }
 
 velox::core::PlanNodePtr Emitter::emitRootProjectOver(
@@ -1173,11 +1174,7 @@ velox::core::PlanNodePtr Emitter::emitMarkDistinct(
     const MarkDistinct& markDistinct) {
   velox::core::PlanNodePtr input = emit(markDistinct.input());
 
-  std::vector<std::string> markerNames;
-  markerNames.reserve(markDistinct.markers().size());
-  for (ColumnCP marker : markDistinct.markers()) {
-    markerNames.emplace_back(marker->outputName());
-  }
+  auto markerNames = namesOf(markDistinct.markers());
 
   std::vector<velox::core::FieldAccessTypedExprPtr> distinctKeys =
       toFieldAccessList(markDistinct.distinctKeys(), "MarkDistinct key");
@@ -1575,34 +1572,20 @@ velox::core::PlanNodePtr Emitter::emitUnnest(const Unnest& unnest) {
 }
 
 velox::core::PlanNodePtr Emitter::emitUnionAll(const UnionAll& unionNode) {
-  // `LocalPartitionNode` requires every source to share an identical output
-  // type. Each leg's IR `outputColumns` may be narrower than the union's
-  // width (legs collapse dup outputs independently), so always wrap each leg
-  // in a per-leg ProjectNode that selects via `legColumns[i][j]` (a Column*
-  // in the leg's outputColumns) and renames to the union's output names.
-  const auto& outputColumns = unionNode.outputColumns();
-  const auto& legColumns = unionNode.legColumns();
-  const auto numOutputs = outputColumns.size();
+  // PrecomputeProjectionsPass has aligned every leg to the union's output
+  // columns (Velox's LocalPartition requires all sources to share one output
+  // type), so this is a plain gather over the emitted legs.
   std::vector<velox::core::PlanNodePtr> sources;
   sources.reserve(unionNode.inputs().size());
-  for (size_t legIdx = 0; legIdx < unionNode.inputs().size(); ++legIdx) {
-    NodeCP input = unionNode.inputs()[legIdx];
-    velox::core::PlanNodePtr emittedInput = emit(input);
-    const auto& legCols = legColumns[legIdx];
-    std::vector<std::string> names;
-    std::vector<velox::core::TypedExprPtr> exprs;
-    names.reserve(numOutputs);
-    exprs.reserve(numOutputs);
-    for (size_t j = 0; j < numOutputs; ++j) {
-      names.push_back(outputColumns[j]->outputName());
-      exprs.push_back(toFieldAccess(legCols[j]));
+  for (NodeCP input : unionNode.inputs()) {
+    velox::core::PlanNodePtr emitted = emit(input);
+    // A leg whose scan carries a rejected filter emits the filter-only columns
+    // for the FilterNode (see emitScan); trim them so every source shares the
+    // union's output type, as emitRoot does for the query output.
+    if (emitted->outputType()->size() > input->outputColumns().size()) {
+      emitted = projectToColumns(input->outputColumns(), std::move(emitted));
     }
-    sources.push_back(
-        std::make_shared<velox::core::ProjectNode>(
-            nextId(),
-            std::move(names),
-            std::move(exprs),
-            std::move(emittedInput)));
+    sources.push_back(std::move(emitted));
   }
   return velox::core::LocalPartitionNode::gather(nextId(), std::move(sources));
 }

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1210,13 +1210,17 @@ Partitioning unionGlobalPartition(const UnionAll::Key& key) {
     return Partitioning::globalGather();
   }
 
+  // A partitionType of nullptr is standard hash partitioning; a non-null one is
+  // a connector's bucketing. Two legs co-partition on the mapped output keys
+  // when both are standard hash (same hash, so a given key value lands on the
+  // same partition in every leg) or both are copartitionable connector types.
+  // The two kinds never co-partition with each other.
   const connector::PartitionType* representative = nullptr;
   ExprVector outputKeys;
   for (size_t leg = 0; leg < key.inputs.size(); ++leg) {
     const Partitioning& part =
         key.inputs[leg]->physicalProperties().globalPartition;
-    if (part.kind != PartitionKind::kPartitioned ||
-        part.partitionType == nullptr) {
+    if (part.kind != PartitionKind::kPartitioned) {
       return {};
     }
     // Map each leg partition key to the union output column at the same index.
@@ -1250,20 +1254,28 @@ Partitioning unionGlobalPartition(const UnionAll::Key& key) {
         return {};
       }
     }
-    // copartition is only a feasibility check; the output reuses the
-    // min-partition-count leg's layout-owned type, whose count equals
-    // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
-    const auto compatible = representative->copartition(*part.partitionType);
-    if (compatible == nullptr) {
-      return {};
+    if (representative == nullptr || part.partitionType == nullptr) {
+      // Standard hash is compatible only with standard hash.
+      if (representative != part.partitionType) {
+        return {};
+      }
+    } else {
+      // copartition is only a feasibility check; the output reuses the
+      // min-partition-count leg's layout-owned type, whose count equals
+      // copartition's (a fresh shared_ptr we can't retain as a raw pointer).
+      const auto compatible = representative->copartition(*part.partitionType);
+      if (compatible == nullptr) {
+        return {};
+      }
+      if (part.partitionType->numPartitions() <
+          representative->numPartitions()) {
+        representative = part.partitionType;
+      }
+      VELOX_DCHECK_EQ(
+          representative->numPartitions(),
+          compatible->numPartitions(),
+          "Co-bucketed union output must reuse a layout type matching copartition's count");
     }
-    if (part.partitionType->numPartitions() < representative->numPartitions()) {
-      representative = part.partitionType;
-    }
-    VELOX_DCHECK_EQ(
-        representative->numPartitions(),
-        compatible->numPartitions(),
-        "Co-bucketed union output must reuse a layout type matching copartition's count");
   }
   return Partitioning{
       .kind = PartitionKind::kPartitioned,

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -718,12 +718,15 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
          node->count()});
   }
 
-  // Distributes a UNION ALL: at numWorkers>1 isolate each leg behind a remote
-  // exchange so a single-task leg (global aggregate, order/limit, Values) does
-  // not pin the union to one task and never shares a fragment with a parallel
-  // leg. Arbitrary partitioning
-  // suffices — the union only concatenates; a downstream operator that needs a
-  // partitioning establishes it on the union's output itself.
+  // Distributes a UNION ALL: at numWorkers>1 isolate each single-task leg
+  // (global aggregate, order/limit, Values) behind a remote exchange, so it
+  // does not share a fragment with a parallel leg -- which would replicate it
+  // across that fragment's tasks. Parallel legs (scans, distincts) stay
+  // un-isolated and co-locate in the union fragment, keeping the union parallel
+  // rather than funneling every row through one task. Arbitrary partitioning
+  // suffices for the isolated legs -- the union only concatenates; a downstream
+  // operator that needs a partitioning establishes it on the union's output
+  // itself.
   NodeCP rewriteUnionAll(const UnionAll* node, NoContext& context) override {
     NodeVector newInputs;
     newInputs.reserve(node->inputs().size());
@@ -751,10 +754,51 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
           partition.is(PartitionKind::kGather)) {
         return coalesced;
       }
-      for (NodeCP& newInput : newInputs) {
-        newInput = arbitrary(newInput);
+
+      // Mixed legs. Parallel legs (scans, distincts) co-locate in the union
+      // fragment and run in parallel. The single-task (gathered) legs (Values,
+      // global aggregate, order/limit) are grouped into one sub-union and
+      // isolated behind a single arbitrary exchange, so they run once and feed
+      // the parallel union -- rather than sharing the parallel fragment (which
+      // would replicate them across its tasks) or each spawning its own
+      // fragment.
+      NodeVector parallelLegs;
+      QGVector<ColumnVector> parallelLegColumns;
+      NodeVector singleTaskLegs;
+      QGVector<ColumnVector> singleTaskLegColumns;
+      for (size_t i = 0; i < newInputs.size(); ++i) {
+        if (newInputs[i]->physicalProperties().globalPartition.is(
+                PartitionKind::kGather)) {
+          singleTaskLegs.push_back(newInputs[i]);
+          singleTaskLegColumns.push_back(node->legColumns()[i]);
+        } else {
+          parallelLegs.push_back(newInputs[i]);
+          parallelLegColumns.push_back(node->legColumns()[i]);
+        }
       }
-      changed = true;
+
+      NodeVector unionInputs = std::move(parallelLegs);
+      QGVector<ColumnVector> unionLegColumns = std::move(parallelLegColumns);
+      if (!singleTaskLegs.empty()) {
+        NodeCP grouped;
+        ColumnVector groupedColumns;
+        if (singleTaskLegs.size() == 1) {
+          grouped = singleTaskLegs.front();
+          groupedColumns = singleTaskLegColumns.front();
+        } else {
+          groupedColumns = node->outputColumns();
+          grouped = builder().make<UnionAll>(
+              {std::move(singleTaskLegs),
+               std::move(singleTaskLegColumns),
+               node->outputColumns()});
+        }
+        unionInputs.push_back(arbitrary(grouped));
+        unionLegColumns.push_back(std::move(groupedColumns));
+      }
+      return builder().make<UnionAll>(
+          {std::move(unionInputs),
+           std::move(unionLegColumns),
+           node->outputColumns()});
     }
 
     if (!changed) {

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -25,6 +25,32 @@
 namespace facebook::axiom::optimizer::v2 {
 namespace {
 
+// Builds `Project(exprs -> outColumns)` over `input`, folding into `input` when
+// it is a deterministic Project (substituting the expressions through the
+// child's output->expression map) rather than stacking a second Project. A
+// non-deterministic child is left alone, since a fold could evaluate one of its
+// outputs more than once.
+//
+// TODO: still inline the deterministic outputs when only some are
+// non-deterministic — isolate the non-deterministic ones in a separate Project
+// below and fold the rest.
+NodeCP makeProject(
+    NodeCP input,
+    ExprVector exprs,
+    ColumnVector outColumns,
+    Builder& builder) {
+  if (input->is(NodeType::kProject)) {
+    const auto* child = input->as<Project>();
+    if (child->isDeterministic()) {
+      exprs = ExprFactory(builder).substitute(
+          exprs, child->outputColumns(), child->exprs());
+      input = child->input();
+    }
+  }
+  return builder.make<Project>(
+      {input, std::move(exprs), std::move(outColumns)});
+}
+
 // Per-consumer builder that lifts compound sub-expressions into a Project
 // inserted between the consumer and its existing input.
 class PrecomputeProjections {
@@ -136,25 +162,8 @@ NodeCP PrecomputeProjections::node() && {
   if (!needsProject_) {
     return input_;
   }
-
-  // Fold into a child Project rather than stacking a second one: substitute
-  // this project's expressions through the child's output->expression map.
-  // Skipped when the child has a non-deterministic expression, since a fold
-  // could evaluate such an output more than once.
-  //
-  // TODO: still inline the deterministic outputs when only some are
-  // non-deterministic — isolate the non-deterministic ones in a separate
-  // Project below and fold the rest.
-  if (input_->is(NodeType::kProject)) {
-    const auto* childProject = input_->as<Project>();
-    if (childProject->isDeterministic()) {
-      outExprs_ = ExprFactory(builder_).substitute(
-          outExprs_, childProject->outputColumns(), childProject->exprs());
-      input_ = childProject->input();
-    }
-  }
-  return builder_.make<Project>(
-      {input_, std::move(outExprs_), std::move(outColumns_)});
+  return makeProject(
+      input_, std::move(outExprs_), std::move(outColumns_), builder_);
 }
 
 void PrecomputeProjections::addToProject(ExprCP expr, ColumnCP column) {
@@ -196,6 +205,7 @@ class Rewriter : public NodeRewriter<> {
   NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
   NodeCP rewriteJoin(const Join* join, NoContext& context) override;
   NodeCP rewriteExchange(const Exchange* exchange, NoContext& context) override;
+  NodeCP rewriteUnionAll(const UnionAll* unionAll, NoContext& context) override;
   NodeCP rewriteApply(const Apply* /*apply*/, NoContext& /*context*/) override {
     VELOX_UNREACHABLE(
         "Apply must be removed by decorrelate before PrecomputeProjections");
@@ -445,6 +455,60 @@ NodeCP Rewriter::rewriteUnnest(const Unnest* unnest, NoContext& context) {
        unnest->unnestColumns(),
        unnest->ordinalityColumn(),
        unnest->outputColumns()});
+}
+
+NodeCP Rewriter::rewriteUnionAll(const UnionAll* unionAll, NoContext& context) {
+  // Velox's LocalPartition requires every source to share one output RowType,
+  // so each leg must produce the union's output columns (same names, same
+  // order). Emit that aligning projection here -- like the pre-projections for
+  // aggregates/joins -- rather than at emit, folding it into a deterministic
+  // child Project so a coercion leg (e.g. VALUES needing a cast) does not stack
+  // two Projects. For a leg already isolated behind a remote exchange, the
+  // rename lands on the exchange's consumer side; moving it below the exchange
+  // is future work.
+  const ColumnVector& outputColumns = unionAll->outputColumns();
+  NodeVector newInputs;
+  newInputs.reserve(unionAll->inputs().size());
+  QGVector<ColumnVector> newLegColumns;
+  newLegColumns.reserve(unionAll->inputs().size());
+  bool changed = false;
+  for (size_t i = 0; i < unionAll->inputs().size(); ++i) {
+    NodeCP input = rewrite(unionAll->inputs()[i], context);
+    const ColumnVector& legCols = unionAll->legColumns()[i];
+
+    // Already aligned: the leg produces exactly legCols in order and each
+    // carries the union's output name (so its type matches too).
+    bool aligned = input->outputColumns().size() == legCols.size();
+    for (size_t k = 0; aligned && k < legCols.size(); ++k) {
+      aligned = input->outputColumns()[k] == legCols[k] &&
+          legCols[k]->outputName() == outputColumns[k]->outputName();
+    }
+    if (aligned) {
+      changed |= input != unionAll->inputs()[i];
+      newInputs.push_back(input);
+      newLegColumns.push_back(legCols);
+      continue;
+    }
+
+    // Rename legCols to fresh columns carrying the union's output names.
+    ExprVector exprs(legCols.begin(), legCols.end());
+    ColumnVector projectColumns;
+    projectColumns.reserve(outputColumns.size());
+    for (ColumnCP column : outputColumns) {
+      projectColumns.push_back(
+          Column::createForSymbol(
+              toName(column->outputName()), column->value()));
+    }
+    newInputs.push_back(
+        makeProject(input, std::move(exprs), projectColumns, builder()));
+    newLegColumns.push_back(std::move(projectColumns));
+    changed = true;
+  }
+  if (!changed) {
+    return unionAll;
+  }
+  return builder().make<UnionAll>(
+      {std::move(newInputs), std::move(newLegColumns), outputColumns});
 }
 
 } // namespace

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1791,10 +1791,31 @@ Translated Translator::buildUnionAll(
     const std::vector<lp::LogicalPlanNodePtr>& inputs,
     const velox::RowTypePtr& outputType,
     const LpNameSet& required) {
+  // Flatten nested UNION ALL into one N-way union: a leg that is itself a UNION
+  // ALL contributes its own legs directly. Legs align positionally with the
+  // union's outputType at every level, so a flattened leg maps to the same kept
+  // positions as a direct one.
+  std::vector<lp::LogicalPlanNodePtr> flatInputs;
+  std::function<void(const lp::LogicalPlanNodePtr&)> collect =
+      [&](const lp::LogicalPlanNodePtr& node) {
+        if (node->kind() == lp::NodeKind::kSet &&
+            node->as<lp::SetNode>()->operation() ==
+                lp::SetOperation::kUnionAll) {
+          for (const auto& child : node->inputs()) {
+            collect(child);
+          }
+        } else {
+          flatInputs.push_back(node);
+        }
+      };
+  for (const auto& in : inputs) {
+    collect(in);
+  }
+
   NodeVector inputNodes;
-  inputNodes.reserve(inputs.size());
+  inputNodes.reserve(flatInputs.size());
   QGVector<ColumnVector> legColumns;
-  legColumns.reserve(inputs.size());
+  legColumns.reserve(flatInputs.size());
   // Union output positions parent doesn't require are dropped from the union
   // node entirely. Build a list of kept positions once and reuse it for every
   // leg's column mapping.
@@ -1805,7 +1826,7 @@ Translated Translator::buildUnionAll(
       keptPositions.push_back(j);
     }
   }
-  for (const auto& in : inputs) {
+  for (const auto& in : flatInputs) {
     // Each leg's required-set is the kept union output names, mapped to that
     // leg's positional outputType names (legs align 1:1 with the union's
     // outputType by SQL semantics).
@@ -1835,8 +1856,21 @@ Translated Translator::buildUnionAll(
   Scope scope;
   ColumnVector outputColumns;
   outputColumns.reserve(keptPositions.size());
-  for (size_t j : keptPositions) {
-    Value value(toType(outputType->childAt(j)));
+  for (size_t k = 0; k < keptPositions.size(); ++k) {
+    const size_t j = keptPositions[k];
+    // The union output NDV is the max of the legs' NDVs: a lower bound on the
+    // true union NDV (which can be up to their sum), order-independent, and
+    // known as long as any leg has an NDV. A known NDV lets the cost model rank
+    // a join on a union key instead of dropping it as uncostable.
+    std::optional<float> cardinality;
+    for (const auto& legCols : legColumns) {
+      const auto legNdv = legCols[k]->value().cardinality;
+      if (legNdv.has_value()) {
+        cardinality =
+            cardinality.has_value() ? std::max(*cardinality, *legNdv) : *legNdv;
+      }
+    }
+    Value value(toType(outputType->childAt(j)), cardinality);
     auto* column =
         Column::createForSymbol(toName(outputType->nameOf(j)), value);
     outputColumns.push_back(column);


### PR DESCRIPTION
Summary:

v2 planned every UNION ALL by isolating each leg behind an arbitrary exchange and gathering the legs into a single-task fragment, so every row funneled through one node before any downstream operator. `(FROM a UNION ALL FROM b) JOIN c` gathered both scans onto one task and then re-shuffled to the parallel join. Now parallel legs (scans, distincts) co-locate in one fragment and run in parallel; only single-task legs (Values, global aggregate) are isolated, and several of them are grouped into one sub-union behind a single arbitrary exchange.

Supporting fixes to v2 UNION ALL planning:
- Flatten nested UNION ALL into one N-way union.
- Derive a union column's NDV as the max of its legs' NDVs (in both optimizers), so a join on a union key is costable and its build side is chosen by cost rather than left syntactic.
- Treat standard-hash legs, not only connector-bucketed ones, as co-partitioned, so `(DISTINCT a UNION ALL DISTINCT b) GROUP BY a` needs no extra shuffle.
- Fold a leg's type-coercion cast into the union output projection instead of stacking a second Project.

`emitUnionAll` is reduced to a plain gather over the emitted legs; per-leg output alignment now lives in the passes — leg projections in `PrecomputeProjectionsPass`, distribution in `PlanPhysicalPass`. The gather still trims the filter-only columns a scan leaks for a rejected filter, as the query root already does.

`UnionAllTest` now runs under both optimizers; `PlanMatcher` gained a per-fragment type assertion carried on shuffle boundaries and an `output()` assertion for the root fragment.

Differential Revision: D113809366
