### PR TITLE
misc: Advance Velox submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Axiom integrates Velox as a Git submodule, referencing a specific commit of the
 Velox repository. The Velox badge at the top of this README shows the current
 commit and how far behind it is from Velox main.
 
-[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/974ccd6693fb80e5086b989d49ef4163c8d1b5d9...main)
+[See what changed since the current Velox commit.](https://github.com/facebookincubator/velox/compare/ef1caf839d7b7cd7f2aafa86b4472ff5c8b269bc...main)
 <!-- pre-commit check-velox-readme validates the SHA above matches the submodule -->
 
 Advance Velox when your changes depend on code in Velox that


### PR DESCRIPTION
Summary: Bump the pinned Velox commit so Axiom's build picks it up. Keeps the README compare-link SHA in sync so `check-velox-readme` passes.

Differential Revision: D114610562
