### PR TITLE
feat(stats): Make QueryRuntimeStats a velox BaseRuntimeStatWriter

### DIFF
--- a/axiom/common/QueryRuntimeStats.cpp
+++ b/axiom/common/QueryRuntimeStats.cpp
@@ -93,6 +93,18 @@ void QueryRuntimeStats::merge(
   mergeRuntimeMetric(metrics_, std::string(name), metric);
 }
 
+void QueryRuntimeStats::setRuntimeStat(
+    std::string_view name,
+    const velox::RuntimeMetric& metric) {
+  metrics_.insert_or_assign(std::string(name), metric);
+}
+
+void QueryRuntimeStats::addRuntimeStat(
+    std::string_view name,
+    const velox::RuntimeCounter& counter) {
+  merge(name, velox::RuntimeMetric(counter.value, counter.unit));
+}
+
 std::unordered_map<std::string, velox::RuntimeMetric> QueryRuntimeStats::toMap()
     const {
   std::unordered_map<std::string, velox::RuntimeMetric> result;

--- a/axiom/common/QueryRuntimeStats.h
+++ b/axiom/common/QueryRuntimeStats.h
@@ -33,8 +33,9 @@ namespace facebook::axiom {
 /// Accumulates runtime metrics from Axiom's query pipeline (parser, optimizer,
 /// split manager, runner). Each metric is a velox::RuntimeMetric with
 /// sum/count/min/max. Thread-safe — multiple pipeline stages may record
-/// concurrently.
-class QueryRuntimeStats {
+/// concurrently. Implements velox::BaseRuntimeStatWriter so instrumented Velox
+/// components (e.g. velox::TrackedExecutor) can report directly into it.
+class QueryRuntimeStats : public velox::BaseRuntimeStatWriter {
  public:
   // Parser.
   static constexpr std::string_view kParseWallNanos{"axiom-parseWallNanos"};
@@ -98,6 +99,15 @@ class QueryRuntimeStats {
 
   /// Merges a pre-aggregated metric into this recorder.
   void merge(std::string_view name, const velox::RuntimeMetric& metric);
+
+  /// Sets 'metric' under 'name', replacing any existing value.
+  void setRuntimeStat(std::string_view name, const velox::RuntimeMetric& metric)
+      override;
+
+  /// Adds 'counter' as one sample under 'name', accumulating across calls.
+  void addRuntimeStat(
+      std::string_view name,
+      const velox::RuntimeCounter& counter) override;
 
   /// Returns a snapshot of all recorded metrics.
   std::unordered_map<std::string, velox::RuntimeMetric> toMap() const;

--- a/axiom/common/tests/QueryRuntimeStatsTest.cpp
+++ b/axiom/common/tests/QueryRuntimeStatsTest.cpp
@@ -72,6 +72,47 @@ TEST(QueryRuntimeStatsTest, merge) {
   EXPECT_EQ(metric.max, 500);
 }
 
+TEST(QueryRuntimeStatsTest, setRuntimeStat) {
+  QueryRuntimeStats stats;
+  velox::BaseRuntimeStatWriter& writer = stats;
+
+  velox::RuntimeMetric first(100, velox::RuntimeCounter::Unit::kNanos);
+  writer.setRuntimeStat(QueryRuntimeStats::kOptimizeWallNanos, first);
+
+  velox::RuntimeMetric second(500, velox::RuntimeCounter::Unit::kNanos);
+  second.addValue(300);
+  writer.setRuntimeStat(QueryRuntimeStats::kOptimizeWallNanos, second);
+
+  // The second value replaces the first rather than accumulating.
+  auto map = stats.toMap();
+  auto& metric = map.at(std::string(QueryRuntimeStats::kOptimizeWallNanos));
+  EXPECT_EQ(metric.sum, 800);
+  EXPECT_EQ(metric.count, 2);
+  EXPECT_EQ(metric.min, 300);
+  EXPECT_EQ(metric.max, 500);
+  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNanos);
+}
+
+TEST(QueryRuntimeStatsTest, addRuntimeStat) {
+  QueryRuntimeStats stats;
+  velox::BaseRuntimeStatWriter& writer = stats;
+
+  writer.addRuntimeStat(
+      QueryRuntimeStats::kGetSplitsCount,
+      velox::RuntimeCounter(7, velox::RuntimeCounter::Unit::kNone));
+  writer.addRuntimeStat(
+      QueryRuntimeStats::kGetSplitsCount,
+      velox::RuntimeCounter(3, velox::RuntimeCounter::Unit::kNone));
+
+  auto map = stats.toMap();
+  auto& metric = map.at(std::string(QueryRuntimeStats::kGetSplitsCount));
+  EXPECT_EQ(metric.sum, 10);
+  EXPECT_EQ(metric.count, 2);
+  EXPECT_EQ(metric.min, 3);
+  EXPECT_EQ(metric.max, 7);
+  EXPECT_EQ(metric.unit, velox::RuntimeCounter::Unit::kNone);
+}
+
 TEST(QueryRuntimeStatsTest, toDynamic) {
   QueryRuntimeStats stats;
   stats.recordTiming(


### PR DESCRIPTION
Summary:
Make `QueryRuntimeStats` implement `velox::BaseRuntimeStatWriter` (adding `setRuntimeStat` and `addRuntimeStat`), so an instrumented Velox component such as `velox::TrackedExecutor` — can report its metrics straight into it.

Differential Revision: D114438362


