### PR TITLE
fix(parser): Extract windows from ORDER BY over GROUP BY (#1667)

### DIFF
--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -201,6 +201,19 @@ SELECT a, c FROM t ORDER BY c / sum(c) OVER () DESC
 -- ordered
 SELECT DISTINCT c / sum(c) OVER () AS s FROM t ORDER BY c / sum(c) OVER ()
 ----
+-- ORDER BY a window nested in an expression over a GROUP BY, where the
+-- expression is not in the SELECT list.
+-- ordered
+SELECT a, sum(b) FROM t GROUP BY a ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC
+----
+-- Same nested window over a GROUP BY, but the ORDER BY expression also appears
+-- in the SELECT list.
+-- ordered
+SELECT a, sum(b) * 1.0 / sum(sum(b)) OVER () AS share
+FROM t
+GROUP BY a
+ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC
+----
 -- A window whose ORDER BY key is an aggregate and whose frame is a RANGE
 -- offset, over a GROUP BY.
 -- ordered

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -759,18 +759,30 @@ void GroupByPlanner::projectNestedWindows(
   std::vector<const core::IExpr*> windowOrder;
   ExpressionPlanner::findNestedWindowExprs(
       projections_, windowExprPtrs, windowOrder);
+  ExpressionPlanner::findNestedWindowExprs(
+      sortingKeyExprs_, windowExprPtrs, windowOrder);
 
   if (windowOrder.empty()) {
     return;
   }
 
+  // Deduplicate structurally-identical windows so a window that appears in both
+  // a SELECT item and an ORDER BY expression is computed once.
+  ExprMap<size_t> columnByWindow;
   std::vector<lp::ExprApi> windowExprs;
-  windowExprs.reserve(windowOrder.size());
+  std::vector<size_t> columnOfWindow;
+  columnOfWindow.reserve(windowOrder.size());
   for (const auto* exprPtr : windowOrder) {
-    // Rewrite aggregate references in function arguments, partition keys,
-    // and order by keys.
-    windowExprs.push_back(rewriteWindowExpr(
-        lp::ExprApi(windowExprPtrs.at(exprPtr)), rewriteIExpr));
+    const auto& windowExpr = windowExprPtrs.at(exprPtr);
+    auto [it, inserted] =
+        columnByWindow.emplace(windowExpr, windowExprs.size());
+    if (inserted) {
+      // Rewrite aggregate references in function arguments, partition keys,
+      // and order by keys.
+      windowExprs.push_back(
+          rewriteWindowExpr(lp::ExprApi(windowExpr), rewriteIExpr));
+    }
+    columnOfWindow.push_back(it->second);
   }
 
   builder_->with(windowExprs);
@@ -778,9 +790,9 @@ void GroupByPlanner::projectNestedWindows(
   auto outputColumns =
       builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
 
-  auto numInputColumns = outputColumns.size() - windowOrder.size();
+  auto numInputColumns = outputColumns.size() - windowExprs.size();
   for (size_t i = 0; i < windowOrder.size(); ++i) {
-    const auto& column = outputColumns.at(numInputColumns + i);
+    const auto& column = outputColumns.at(numInputColumns + columnOfWindow[i]);
     keyInputs.emplace(windowExprPtrs.at(windowOrder[i]), column.toCol().expr());
   }
 }

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -1172,6 +1172,31 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
           .project({"b", "sum::double * 1.0 / expr::double"})
           .output());
 
+  // Window nested inside an arithmetic expression in ORDER BY over a GROUP BY,
+  // where the expression is not in the SELECT list.
+  testSelect(
+      "SELECT a, sum(b) FROM t GROUP BY a "
+      "ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b) as total"})
+          .project({"a", "total", "sum(total) OVER () as win"})
+          .project({"a", "total", "total::double * 1.0 / win::double"})
+          .sort()
+          .project({"a", "total"})
+          .output());
+
+  // The same nested window appears in both the SELECT list and the ORDER BY
+  // expression. It is projected as a single window column shared by both.
+  testSelect(
+      "SELECT a, sum(b) * 1.0 / sum(sum(b)) OVER () AS share FROM t GROUP BY a "
+      "ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b) as total"})
+          .project({"a", "total", "sum(total) OVER () as win"})
+          .project({"a", "total::double * 1.0 / win::double as share"})
+          .sort()
+          .output({"a", "share"}));
+
   // Same as above but with PARTITION BY in the nested window function.
   testSelect(
       "SELECT b, sum(a) * 1.0 / sum(sum(a)) OVER (PARTITION BY b) FROM t GROUP BY b",

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -349,7 +349,9 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
     EXPECT_EQ(numExprs, plan.expressions().size());
     AXIOM_RETURN_IF_FAILURE;
 
-    std::unordered_map<std::string, std::string> newSymbols;
+    // Inherit aliases captured below so a name bound at a descendant (e.g. an
+    // aggregate output) stays resolvable above this projection.
+    std::unordered_map<std::string, std::string> newSymbols = symbols;
     velox::parse::ParseOptions parseOptions;
     parseOptions.correctWindowFrameDefault = true;
     velox::parse::DuckSqlExpressionsParser parser(parseOptions);


### PR DESCRIPTION
Summary:

A window function nested inside a scalar expression in an ORDER BY key, over a GROUP BY, failed to plan. For example:

    SELECT a, sum(b) FROM t GROUP BY a
    ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC

failed with:

    Scalar function doesn't exist: sum

The GROUP BY planner extracted nested window functions only from the SELECT list, never from ORDER BY keys. An ORDER BY expression like the one above kept its raw window node, so its inner aggregate `sum` was later resolved as a scalar function and rejected. The planner now extracts nested windows from ORDER BY keys as well, and a window that appears in both the SELECT list and ORDER BY is projected once and shared.

Also fixes the logical-plan test matcher: a projection now inherits the aliases bound by its input, so a name captured at a descendant (such as an aggregate output) stays resolvable in matcher steps above the projection.

Reviewed By: xiaoxmeng

Differential Revision: D114287536
