### PR TITLE
build(common): Add TrackedExecutor to the axiom_common CMake library

### DIFF
--- a/axiom/common/CMakeLists.txt
+++ b/axiom/common/CMakeLists.txt
@@ -26,6 +26,7 @@ add_library(
   SchemaTableName.cpp
   SchemaTypeName.cpp
   SessionConfig.cpp
+  TrackedExecutor.cpp
 )
 
 target_link_libraries(axiom_common velox_common_base velox_config_property Folly::folly)

--- a/axiom/common/tests/CMakeLists.txt
+++ b/axiom/common/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(
   QueryRuntimeStatsTest.cpp
   SchemaTableNameTest.cpp
   SessionConfigTest.cpp
+  TrackedExecutorTest.cpp
 )
 
 add_test(axiom_common_tests axiom_common_tests)


### PR DESCRIPTION
Summary:
`TrackedExecutor.cpp` is built by Buck but was missing from the `axiom_common`
CMake library, so it is compiled nowhere in the CMake build. Downstream CMake
consumers (e.g. axel) then fail to link with undefined references to
`TrackedExecutor::wrapFunc`, `TrackedExecutor::reportTo`, and
`TrackedExecutor::Metrics::Metrics`. Add the source to `axiom_common` (which
already provides `QueryRuntimeStats`, used by `TrackedExecutor::reportTo`).

Also wire `TrackedExecutorTest.cpp` into the `axiom_common_tests` CMake target
(same drift: Buck has `tracked_executor_test`, CMake omitted it) so axiom's own
CMake build exercises it.

Reviewed By: natashasehgal

Differential Revision: D114169138
