### PR TITLE
fix(runner): Route by groupId only for grouped scans

### DIFF
--- a/axiom/optimizer/docs/DistributedExecution.md
+++ b/axiom/optimizer/docs/DistributedExecution.md
@@ -9,7 +9,7 @@ The optimizer's role is to decide where exchanges go, what partitioning each exc
 **Implementation status.** Sections 1 and 2 describe the fragment and exchange model that is in place today, with two exceptions called out where they appear:
 
 - **`kCoordinator` fragments and SystemConnector isolation** are not yet implemented. Section 1 (UNION ALL with single-task inputs) and Section 2 (`FragmentType::kCoordinator`) describe the intended behavior.
-- **Grouped execution** (Section 3) — including the `PartitionType` API, `groupedNodes` / `groupedExecution` fields on `ExecutableFragment`, `GroupedSplitSource`, and split-level `groupId` tagging — is a design proposal, not yet implemented.
+- **Grouped execution** (Section 3) is partially implemented. The shuffle-avoidance path is in place: the `PartitionType` API, the `groupedNodes` field on `ExecutableFragment`, split-level `groupId` tagging, and `scaleDown` to a `kFixed` fragment whose tasks are routed by `groupId`. The full per-group-processing path — `GroupedSplitSource` (complete groups in order) and the `groupedExecution` flag that clears hash tables between groups — is not yet implemented.
 
 ### 1. Fragment Structure and Scheduling Constraints
 
@@ -325,11 +325,14 @@ The FINAL aggregation lives in the same fragment as the UNION ALL because A6 (kS
 
 ### 3. Grouped Execution (Bucketed Tables)
 
-> **Status: design proposal — not yet implemented.** This section
-> describes the intended model. The `PartitionType` API,
-> `groupedNodes` / `groupedExecution` fields on `ExecutableFragment`,
-> `GroupedSplitSource`, and split-level `groupId` tagging do not
-> exist in the codebase today (2026-05-08).
+> **Status (2026-07-31): partially implemented.** The shuffle-avoidance
+> path is in place — the `PartitionType` API, the `groupedNodes` field on
+> `ExecutableFragment`, split-level `groupId` tagging, and `scaleDown` to a
+> `kFixed` fragment routed by `groupId` (see "Shuffle avoidance without
+> per-group processing" below). The full per-group-processing path described
+> in this section — `GroupedSplitSource` / `co_getGroups` and the
+> `groupedExecution` flag that clears hash tables between groups — is not yet
+> implemented.
 
 Bucketed tables (e.g., Hive tables with `bucketed_by`) store data
 pre-partitioned by key into a fixed number of **buckets**. The

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -143,6 +143,7 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
     std::shared_ptr<connector::SplitSource> source,
     velox::core::PlanNodeId scanId,
     std::vector<std::shared_ptr<velox::exec::Task>> tasks,
+    bool grouped,
     std::function<void(std::exception_ptr)> onError,
     QueryRuntimeStats& runtimeStats) {
   std::exception_ptr ex;
@@ -167,11 +168,20 @@ folly::coro::Task<void> co_generateAndDistributeSplits(
       auto batch = co_await source->co_getSplits(1);
       for (auto& split : batch.splits) {
         size_t targetTask;
-        if (split.groupId.has_value()) {
-          // The connector guarantees groupId is in [0, tasks.size()).
+        if (grouped) {
+          // Grouped execution routes each split to the task owning its group.
+          // The connector tags grouped splits with a groupId in
+          // [0, tasks.size()); same-group splits must share a task.
+          VELOX_CHECK(
+              split.groupId.has_value(),
+              "Grouped scan produced a split without a groupId: {}",
+              scanId);
           VELOX_CHECK_LT(static_cast<size_t>(*split.groupId), tasks.size());
           targetTask = static_cast<size_t>(*split.groupId);
         } else {
+          // Not grouped: round-robin. Any groupId a connector stamped is
+          // ignored here rather than used as a task index that could be out of
+          // range.
           targetTask = taskIdx;
           taskIdx = (taskIdx + 1) % tasks.size();
         }
@@ -803,7 +813,12 @@ void LocalRunner::makeStages(
             folly::coro::co_withExecutor(
                 params_.queryCtx->executor(),
                 co_generateAndDistributeSplits(
-                    source, scan->id(), stage, onError, runtimeStats_)));
+                    source,
+                    scan->id(),
+                    stage,
+                    /*grouped=*/partitionType != nullptr,
+                    onError,
+                    runtimeStats_)));
       }
 
       for (const auto& input : fragment.inputStages) {


### PR DESCRIPTION
Summary:
LocalRunner routed a split to task `groupId` whenever the split carried a groupId, regardless of whether its scan was grouped. A non-grouped scan whose connector stamped a stray groupId (e.g. a raw bucket number) then failed:

    static_cast<size_t>(*split.groupId) < tasks.size()

Split routing now gates on grouped-ness. A grouped scan routes each split to the task for its group. A non-grouped scan round-robins, ignoring any groupId the connector set rather than using it as a task index.

Also updates DistributedExecution.md: grouped execution's shuffle-avoidance path (PartitionType, groupedNodes, groupId tagging, scaleDown to a kFixed fragment) is implemented; the "design proposal" status now covers only the not-yet-built per-group-processing path.

Differential Revision: D114354546
