### PR TITLE
feat(v2): Schedule coordinator-only scans on coordinator (#1662)

### DIFF
--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -593,6 +593,15 @@ class TableLayout {
     return false;
   }
 
+  /// True if a scan of this layout must run as a single task on the coordinator
+  /// node, because the layout's data exists only there -- e.g. process-local
+  /// system tables (active queries, session properties) or metadata tables read
+  /// from a coordinator-only source. Default false: an ordinary layout scans in
+  /// parallel on any worker.
+  virtual bool runsOnCoordinator() const {
+    return false;
+  }
+
   /// The columns and their names as a RowType.
   const velox::RowTypePtr& rowType() const {
     return rowType_;

--- a/axiom/connectors/system/SystemConnectorMetadata.h
+++ b/axiom/connectors/system/SystemConnectorMetadata.h
@@ -54,6 +54,10 @@ class SystemTableLayout : public TableLayout {
     return false;
   }
 
+  bool runsOnCoordinator() const override {
+    return true;
+  }
+
   velox::connector::ColumnHandlePtr createColumnHandle(
       const ConnectorSessionPtr& session,
       const std::string& columnName,

--- a/axiom/connectors/system/tests/CMakeLists.txt
+++ b/axiom/connectors/system/tests/CMakeLists.txt
@@ -14,6 +14,7 @@
 
 add_executable(
   axiom_system_connector_test
+  CoordinatorSchedulingTest.cpp
   SystemConnectorMetadataTest.cpp
   SystemConnectorSerDeTest.cpp
 )
@@ -24,9 +25,13 @@ target_link_libraries(
   axiom_system_connector_test
   axiom_system_connector
   axiom_connectors
+  axiom_optimizer_tests_query_test_base
+  axiom_optimizer_tests_plan_matcher
+  axiom_runner_tests_utils
   velox_connector
   velox_exec
   velox_exec_test_lib
+  velox_dwio_common_test_utils
   velox_expression
   velox_function_registry
   velox_vector_test_lib

--- a/axiom/connectors/system/tests/CoordinatorSchedulingTest.cpp
+++ b/axiom/connectors/system/tests/CoordinatorSchedulingTest.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "axiom/connectors/ConnectorMetadataRegistry.h"
+#include "axiom/connectors/system/SystemConnector.h"
+#include "axiom/connectors/system/SystemConnectorMetadata.h"
+#include "axiom/optimizer/MultiFragmentPlan.h"
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+#include "velox/connectors/Connector.h"
+
+namespace facebook::axiom {
+namespace {
+
+using optimizer::FragmentType;
+using velox::core::PlanMatcherBuilder;
+
+// Empty providers: these plan-shape tests only resolve the table layout and
+// inspect the produced fragments; they never read query or session data.
+class EmptyQueryInfoProvider : public connector::system::QueryInfoProvider {
+ public:
+  std::vector<connector::system::QueryInfo> getQueryInfos() const override {
+    return {};
+  }
+};
+
+class EmptySessionPropertiesProvider
+    : public connector::system::SessionPropertiesProvider {
+ public:
+  std::vector<connector::system::SessionPropertyInfo> getSessionProperties()
+      const override {
+    return {};
+  }
+};
+
+class CoordinatorSchedulingTest : public optimizer::test::QueryTestBase {
+ protected:
+  static constexpr auto kSystemConnectorId = "testsystem";
+
+  CoordinatorSchedulingTest() {
+    useV2_ = true;
+  }
+
+  void SetUp() override {
+    optimizer::test::QueryTestBase::SetUp();
+
+    systemConnector_ = std::make_shared<connector::system::SystemConnector>(
+        kSystemConnectorId, &queryProvider_, &sessionProvider_);
+    velox::connector::registerConnector(systemConnector_);
+
+    systemMetadata_ =
+        std::make_shared<connector::system::SystemConnectorMetadata>(
+            systemConnector_.get());
+    connector::ConnectorMetadataRegistry::global().insert(
+        kSystemConnectorId, systemMetadata_);
+  }
+
+  void TearDown() override {
+    connector::ConnectorMetadataRegistry::global().erase(kSystemConnectorId);
+    systemMetadata_.reset();
+
+    velox::connector::unregisterConnector(kSystemConnectorId);
+    systemConnector_.reset();
+
+    optimizer::test::QueryTestBase::TearDown();
+  }
+
+  logical_plan::LogicalPlanNodePtr parseSelect(std::string_view sql) {
+    return optimizer::test::QueryTestBase::parseSelect(sql, kSystemConnectorId);
+  }
+
+  EmptyQueryInfoProvider queryProvider_;
+  EmptySessionPropertiesProvider sessionProvider_;
+  std::shared_ptr<connector::system::SystemConnector> systemConnector_;
+  std::shared_ptr<connector::system::SystemConnectorMetadata> systemMetadata_;
+};
+
+// A scan of a coordinator-only system table is planned as a single coordinator
+// fragment, even with multiple workers available.
+TEST_F(CoordinatorSchedulingTest, scan) {
+  auto logicalPlan = parseSelect("SELECT query_id FROM runtime.queries");
+  auto plan = planVelox(logicalPlan).plan;
+
+  auto matcher = PlanMatcherBuilder()
+                     .tableScan("runtime.queries")
+                     .output(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
+}
+
+// A global aggregation over a system table runs entirely on the coordinator:
+// the partial/final split is local (across drivers), never a cross-node
+// shuffle.
+TEST_F(CoordinatorSchedulingTest, globalAggregation) {
+  auto logicalPlan = parseSelect("SELECT count(*) FROM runtime.queries");
+  auto plan = planVelox(logicalPlan).plan;
+
+  auto matcher = PlanMatcherBuilder()
+                     .tableScan("runtime.queries")
+                     .partialAggregation()
+                     .localGather()
+                     .finalAggregation()
+                     .output(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
+}
+
+// A union of a system table and inline values pools both single-task legs into
+// one coordinator fragment.
+TEST_F(CoordinatorSchedulingTest, unionWithValues) {
+  auto logicalPlan = parseSelect(
+      "SELECT query_id FROM runtime.queries "
+      "UNION ALL "
+      "SELECT c FROM (VALUES ('x')) AS _(c)");
+  auto plan = planVelox(logicalPlan).plan;
+
+  auto matcher = PlanMatcherBuilder()
+                     .tableScan("runtime.queries")
+                     .localPartition(matchValues().project().build())
+                     .output(FragmentType::kCoordinator)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
+}
+
+// A union of a system table and an ordinary table isolates the system leg into
+// its own coordinator fragment; the ordinary leg keeps parallel workers.
+TEST_F(CoordinatorSchedulingTest, unionWithRegular) {
+  auto logicalPlan = parseSelect(
+      "SELECT query_id FROM runtime.queries "
+      "UNION ALL "
+      "SELECT n_name FROM test.default.nation");
+  auto plan = planVelox(logicalPlan).plan;
+
+  auto matcher = PlanMatcherBuilder()
+                     .tableScan("\"default\".\"nation\"")
+                     .project()
+                     .localPartition(
+                         PlanMatcherBuilder()
+                             .tableScan("runtime.queries")
+                             .arbitrary(FragmentType::kCoordinator)
+                             .build())
+                     .gather(FragmentType::kSource)
+                     .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(plan, matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom

--- a/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
+++ b/axiom/connectors/system/tests/SystemConnectorMetadataTest.cpp
@@ -35,7 +35,7 @@ namespace {
 
 // Test functions for the system.metadata.functions table.
 
-// toss() -> boolean. Non-deterministic coin toss.
+// __toss() -> boolean. Non-deterministic coin toss.
 template <typename T>
 struct TossFunction {
   static constexpr bool is_deterministic = false;
@@ -45,7 +45,8 @@ struct TossFunction {
   }
 };
 
-// roll() -> integer and roll(integer) -> integer. Non-deterministic dice roll.
+// __roll() -> integer and __roll(integer) -> integer. Non-deterministic dice
+// roll.
 template <typename T>
 struct RollFunction {
   static constexpr bool is_deterministic = false;
@@ -55,7 +56,7 @@ struct RollFunction {
   }
 };
 
-// plus(integer, integer, ...) -> integer and plus(real, real, ...) -> real.
+// __plus(integer, integer, ...) -> integer and __plus(real, real, ...) -> real.
 // Variadic addition.
 template <typename TExec>
 struct PlusFunction {
@@ -84,21 +85,21 @@ void registerTestFunctions() {
   }
   kRegistered = true;
 
-  velox::registerFunction<TossFunction, bool>({"toss"});
-  velox::registerFunction<RollFunction, int32_t>({"roll"});
-  velox::registerFunction<RollFunction, int32_t, int32_t>({"roll"});
+  velox::registerFunction<TossFunction, bool>({"__toss"});
+  velox::registerFunction<RollFunction, int32_t>({"__roll"});
+  velox::registerFunction<RollFunction, int32_t, int32_t>({"__roll"});
   velox::registerFunction<
       PlusFunction,
       int32_t,
       int32_t,
       int32_t,
-      velox::Variadic<int32_t>>({"plus"});
+      velox::Variadic<int32_t>>({"__plus"});
   velox::registerFunction<
       PlusFunction,
       float,
       float,
       float,
-      velox::Variadic<float>>({"plus"});
+      velox::Variadic<float>>({"__plus"});
 }
 
 const char* const kSystemCatalog = "test-system";
@@ -555,6 +556,34 @@ TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
   auto actual = readTable(kFunctionsTable, functionsTableSchema());
   ASSERT_NE(actual, nullptr);
 
+  // The functions table lists every registered function; keep only the ones
+  // this test registered so the assertion does not depend on the global
+  // registry (the test binary may link many other functions).
+  const auto& nameColumn = actual->childAt(0);
+  velox::BufferPtr indices =
+      velox::allocateIndices(actual->size(), pool_.get());
+  auto* rawIndices = indices->asMutable<velox::vector_size_t>();
+  velox::vector_size_t numMatched = 0;
+  for (velox::vector_size_t i = 0; i < actual->size(); ++i) {
+    const auto name = nameColumn->variantAt(i).value<std::string>();
+    if (name == "__plus" || name == "__roll" || name == "__toss") {
+      rawIndices[numMatched++] = i;
+    }
+  }
+  std::vector<velox::VectorPtr> matchedChildren;
+  matchedChildren.reserve(actual->childrenSize());
+  for (const auto& child : actual->children()) {
+    matchedChildren.push_back(
+        velox::BaseVector::wrapInDictionary(
+            /*nulls=*/nullptr, indices, numMatched, child));
+  }
+  actual = std::make_shared<velox::RowVector>(
+      pool_.get(),
+      actual->type(),
+      /*nulls=*/nullptr,
+      numMatched,
+      std::move(matchedChildren));
+
   folly::json::serialization_opts opts;
   opts.sort_keys = true;
   auto kDeterministic = folly::json::serialize(
@@ -570,9 +599,9 @@ TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
       velox::BaseVector::createFromVariants(
           functionsTableSchema(),
           {
-              // plus(integer, integer, integer...) -> integer.
+              // __plus(integer, integer, integer...) -> integer.
               velox::Variant::row({
-                  "plus",
+                  "__plus",
                   "scalar",
                   "integer",
                   velox::Variant::array({"integer", "integer", "integer"}),
@@ -580,9 +609,9 @@ TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
                   "",
                   kDeterministic,
               }),
-              // plus(real, real, real...) -> real.
+              // __plus(real, real, real...) -> real.
               velox::Variant::row({
-                  "plus",
+                  "__plus",
                   "scalar",
                   "real",
                   velox::Variant::array({"real", "real", "real"}),
@@ -590,9 +619,9 @@ TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
                   "",
                   kDeterministic,
               }),
-              // roll() -> integer.
+              // __roll() -> integer.
               velox::Variant::row({
-                  "roll",
+                  "__roll",
                   "scalar",
                   "integer",
                   velox::Variant::array({}),
@@ -600,9 +629,9 @@ TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
                   "",
                   kNonDeterministic,
               }),
-              // roll(integer) -> integer.
+              // __roll(integer) -> integer.
               velox::Variant::row({
-                  "roll",
+                  "__roll",
                   "scalar",
                   "integer",
                   velox::Variant::array({"integer"}),
@@ -610,9 +639,9 @@ TEST_F(SystemConnectorMetadataTest, functionsDataSource) {
                   "",
                   kNonDeterministic,
               }),
-              // toss() -> boolean.
+              // __toss() -> boolean.
               velox::Variant::row({
-                  "toss",
+                  "__toss",
                   "scalar",
                   "boolean",
                   velox::Variant::array({}),

--- a/axiom/optimizer/QueryGraph.cpp
+++ b/axiom/optimizer/QueryGraph.cpp
@@ -556,6 +556,15 @@ PathSet BaseTable::columnSubfields(int32_t id) const {
   return subfields;
 }
 
+const connector::TableLayout* BaseTable::layout() const {
+  VELOX_CHECK_NOT_NULL(schemaTable);
+  VELOX_CHECK(!schemaTable->columnGroups.empty());
+
+  const auto* layout = schemaTable->columnGroups[0]->layout;
+  VELOX_CHECK_NOT_NULL(layout);
+  return layout;
+}
+
 std::string BaseTable::toString() const {
   std::stringstream out;
   out << "{" << PlanObject::toString();

--- a/axiom/optimizer/QueryGraph.h
+++ b/axiom/optimizer/QueryGraph.h
@@ -1183,6 +1183,11 @@ struct BaseTable : public TableObject {
     return {schemaTable->columnGroups[0]};
   }
 
+  /// The connector table layout backing this scan. A BaseTable always has
+  /// backing, so the schema table, its first column group, and the layout are
+  /// all present.
+  const connector::TableLayout* layout() const;
+
   std::string toString() const override;
 };
 

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(axiom_optimizer_tests_query_test_base QueryTestBase.cpp)
 target_link_libraries(
   axiom_optimizer_tests_query_test_base
   axiom_optimizer
+  axiom_optimizer_v2
   axiom_sql_presto_parser
   axiom_test_connector
   velox_tpch_gen

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -602,19 +602,6 @@ void collectInputColumnNames(
   collectInputColumnNamesImpl(expr, names, /*boundNames=*/{});
 }
 
-// The connector partitioning of a scan's table, or null when the table is not
-// bucketed. A property of the table layout, independent of which columns the
-// scan projects: a bucketed table runs grouped even when its bucket column is
-// pruned from the output.
-const connector::PartitionType* tablePartitionType(const Scan& scan) {
-  const auto* schemaTable = scan.baseTable()->schemaTable;
-  if (schemaTable == nullptr || schemaTable->columnGroups.empty()) {
-    return nullptr;
-  }
-  const connector::TableLayout* layout = schemaTable->columnGroups[0]->layout;
-  return layout != nullptr ? layout->partitionType().get() : nullptr;
-}
-
 velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
   // The read schema is the consumer output columns followed by the filter-only
   // columns, with columnHandles aligned to that order. Consumer columns keep
@@ -673,8 +660,10 @@ velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
       std::move(assignments));
 
   // A scan of a bucketed table is a grouped leaf: it runs per bucket-group
-  // under grouped execution, tagging the fragment as bucketed.
-  if (const auto* partitionType = tablePartitionType(scan)) {
+  // under grouped execution, tagging the fragment as bucketed. The layout's
+  // partition type is null when the table is not bucketed.
+  if (const auto* partitionType =
+          scan.baseTable()->layout()->partitionType().get()) {
     groupedLeaves_.push_back({scanNode->id(), partitionType});
   }
 
@@ -1635,8 +1624,11 @@ velox::core::PlanNodePtr Emitter::emitEnforceDistinct(
 }
 
 // Merges two fragment-type contributions: a kSource and a kFixed coexist as
-// kFixed (split-driven scans feeding a fixed-width stage); equal types merge to
-// themselves; nullopt is "no constraint".
+// kFixed (split-driven scans feeding a fixed-width stage); a kCoordinator
+// pooled with single-task work stays kCoordinator (coordinator dominates
+// single); equal types merge to themselves; nullopt is "no constraint". A
+// kCoordinator with a parallel source (kSource/kFixed) is an invariant
+// violation.
 std::optional<FragmentType> mergeFragmentTypes(
     std::optional<FragmentType> lhs,
     std::optional<FragmentType> rhs) {
@@ -1653,6 +1645,10 @@ std::optional<FragmentType> mergeFragmentTypes(
       (*lhs == FragmentType::kFixed && *rhs == FragmentType::kSource)) {
     return FragmentType::kFixed;
   }
+  if ((*lhs == FragmentType::kCoordinator && *rhs == FragmentType::kSingle) ||
+      (*lhs == FragmentType::kSingle && *rhs == FragmentType::kCoordinator)) {
+    return FragmentType::kCoordinator;
+  }
   VELOX_FAIL(
       "Incompatible fragment-type contributions in one fragment: {} + {}",
       *lhs,
@@ -1662,7 +1658,8 @@ std::optional<FragmentType> mergeFragmentTypes(
 // The fragment type the subtree at 'node' contributes, walking down to (not
 // across) inner exchanges. An exchange yields its consumer-side type
 // (partitioned → kFixed, gather → kSingle, broadcast/arbitrary → no
-// constraint); a scan yields kSource.
+// constraint); a scan yields kSource, or kCoordinator when it reads a
+// coordinator-only layout.
 std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
   if (node->is(NodeType::kExchange)) {
     switch (node->as<Exchange>()->partitioning().kind) {
@@ -1678,7 +1675,9 @@ std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
   }
   switch (node->nodeType()) {
     case NodeType::kScan:
-      return FragmentType::kSource;
+      return node->as<Scan>()->baseTable()->layout()->runsOnCoordinator()
+          ? FragmentType::kCoordinator
+          : FragmentType::kSource;
     case NodeType::kValues:
       return FragmentType::kSingle;
     default: {
@@ -1691,24 +1690,35 @@ std::optional<FragmentType> fragmentTypeContribution(NodeCP node) {
   }
 }
 
-// Sets 'fragment.type' (and 'width' for kFixed) from the contents at 'node'. At
-// numWorkers == 1 all parallelism collapses to one task. A fragment with no
-// split source (no scan; only exchanges and/or values below) is single-task
-// regardless of its output partitioning: kSource requires connector splits to
-// drive its task count, so the fallback is kSingle, not kSource.
+// Sets 'fragment.type' (and 'width' for kFixed) from an already-computed root
+// 'contribution'. At numWorkers == 1 all parallelism collapses to one task. A
+// nullopt contribution (no split source below -- no scan, only exchanges and/or
+// values) is single-task regardless of output partitioning: kSource requires
+// connector splits to drive its task count, so the fallback is kSingle.
 void decideFragmentType(
-    NodeCP node,
+    std::optional<FragmentType> contribution,
     int32_t numWorkers,
     ExecutableFragment& fragment) {
   if (numWorkers == 1) {
     fragment.type = FragmentType::kSingle;
     return;
   }
-  fragment.type =
-      fragmentTypeContribution(node).value_or(FragmentType::kSingle);
+  fragment.type = contribution.value_or(FragmentType::kSingle);
   if (fragment.type == FragmentType::kFixed) {
     fragment.width = numWorkers;
   }
+}
+
+// Computes 'node's contribution with fragmentTypeContribution -- walking down
+// to, not across, inner exchanges -- and sets the fragment type from it.
+void decideFragmentType(
+    NodeCP node,
+    int32_t numWorkers,
+    ExecutableFragment& fragment) {
+  decideFragmentType(
+      numWorkers == 1 ? std::nullopt : fragmentTypeContribution(node),
+      numWorkers,
+      fragment);
 }
 
 void Emitter::finalizeGroupedLeaves(ExecutableFragment& fragment) {
@@ -2094,20 +2104,28 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
       top.fragment.planNode = writePlan;
     }
   } else {
-    // A root whose subtree already runs on one task (e.g. below a global ORDER
-    // BY or aggregate) needs no output gather and is emitted directly, like the
-    // single-node case. Only a multi-task root is gathered to a single task for
-    // the query output.
+    // A root whose subtree already runs on one task needs no output gather and
+    // is emitted directly, like the single-node case: below a global ORDER BY
+    // or aggregate (kSingle), or a coordinator-only scan (kCoordinator). Only a
+    // multi-task root is gathered to a single task for the query output.
+    // The root's fragment-type contribution drives both the output-gather
+    // decision and the root fragment's type; compute it once and reuse it.
+    std::optional<FragmentType> rootType;
+    if (options_.numWorkers > 1) {
+      rootType = fragmentTypeContribution(root);
+    }
     const bool gatherForOutput = options_.numWorkers > 1 &&
-        fragmentTypeContribution(root) != FragmentType::kSingle;
+        rootType != FragmentType::kSingle &&
+        rootType != FragmentType::kCoordinator;
 
     if (options_.remoteOutput) {
       // Results stay distributed: emit the root as a single fragment capped by
       // a PartitionedOutput for remote consumption, with no gather consumer
       // fragment. The fragment type follows the root's contents (kFixed for a
-      // multi-worker source, kSingle at numWorkers == 1).
+      // multi-worker source, kCoordinator for a coordinator-only scan, kSingle
+      // at numWorkers == 1 or when there is no split source below).
       currentFragment_ = &top;
-      decideFragmentType(root, options_.numWorkers, top);
+      decideFragmentType(rootType, options_.numWorkers, top);
       outputProjection = emitRoot(root, outputColumns, outputNames);
       top.fragment.planNode =
           makeSingleOutput(outputProjection->outputType(), outputProjection);
@@ -2115,6 +2133,7 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
       emitGatheredOutput(root, outputColumns, outputNames, top);
     } else {
       currentFragment_ = &top;
+      decideFragmentType(rootType, options_.numWorkers, top);
       top.fragment.planNode = emitRoot(root, outputColumns, outputNames);
     }
   }

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -441,13 +441,13 @@ Partitioning aggregateGlobalPartition(
 // a partition column is not in the scan's output (so the partitioning can't be
 // expressed over the output).
 Partitioning scanGlobalPartition(const Scan::Key& key) {
-  const auto* schemaTable = key.baseTable->schemaTable;
-  if (schemaTable == nullptr || schemaTable->columnGroups.empty()) {
-    return {};
-  }
-  const connector::TableLayout* layout = schemaTable->columnGroups[0]->layout;
-  if (layout == nullptr) {
-    return {};
+  const connector::TableLayout* layout = key.baseTable->layout();
+  // A coordinator-only layout's data lives solely on the coordinator, so its
+  // scan produces a single partition there. Model that as a gather (single
+  // partition, like Values); the coordinator placement itself is a separate
+  // leaf fact read at fragment-typing time.
+  if (layout->runsOnCoordinator()) {
+    return Partitioning::globalGather();
   }
   const auto partitionType = layout->partitionType();
   const auto& partitionColumns = layout->partitionColumns();


### PR DESCRIPTION
Summary:

Some tables can only be scanned on the coordinator, because their data lives solely there — for example system tables exposing active queries or session properties. v2 had no way to express this, so it planned such scans as ordinary parallel worker scans. This adds a `TableLayout::runsOnCoordinator()` flag; a layout that returns true is scanned as a single task on the coordinator.

The placement is modeled as a leaf fact. A coordinator-only layout's scan produces a single gather partition, like `Values`. At fragment typing, such a scan contributes a new `kCoordinator` fragment type — previously defined but never produced. It pools with single-task work in the same fragment. Mixing it with a parallel source is an invariant violation. A coordinator-rooted plan already runs on one task, so it is emitted directly with no output gather.

The distributed runner must still honor `kCoordinator` by pinning the fragment's task to the coordinator. Today only the single-node runner consumes the plan, where `kCoordinator` is equivalent to `kSingle`.

Reviewed By: xiaoxmeng, amitkdutta

Differential Revision: D113809367
