### PR TITLE
fix(parser): Reject misplaced aggregate with a clear error

### DIFF
--- a/axiom/logical_plan/ExprResolver.cpp
+++ b/axiom/logical_plan/ExprResolver.cpp
@@ -878,6 +878,14 @@ ExprPtr ExprResolver::resolveSqlFunction(
 ExprPtr ExprResolver::resolveScalarTypes(
     const velox::core::ExprPtr& expr,
     const InputNameResolver& inputNameResolver) const {
+  // An aggregate reaching scalar resolution is misplaced (e.g. in a WHERE
+  // predicate).
+  if (expr->is(velox::core::IExpr::Kind::kAggregate)) {
+    VELOX_USER_FAIL(
+        "Aggregate function is not allowed here: {}",
+        expr->as<velox::core::AggregateCallExpr>()->name());
+  }
+
   if (const auto* fieldAccess =
           dynamic_cast<const velox::core::FieldAccessExpr*>(expr.get())) {
     const auto& name = fieldAccess->name();

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -201,6 +201,19 @@ SELECT a, c FROM t ORDER BY c / sum(c) OVER () DESC
 -- ordered
 SELECT DISTINCT c / sum(c) OVER () AS s FROM t ORDER BY c / sum(c) OVER ()
 ----
+-- ORDER BY a window nested in an expression over a GROUP BY, where the
+-- expression is not in the SELECT list.
+-- ordered
+SELECT a, sum(b) FROM t GROUP BY a ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC
+----
+-- Same nested window over a GROUP BY, but the ORDER BY expression also appears
+-- in the SELECT list.
+-- ordered
+SELECT a, sum(b) * 1.0 / sum(sum(b)) OVER () AS share
+FROM t
+GROUP BY a
+ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC
+----
 -- A window whose ORDER BY key is an aggregate and whose frame is a RANGE
 -- offset, over a GROUP BY.
 -- ordered

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -759,18 +759,30 @@ void GroupByPlanner::projectNestedWindows(
   std::vector<const core::IExpr*> windowOrder;
   ExpressionPlanner::findNestedWindowExprs(
       projections_, windowExprPtrs, windowOrder);
+  ExpressionPlanner::findNestedWindowExprs(
+      sortingKeyExprs_, windowExprPtrs, windowOrder);
 
   if (windowOrder.empty()) {
     return;
   }
 
+  // Deduplicate structurally-identical windows so a window that appears in both
+  // a SELECT item and an ORDER BY expression is computed once.
+  ExprMap<size_t> columnByWindow;
   std::vector<lp::ExprApi> windowExprs;
-  windowExprs.reserve(windowOrder.size());
+  std::vector<size_t> columnOfWindow;
+  columnOfWindow.reserve(windowOrder.size());
   for (const auto* exprPtr : windowOrder) {
-    // Rewrite aggregate references in function arguments, partition keys,
-    // and order by keys.
-    windowExprs.push_back(rewriteWindowExpr(
-        lp::ExprApi(windowExprPtrs.at(exprPtr)), rewriteIExpr));
+    const auto& windowExpr = windowExprPtrs.at(exprPtr);
+    auto [it, inserted] =
+        columnByWindow.emplace(windowExpr, windowExprs.size());
+    if (inserted) {
+      // Rewrite aggregate references in function arguments, partition keys,
+      // and order by keys.
+      windowExprs.push_back(
+          rewriteWindowExpr(lp::ExprApi(windowExpr), rewriteIExpr));
+    }
+    columnOfWindow.push_back(it->second);
   }
 
   builder_->with(windowExprs);
@@ -778,9 +790,9 @@ void GroupByPlanner::projectNestedWindows(
   auto outputColumns =
       builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
 
-  auto numInputColumns = outputColumns.size() - windowOrder.size();
+  auto numInputColumns = outputColumns.size() - windowExprs.size();
   for (size_t i = 0; i < windowOrder.size(); ++i) {
-    const auto& column = outputColumns.at(numInputColumns + i);
+    const auto& column = outputColumns.at(numInputColumns + columnOfWindow[i]);
     keyInputs.emplace(windowExprPtrs.at(windowOrder[i]), column.toCol().expr());
   }
 }

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -195,6 +195,15 @@ TEST_F(AggregationParserTest, unsupportedOuterScopeAggregateRejected) {
       "Outer-scope aggregate could not be lifted.");
 }
 
+// An aggregate in a WHERE predicate is rejected: an aggregate cannot appear in
+// a filter.
+TEST_F(AggregationParserTest, outerScopeAggregateInFilterRejected) {
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT * FROM nation WHERE n_nationkey = (SELECT max(n_nationkey))"),
+      "Aggregate function is not allowed here");
+}
+
 TEST_F(AggregationParserTest, aggregateCoercions) {
   auto matcher = matchScan().aggregate().output();
 

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -1172,6 +1172,31 @@ TEST_F(AggregationParserTest, groupByWithWindowFunction) {
           .project({"b", "sum::double * 1.0 / expr::double"})
           .output());
 
+  // Window nested inside an arithmetic expression in ORDER BY over a GROUP BY,
+  // where the expression is not in the SELECT list.
+  testSelect(
+      "SELECT a, sum(b) FROM t GROUP BY a "
+      "ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b) as total"})
+          .project({"a", "total", "sum(total) OVER () as win"})
+          .project({"a", "total", "total::double * 1.0 / win::double"})
+          .sort()
+          .project({"a", "total"})
+          .output());
+
+  // The same nested window appears in both the SELECT list and the ORDER BY
+  // expression. It is projected as a single window column shared by both.
+  testSelect(
+      "SELECT a, sum(b) * 1.0 / sum(sum(b)) OVER () AS share FROM t GROUP BY a "
+      "ORDER BY sum(b) * 1.0 / sum(sum(b)) OVER () DESC",
+      matchScan("t")
+          .aggregate({"a"}, {"sum(b) as total"})
+          .project({"a", "total", "sum(total) OVER () as win"})
+          .project({"a", "total::double * 1.0 / win::double as share"})
+          .sort()
+          .output({"a", "share"}));
+
   // Same as above but with PARTITION BY in the nested window function.
   testSelect(
       "SELECT b, sum(a) * 1.0 / sum(sum(a)) OVER (PARTITION BY b) FROM t GROUP BY b",

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -349,7 +349,9 @@ class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
     EXPECT_EQ(numExprs, plan.expressions().size());
     AXIOM_RETURN_IF_FAILURE;
 
-    std::unordered_map<std::string, std::string> newSymbols;
+    // Inherit aliases captured below so a name bound at a descendant (e.g. an
+    // aggregate output) stays resolvable above this projection.
+    std::unordered_map<std::string, std::string> newSymbols = symbols;
     velox::parse::ParseOptions parseOptions;
     parseOptions.correctWindowFrameDefault = true;
     velox::parse::DuckSqlExpressionsParser parser(parseOptions);


### PR DESCRIPTION
Summary:
An aggregate that reaches scalar resolution — for example a pure-outer aggregate in a WHERE predicate:

    SELECT * FROM t WHERE x = (SELECT MAX(x))

failed with a misleading error:

    Scalar function doesn't exist: max

The aggregate was routed to scalar-function resolution and reported as a missing scalar function. Scalar resolution now rejects an aggregate up front with a clear message: `Aggregate function is not allowed here: max`. Presto and DuckDB also reject this shape.

Differential Revision: D114301981
