### PR TITLE
fix(planner): Allow relations to reuse an alias

### DIFF
--- a/axiom/connectors/ConnectorMetadata.cpp
+++ b/axiom/connectors/ConnectorMetadata.cpp
@@ -26,17 +26,31 @@ void applyFilterEstimates(
     const folly::F14FastMap<std::string, const velox::common::Filter*>&
         commonFilters,
     const velox::core::TypedExprPtr& remainingFilter,
+    const std::vector<const Column*>& columns,
     const FilterSelectivityEstimator& estimator,
     FilteredTableStats& stats) {
   if (stats.columnStats.empty()) {
     return;
   }
 
-  folly::F14FastMap<std::string, ColumnStatistics> columnStatsByName;
+  folly::F14FastMap<std::string, const velox::Type*> typeByName;
+  typeByName.reserve(columns.size());
+  for (const auto* column : columns) {
+    typeByName.emplace(column->name(), column->type().get());
+  }
+
+  folly::F14FastMap<std::string, TypedColumnStatistics> columnStatsByName;
   folly::F14FastMap<std::string, size_t> indexByName;
   for (size_t i = 0; i < stats.columnStats.size(); ++i) {
-    columnStatsByName.emplace(stats.columnStats[i].name, stats.columnStats[i]);
-    indexByName[stats.columnStats[i].name] = i;
+    const auto& columnStats = stats.columnStats[i];
+    auto typeIt = typeByName.find(columnStats.name);
+    VELOX_CHECK(
+        typeIt != typeByName.end(),
+        "Missing type for statistics column {}",
+        columnStats.name);
+    columnStatsByName.emplace(
+        columnStats.name, TypedColumnStatistics{typeIt->second, columnStats});
+    indexByName[columnStats.name] = i;
   }
 
   double selectivity = 1.0;

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -121,6 +121,16 @@ struct FilterEstimate {
   folly::F14FastMap<std::string, ColumnStatistics> columnStats;
 };
 
+/// A column's statistics paired with its type, keyed by column name and passed
+/// to FilterSelectivityEstimator::estimate. 'type' is authoritative (from the
+/// table schema), not inferred from the statistics: the estimator interprets
+/// min/max bounds and filter values as this type. Non-owning -- 'type' must
+/// outlive the estimate() call, which it does, as the caller holds the schema.
+struct TypedColumnStatistics {
+  const velox::Type* type;
+  ColumnStatistics stats;
+};
+
 /// Optional shared helper for estimating the selectivity and refined per-column
 /// statistics of a conjunction of filters from column statistics. Offered to
 /// TableLayout::co_estimateStats -- analogous to the ExpressionEvaluator
@@ -138,7 +148,7 @@ class FilterSelectivityEstimator {
   /// always a usable fraction.
   virtual FilterEstimate estimate(
       const std::vector<velox::core::TypedExprPtr>& filters,
-      const folly::F14FastMap<std::string, ColumnStatistics>& columnStats)
+      const folly::F14FastMap<std::string, TypedColumnStatistics>& columnStats)
       const = 0;
 
   /// Overload for connectors whose accepted filters are single-column
@@ -149,7 +159,7 @@ class FilterSelectivityEstimator {
   virtual FilterEstimate estimate(
       const folly::F14FastMap<std::string, const velox::common::Filter*>&
           filters,
-      const folly::F14FastMap<std::string, ColumnStatistics>& columnStats)
+      const folly::F14FastMap<std::string, TypedColumnStatistics>& columnStats)
       const = 0;
 };
 
@@ -435,11 +445,14 @@ struct FilteredTableStats {
 /// 'estimator' over the base column statistics already in 'stats'. A no-op when
 /// 'stats' has no column statistics. Shared by connectors that own their pushed
 /// filters and derive a base estimate (row count + column stats) some other way
-/// (e.g. partition metadata).
+/// (e.g. partition metadata). 'columns' are the table's columns; their types
+/// are authoritative (from the schema), so the estimator interprets each
+/// statistics column's bounds and filter values as the right type.
 void applyFilterEstimates(
     const folly::F14FastMap<std::string, const velox::common::Filter*>&
         commonFilters,
     const velox::core::TypedExprPtr& remainingFilter,
+    const std::vector<const Column*>& columns,
     const FilterSelectivityEstimator& estimator,
     FilteredTableStats& stats);
 

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -378,7 +378,8 @@ void HiveTableLayout::foldNonPartitionFilterStats(
     }
   }
 
-  applyFilterEstimates(dataFilters, handle.remainingFilter(), estimator, stats);
+  applyFilterEstimates(
+      dataFilters, handle.remainingFilter(), columns(), estimator, stats);
 }
 
 namespace {

--- a/axiom/logical_plan/NameMappings.cpp
+++ b/axiom/logical_plan/NameMappings.cpp
@@ -141,7 +141,11 @@ void NameMappings::merge(const NameMappings& other) {
 
   for (const auto& [name, id] : other.mappings_) {
     if (auto existing = mappings_.find(name); existing != mappings_.end()) {
-      VELOX_CHECK(!name.alias.has_value());
+      // The same name exists on both sides, so it is ambiguous across the
+      // merged relations: drop it. A qualified name collides here only when
+      // both sides reuse a relation alias. Referencing a dropped name later
+      // fails as unresolved, matching Presto's report-at-reference-time
+      // behavior.
       const auto& existingId = existing->second;
       if (auto entry = reverseIndex_.find(existingId);
           entry != reverseIndex_.end()) {

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -277,20 +277,8 @@ void Optimization::applyFilteredStats(
     for (size_t i = 0; i < stats->columnStats.size(); ++i) {
       const auto& columnStats = stats->columnStats[i];
       auto& existing = baseTable.columns[columnIndices[i]]->value();
-      // The column cardinality is unknown when the connector reports no NDV.
-      Value value(existing.type);
-      if (columnStats.numDistinct.has_value()) {
-        value.cardinality = std::max<float>(1, columnStats.numDistinct.value());
-      }
-      value.min = columnStats.min.has_value()
-          ? registerVariant(columnStats.min.value())
-          : nullptr;
-      value.max = columnStats.max.has_value()
-          ? registerVariant(columnStats.max.value())
-          : nullptr;
-      value.nullFraction = columnStats.nullPct / 100.0f;
-      value.nullable = !columnStats.nonNull;
-      const_cast<Value&>(existing) = value;
+      const_cast<Value&>(existing) =
+          Value::fromColumnStatistics(existing.type, columnStats);
     }
   }
 

--- a/axiom/optimizer/Schema.cpp
+++ b/axiom/optimizer/Schema.cpp
@@ -141,15 +141,6 @@ ColumnCP SchemaTable::findColumn(Name name) const {
 
 namespace {
 
-// Returns nullptr if the optional has no value, otherwise returns a pointer
-// to a registered copy that lives for the duration of QueryGraphContext.
-const velox::Variant* registerOptionalVariant(
-    const std::optional<velox::Variant>& opt) {
-  if (!opt.has_value()) {
-    return nullptr;
-  }
-  return registerVariant(opt.value());
-}
 // Clamps a known row count to >= 1 so cost math never divides by zero;
 // propagates `nullopt` unchanged.
 std::optional<float> connectorCardinality(
@@ -161,6 +152,35 @@ std::optional<float> connectorCardinality(
   return std::max<float>(1, static_cast<float>(*numRows));
 }
 } // namespace
+
+Value Value::fromColumnStatistics(
+    TypeCP type,
+    const connector::ColumnStatistics& stats) {
+  Value value(type);
+  if (stats.numDistinct.has_value()) {
+    value.cardinality = std::max<float>(1, stats.numDistinct.value());
+  }
+  value.min =
+      stats.min.has_value() ? registerVariant(stats.min.value()) : nullptr;
+  value.max =
+      stats.max.has_value() ? registerVariant(stats.max.value()) : nullptr;
+  value.nullFraction = stats.nullPct / 100.0f;
+  value.nullable = !stats.nonNull;
+  // The connector must report bounds whose kind matches the column type.
+  if (value.min != nullptr) {
+    VELOX_CHECK_EQ(
+        value.min->kind(),
+        type->kind(),
+        "Column statistics min kind must match the column type");
+  }
+  if (value.max != nullptr) {
+    VELOX_CHECK_EQ(
+        value.max->kind(),
+        type->kind(),
+        "Column statistics max kind must match the column type");
+  }
+  return clampCardinality(value);
+}
 
 SchemaTable::SchemaTable(const connector::Table& connectorTable)
     : connectorTable{&connectorTable},
@@ -177,18 +197,12 @@ SchemaTableCP Schema::buildSchemaTable(
     // Cardinality and null fraction are unknown when the connector
     // has no corresponding statistic; downstream cost-based decisions
     // fall back to safe defaults.
-    Value value(toType(tableColumn->type()));
-    if (auto* stats = tableColumn->stats()) {
-      if (stats->numDistinct.has_value()) {
-        value.cardinality = std::max<float>(1, stats->numDistinct.value());
-      }
-      value.min = registerOptionalVariant(stats->min);
-      value.max = registerOptionalVariant(stats->max);
-      value.nullFraction = stats->nullPct / 100.0f;
-    }
+    auto* type = toType(tableColumn->type());
+    auto* stats = tableColumn->stats();
+    Value value =
+        stats ? Value::fromColumnStatistics(type, *stats) : Value(type);
 
-    auto* column =
-        make<Column>(toName(columnName), nullptr, clampCardinality(value));
+    auto* column = make<Column>(toName(columnName), nullptr, value);
     schemaColumns[column->name()] = column;
   }
 

--- a/axiom/optimizer/Schema.h
+++ b/axiom/optimizer/Schema.h
@@ -62,6 +62,15 @@ struct Value {
   /// Assignment operator that checks type equality and assigns other members.
   Value& operator=(const Value& other);
 
+  /// Builds a Value from a connector column's statistics for a column of
+  /// 'type'. Interns the min/max bounds into the query context and clamps the
+  /// distinct count to the type's domain. The connector must supply min/max
+  /// whose Variant kind matches 'type'; a mismatch is a contract violation and
+  /// fails loudly.
+  static Value fromColumnStatistics(
+      TypeCP type,
+      const connector::ColumnStatistics& stats);
+
   /// Returns the average byte size of a value when it occurs as an intermediate
   /// result without dictionary or other encoding.
   float byteSize() const;

--- a/axiom/optimizer/StatsFilterSelectivityEstimator.cpp
+++ b/axiom/optimizer/StatsFilterSelectivityEstimator.cpp
@@ -30,33 +30,14 @@ namespace {
 
 using connector::ColumnStatistics;
 using connector::FilterEstimate;
+using connector::TypedColumnStatistics;
 using velox::core::CallTypedExpr;
 using velox::core::ConstantTypedExpr;
 using velox::core::FieldAccessTypedExpr;
 using velox::core::TypedExprPtr;
 
-// Value <-> ColumnStatistics bridge, shared by both estimate() entry points.
-
-// Builds a Value from column statistics, clamping the distinct count to type
-// limits (mirroring the optimizer's ExprCP path). min/max point into 'stats',
-// which the caller owns for the duration of the estimate.
-Value columnValue(TypeCP type, const ColumnStatistics& stats) {
-  std::optional<float> cardinality;
-  if (stats.numDistinct.has_value()) {
-    cardinality = static_cast<float>(*stats.numDistinct);
-  }
-  Value value(type, cardinality);
-  value.nullFraction = stats.nullPct / 100.0f;
-  value.nullable = !stats.nonNull;
-  if (stats.min.has_value()) {
-    value.min = &stats.min.value();
-  }
-  if (stats.max.has_value()) {
-    value.max = &stats.max.value();
-  }
-  return clampCardinality(value);
-}
-
+// Converts a refined optimizer Value to connector ColumnStatistics for the
+// FilterEstimate result.
 ColumnStatistics toColumnStatistics(const Value& value) {
   ColumnStatistics stats;
   if (value.cardinality.has_value()) {
@@ -73,21 +54,6 @@ ColumnStatistics toColumnStatistics(const Value& value) {
   return stats;
 }
 
-// Builds a Value for the common::Filter path, which has no expression to read a
-// type from: the column type comes from a min/max bound if present, else falls
-// back to BIGINT (used only for bound-free estimates like IN count / NULL).
-Value valueFromStats(const ColumnStatistics& stats) {
-  velox::TypePtr type;
-  if (stats.min.has_value() && !stats.min->isNull()) {
-    type = stats.min->inferType();
-  } else if (stats.max.has_value() && !stats.max->isNull()) {
-    type = stats.max->inferType();
-  } else {
-    type = velox::BIGINT();
-  }
-  return columnValue(type.get(), stats);
-}
-
 // SelectivityEngine policy over velox TypedExpr filters pushed into a
 // connector. Reads statistics from a per-column ColumnStatistics map and writes
 // back refined per-column Values (kUpdatesConstraints == true) so the connector
@@ -100,7 +66,7 @@ class TypedExprPolicy {
   static constexpr bool kUpdatesConstraints = true;
 
   explicit TypedExprPolicy(
-      const folly::F14FastMap<std::string, ColumnStatistics>& columnStats)
+      const folly::F14FastMap<std::string, TypedColumnStatistics>& columnStats)
       : columnStats_{columnStats} {
     // Pushed-down filters carry velox operator names. Comparisons and
     // is_null/not already match queryCtx()->functionNames() verbatim, but
@@ -127,7 +93,7 @@ class TypedExprPolicy {
       }
       auto it = columnStats_.find(columnName);
       if (it != columnStats_.end()) {
-        return columnValue(type, it->second);
+        return Value::fromColumnStatistics(type, it->second.stats);
       }
       return Value(type);
     }
@@ -214,7 +180,7 @@ class TypedExprPolicy {
   }
 
  private:
-  const folly::F14FastMap<std::string, ColumnStatistics>& columnStats_;
+  const folly::F14FastMap<std::string, TypedColumnStatistics>& columnStats_;
   // velox special-form name -> optimizer sentinel Name, built once at
   // construction (see the constructor).
   folly::F14FastMap<std::string, Name> specialFormNames_;
@@ -234,7 +200,7 @@ StatsFilterSelectivityEstimator::StatsFilterSelectivityEstimator()
 
 connector::FilterEstimate StatsFilterSelectivityEstimator::estimate(
     const std::vector<velox::core::TypedExprPtr>& filters,
-    const folly::F14FastMap<std::string, connector::ColumnStatistics>&
+    const folly::F14FastMap<std::string, connector::TypedColumnStatistics>&
         columnStats) const {
   std::lock_guard<std::mutex> lock(mutex_);
   velox::ScopedVarSetter contextSetter(&queryCtx(), context_);
@@ -254,7 +220,7 @@ connector::FilterEstimate StatsFilterSelectivityEstimator::estimate(
 
 connector::FilterEstimate StatsFilterSelectivityEstimator::estimate(
     const folly::F14FastMap<std::string, const velox::common::Filter*>& filters,
-    const folly::F14FastMap<std::string, connector::ColumnStatistics>&
+    const folly::F14FastMap<std::string, connector::TypedColumnStatistics>&
         columnStats) const {
   std::lock_guard<std::mutex> lock(mutex_);
   velox::ScopedVarSetter contextSetter(&queryCtx(), context_);
@@ -268,7 +234,8 @@ connector::FilterEstimate StatsFilterSelectivityEstimator::estimate(
       continue;
     }
 
-    Value value = valueFromStats(it->second);
+    Value value =
+        Value::fromColumnStatistics(it->second.type, it->second.stats);
     Value refined = value;
     auto columnSelectivity = commonFilterSelectivity(*filter, value, refined);
     selectivity *= columnSelectivity.has_value()

--- a/axiom/optimizer/StatsFilterSelectivityEstimator.h
+++ b/axiom/optimizer/StatsFilterSelectivityEstimator.h
@@ -45,13 +45,13 @@ class StatsFilterSelectivityEstimator
 
   connector::FilterEstimate estimate(
       const std::vector<velox::core::TypedExprPtr>& filters,
-      const folly::F14FastMap<std::string, connector::ColumnStatistics>&
+      const folly::F14FastMap<std::string, connector::TypedColumnStatistics>&
           columnStats) const override;
 
   connector::FilterEstimate estimate(
       const folly::F14FastMap<std::string, const velox::common::Filter*>&
           filters,
-      const folly::F14FastMap<std::string, connector::ColumnStatistics>&
+      const folly::F14FastMap<std::string, connector::TypedColumnStatistics>&
           columnStats) const override;
 
  private:

--- a/axiom/optimizer/docs/FilteredTableStats.md
+++ b/axiom/optimizer/docs/FilteredTableStats.md
@@ -163,9 +163,11 @@ and estimates in two parts:
    selectivity into `numRows`, and overwrites the refined per-column fields.
 
 `connector::applyFilterEstimates` is connector-agnostic (it takes column-name
--keyed filters plus an optional remaining `TypedExpr`), so a non-Hive connector
-such as Impulse -- which has no partitions and reads its filters from an
-`ImpulseTableHandle` -- reuses the same fold.
+-keyed filters, an optional remaining `TypedExpr`, and the table's `Column`s,
+whose authoritative types let the estimator interpret bounds and filter values
+as the right type), so a non-Hive connector such as Impulse -- which has no
+partitions and reads its filters from an `ImpulseTableHandle` -- reuses the same
+fold.
 
 ## Testing
 

--- a/axiom/optimizer/tests/FiltersTest.cpp
+++ b/axiom/optimizer/tests/FiltersTest.cpp
@@ -24,7 +24,10 @@
 #include "axiom/optimizer/QueryGraph.h"
 #include "axiom/optimizer/StatsFilterSelectivityEstimator.h"
 #include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
 #include "velox/exec/tests/utils/HiveConnectorTestBase.h"
+#include "velox/expression/ExprToSubfieldFilter.h"
+#include "velox/type/Filter.h"
 
 using namespace facebook::velox;
 
@@ -188,14 +191,18 @@ class FiltersTest : public test::HiveQueriesTestBase {
       const Selectivity& expectedSelectivity,
       const ConstraintMap& refinedConstraints) {
     std::vector<velox::core::TypedExprPtr> typedFilters;
-    folly::F14FastMap<std::string, connector::ColumnStatistics> columnStats;
+    folly::F14FastMap<std::string, connector::TypedColumnStatistics>
+        columnStats;
     folly::F14FastMap<std::string, int32_t> columnIdByName;
     for (auto* filter : filters) {
       typedFilters.push_back(optimization.toTypedExpr(filter));
       filter->columns().forEach<Column>([&](auto* column) {
         if (auto* schemaColumn = column->schemaColumn()) {
+          const auto& value = schemaColumn->value();
           columnStats.insert_or_assign(
-              column->outputName(), toColumnStatistics(schemaColumn->value()));
+              column->outputName(),
+              connector::TypedColumnStatistics{
+                  value.type, toColumnStatistics(value)});
           columnIdByName.insert_or_assign(column->outputName(), column->id());
         }
       });
@@ -655,6 +662,46 @@ TEST_F(FiltersTest, rangeCardinalityMaxMin) {
         EXPECT_NEAR(selectivity->trueFraction, 0.5, 0.1);
       },
       kTestConnectorId);
+}
+
+// A stats bound whose kind disagrees with the column type is a connector
+// contract violation; ingestion rejects it loudly rather than build a Value
+// that would be read as the wrong kind.
+TEST_F(FiltersTest, statsBoundKindMismatchRejected) {
+  withContext([&]() {
+    connector::ColumnStatistics stats;
+    stats.nonNull = true;
+    stats.numDistinct = 1'000;
+    stats.min = velox::Variant::create<int64_t>(0);
+    // max's kind disagrees with the BIGINT column type.
+    stats.max = velox::Variant::create<std::string>("Z");
+
+    VELOX_ASSERT_THROW(
+        Value::fromColumnStatistics(toType(BIGINT()), stats),
+        "max kind must match the column type");
+  });
+}
+
+// A VARCHAR column with no min/max statistics and a range filter estimates a
+// selectivity in [0, 1] rather than failing.
+TEST_F(FiltersTest, commonFilterVarcharColumnWithoutBounds) {
+  withContext([&]() {
+    connector::ColumnStatistics stats;
+    stats.nonNull = true;
+    stats.numDistinct = 100;
+
+    auto filter = velox::exec::between("a", "z");
+
+    folly::F14FastMap<std::string, const velox::common::Filter*> filters{
+        {"c", filter.get()}};
+    folly::F14FastMap<std::string, connector::TypedColumnStatistics>
+        columnStats{{"c", {toType(VARCHAR()), stats}}};
+
+    StatsFilterSelectivityEstimator estimator;
+    auto estimate = estimator.estimate(filters, columnStats);
+    EXPECT_GE(estimate.selectivity, 0.0);
+    EXPECT_LE(estimate.selectivity, 1.0);
+  });
 }
 
 TEST_F(FiltersTest, strictInequalityIntegerBounds) {

--- a/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
+++ b/axiom/optimizer/v2/EstimateLeafStatsPass.cpp
@@ -47,19 +47,8 @@ void applyColumnStats(
     ColumnCP column,
     const connector::ColumnStatistics& stats) {
   const auto& existing = column->value();
-  // Propagate an absent NDV as unknown (nullopt) rather than fabricating 1;
-  // downstream fanout estimation treats unknown NDV as unknown selectivity.
-  const std::optional<float> numDistinct = stats.numDistinct.has_value()
-      ? std::optional<float>{std::max<float>(1, *stats.numDistinct)}
-      : std::nullopt;
-  Value value(existing.type, numDistinct);
-  value.min =
-      stats.min.has_value() ? registerVariant(stats.min.value()) : nullptr;
-  value.max =
-      stats.max.has_value() ? registerVariant(stats.max.value()) : nullptr;
-  value.nullFraction = stats.nullPct / 100.0f;
-  value.nullable = !stats.nonNull;
-  const_cast<Value&>(existing) = value;
+  const_cast<Value&>(existing) =
+      Value::fromColumnStatistics(existing.type, stats);
 }
 
 // Applies one base table's connector stats result. Sets filteredCardinality to

--- a/axiom/sql/presto/tests/PrestoParserTest.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTest.cpp
@@ -1350,6 +1350,25 @@ TEST_F(PrestoParserTest, duplicateAliases) {
       parseSql(
           "SELECT x FROM (SELECT a as x, b as x FROM (VALUES (1, 2)) AS t(a, b))"),
       "Cannot resolve column: x");
+
+  // Two CROSS JOIN UNNEST relations may reuse a relation alias and a column
+  // name (both `t` with column `u` here). The shared name `t.u` is ambiguous,
+  // so the unambiguous columns still plan.
+  {
+    auto matcher =
+        matchValues().unnest().project().unnest().project().output({"a", "b"});
+    testSelect(
+        "SELECT a, b FROM UNNEST(ARRAY[1], ARRAY[2]) AS t(a, u) "
+        "CROSS JOIN UNNEST(ARRAY[3], ARRAY[4]) AS t(b, u)",
+        matcher);
+  }
+
+  // Referencing the ambiguous shared column fails.
+  VELOX_ASSERT_THROW(
+      parseSql(
+          "SELECT u FROM UNNEST(ARRAY[1], ARRAY[2]) AS t(a, u) "
+          "CROSS JOIN UNNEST(ARRAY[3], ARRAY[4]) AS t(b, u)"),
+      "Cannot resolve column: u");
 }
 
 TEST_F(PrestoParserTest, outputNames) {


### PR DESCRIPTION
Summary:
This query failed logical planning:

    SELECT a, b FROM UNNEST(ARRAY[1], ARRAY[2]) AS t(a, u)
    CROSS JOIN UNNEST(ARRAY[3], ARRAY[4]) AS t(b, u)

with an internal error:

    Expression: !name.alias.has_value()

Both relations reuse the alias `t` and expose a same-named column, so name resolution saw the qualified name `t.u` on both sides. Merging the two sides asserted that a qualified name could never collide, which reusing an alias breaks. A qualified collision is now treated like an unqualified one: the name is ambiguous, so it is dropped. The unambiguous columns still resolve, and referencing a dropped column fails as unresolved. This matches Presto, which reports the ambiguity only when the column is referenced.

Differential Revision: D114346308
