### PR TITLE
fix(optimizer): Shuffle above UNION ALL when a join build asked for a distribution

### DIFF
--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -3611,7 +3611,7 @@ PlanP Optimization::makePlan(
   needsShuffle = false;
   if (key.firstTable->is(PlanType::kDerivedTableNode) &&
       key.firstTable->as<DerivedTable>()->isUnion()) {
-    return makeUnionPlan(key, distribution);
+    return makeUnionPlan(key, distribution, needsShuffle);
   }
   return makeDtPlan(dt, key, distribution, existsFanout, needsShuffle);
 }
@@ -3627,7 +3627,9 @@ PlanP Optimization::makePlan(
 
 PlanP Optimization::makeUnionPlan(
     const MemoKey& key,
-    const std::optional<DesiredDistribution>& distribution) {
+    const std::optional<DesiredDistribution>& distribution,
+    bool& needsShuffle) {
+  needsShuffle = false;
   const auto* setDt = key.firstTable->as<DerivedTable>();
 
   RelationOpPtrVector inputs;
@@ -3658,7 +3660,7 @@ PlanP Optimization::makeUnionPlan(
     if (inputDt->isUnion()) {
       // Nested union (e.g., UNION ALL of UNION ALL).
       // TODO: Flatten nested unions in ToGraph.
-      inputPlan = makeUnionPlan(inputKey, distribution);
+      inputPlan = makeUnionPlan(inputKey, distribution, inputShuffle);
     } else {
       PlanSet* plans = memo_.find(inputKey);
       if (plans == nullptr) {
@@ -3693,7 +3695,17 @@ PlanP Optimization::makeUnionPlan(
     if (setDt->aggregation) {
       addAggregation(setDt, result, inputStates[0]);
     }
-    return unionPlan(inputStates, result);
+    auto plan = unionPlan(inputStates, result);
+    // Tell the caller whether the union came out copartitioned with what it
+    // asked for. It does not when the request was dropped below, and it can
+    // also miss when the legs that needed no shuffle were merely
+    // copartitioned rather than identically partitioned, leaving the union
+    // with no common distribution. Either way the caller owns the shuffle;
+    // without this a hash join would build on an unpartitioned input and
+    // silently drop rows.
+    needsShuffle = !isSingleWorker_ && distribution.has_value() &&
+        !plan->op->distribution().isCopartitionedWith(*distribution);
+    return plan;
   };
 
   if (isSingleWorker_) {
@@ -3706,14 +3718,9 @@ PlanP Optimization::makeUnionPlan(
   // naturally-matching inputs unnecessarily); UNION ALL can shuffle only
   // the inputs that need it. So if at least one input already produces the
   // desired distribution natively, honor the request and shuffle only the
-  // inputs that don't. Otherwise drop the request — the parent's blanket
-  // shuffle is no worse than per-input shuffles in that case.
-  //
-  // Wrinkle: this assumes the parent commits to the desired distribution it
-  // requested. A parent that later switches strategy (e.g., a hash join that
-  // requests hash(K) for the build, then chooses to broadcast it instead)
-  // leaves the per-input shuffles in place even though they're now wasted.
-  // Such mis-specification is the parent's bug to fix, not UNION ALL's.
+  // inputs that don't. Otherwise drop the request and leave the blanket
+  // shuffle to the parent, which finishUnionPlan asks for by reporting
+  // needsShuffle.
   std::optional<DesiredDistribution> effectiveDistribution = distribution;
   if (effectiveDistribution.has_value() &&
       std::ranges::all_of(inputNeedsShuffle, std::identity{})) {

--- a/axiom/optimizer/Optimization.h
+++ b/axiom/optimizer/Optimization.h
@@ -297,10 +297,13 @@ class Optimization {
   // Plans a set operation (UNION ALL, UNION). Plans each child independently
   // using importUnionChild, combines them with UnionAll, and optionally adds
   // a distinct aggregation for UNION. Individual child shuffles are handled
-  // internally.
+  // internally. Sets 'needsShuffle' when the result does not come out
+  // copartitioned with 'distribution', meaning the caller must shuffle above
+  // the union to get what it asked for.
   PlanP makeUnionPlan(
       const MemoKey& key,
-      const std::optional<DesiredDistribution>& distribution);
+      const std::optional<DesiredDistribution>& distribution,
+      bool& needsShuffle);
 
   PlanP makeDtPlan(
       const DerivedTable& dt,

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <gmock/gmock.h>
+
 #include "axiom/optimizer/tests/PlanMatcher.h"
 #include "axiom/optimizer/tests/QueryTestBase.h"
 
@@ -901,6 +903,131 @@ TEST_P(UnionAllTest, shuffledJoinBuildOverUnion) {
     optimizerOptions_.broadcastSizeLimit = 1024;
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
+}
+
+// UNION ALL as build of a hash join whose probe is already partitioned on
+// the join key by a preceding join. The probe's partitioning makes the join
+// request hash(c) for the build; no union leg produces that natively, so a
+// single hash shuffle must sit above the union. Without it the build stays
+// round-robin against a hash-partitioned probe and the join silently drops
+// rows.
+TEST_P(UnionAllTest, shuffledUnionAsBuildOfCopartitionedJoin) {
+  testConnector_->addTable("v", ROW("c", BIGINT()))
+      ->setStats(1'000, {{"c", {.numDistinct = 1'000}}});
+  testConnector_->addTable("w", ROW("d", BIGINT()))
+      ->setStats(1'000, {{"d", {.numDistinct = 1'000}}});
+
+  auto logicalPlan = parseSelect(
+      "SELECT t.a FROM t JOIN u ON t.a = u.b "
+      "JOIN (FROM v UNION ALL FROM w) s ON u.b = s.c",
+      kTestConnectorId);
+
+  {
+    // Cap the broadcast size limit low so the union build is hash
+    // partitioned rather than replicated, and pin the join order so the
+    // union stays the build of the second join, whose probe the first join
+    // already partitioned on the shared key.
+    optimizerOptions_.broadcastSizeLimit = 1024;
+    optimizerOptions_.syntacticJoinOrder = true;
+
+    auto unionLegs =
+        matchScan("v").localPartition(matchScan("w").project().build());
+    auto firstJoin =
+        matchScan("t")
+            .shuffle({"a"}, FragmentType::kSource)
+            .hashJoin(
+                matchScan("u").shuffle({"b"}, FragmentType::kSource).build());
+
+    // v2 re-shuffles the first join's output onto the second join's key;
+    // v1 keeps it, since it is already partitioned on that key.
+    auto matcher = useV2_ ? std::move(firstJoin)
+                                .shuffle({"b"}, FragmentType::kFixed)
+                                .hashJoin(
+                                    std::move(unionLegs)
+                                        .shuffle({"c"}, FragmentType::kSource)
+                                        .build())
+                                .gather(FragmentType::kFixed)
+                                .build()
+                          : std::move(firstJoin)
+                                .hashJoin(
+                                    std::move(unionLegs)
+                                        .shuffle({"c"}, FragmentType::kSource)
+                                        .build())
+                                .gather(FragmentType::kFixed)
+                                .build();
+    AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
+  }
+}
+
+// Same shape as shuffledUnionAsBuildOfCopartitionedJoin, run over real rows
+// at every parallelism combination. Verifies the outcome the plan shape
+// exists to protect: a build that is not partitioned on the join key while
+// the probe is loses rows silently rather than failing, so checking the plan
+// alone would not catch a regression here.
+TEST_P(UnionAllTest, unionAsJoinBuildReturnsAllRows) {
+  auto keys = [&](velox::vector_size_t begin, velox::vector_size_t end) {
+    return makeRowVector({makeFlatVector<int64_t>(
+        end - begin, [&](auto i) { return static_cast<int64_t>(begin + i); })});
+  };
+
+  // These tables carry data rather than stats; the two cannot be combined on
+  // the same test table.
+  testConnector_->addTable("p", ROW("pk", BIGINT()));
+  testConnector_->addTable("q", ROW("qk", BIGINT()));
+  testConnector_->addTable("r1", ROW("rk", BIGINT()));
+  testConnector_->addTable("r2", ROW("sk", BIGINT()));
+  SCOPE_EXIT {
+    for (const auto& name : {"p", "q", "r1", "r2"}) {
+      testConnector_->dropTableIfExists(name);
+    }
+  };
+  testConnector_->appendData("p", keys(0, 40));
+  testConnector_->appendData("q", keys(0, 40));
+  testConnector_->appendData("r1", keys(0, 20));
+  testConnector_->appendData("r2", keys(20, 40));
+
+  auto logicalPlan = parseSelect(
+      "SELECT p.pk FROM p JOIN q ON p.pk = q.qk "
+      "JOIN (FROM r1 UNION ALL FROM r2) s ON q.qk = s.rk",
+      kTestConnectorId);
+
+  // Rule out broadcast so the union build must be hash partitioned, and pin
+  // the join order so the union stays the build of the second join.
+  optimizerOptions_.broadcastSizeLimit = 1;
+  optimizerOptions_.syntacticJoinOrder = true;
+
+  // The union legs cover 0..39 exactly once, so every p row joins once.
+  auto reference = toSingleNodePlan(logicalPlan);
+  ASSERT_EQ(runVelox(reference).countRows(), 40);
+
+  checkSame(logicalPlan, reference, {.numWorkers = 4, .numDrivers = 4});
+}
+
+// Nested UNION ALL as the build of the same copartitioned join. The inner
+// union reports whether it reached the requested distribution, so the outer
+// union sees an input that still needs a shuffle instead of assuming the
+// nested plan already matched.
+TEST_P(UnionAllTest, shuffledNestedUnionAsBuildOfCopartitionedJoin) {
+  for (const auto& [name, column] :
+       std::vector<std::pair<std::string, std::string>>{
+           {"v", "c"}, {"w", "d"}, {"x", "e"}}) {
+    testConnector_->addTable(name, ROW(column, BIGINT()))
+        ->setStats(1'000, {{column, {.numDistinct = 1'000}}});
+  }
+
+  auto logicalPlan = parseSelect(
+      "SELECT t.a FROM t JOIN u ON t.a = u.b "
+      "JOIN (FROM v UNION ALL FROM w UNION ALL FROM x) s ON u.b = s.c",
+      kTestConnectorId);
+
+  optimizerOptions_.broadcastSizeLimit = 1024;
+  optimizerOptions_.syntacticJoinOrder = true;
+
+  // Whatever nesting the legs end up in, the union must not reach the join
+  // as a round-robin local partition.
+  auto plan = planVelox(logicalPlan).plan;
+  EXPECT_THAT(plan->toString(), testing::HasSubstr("HASH(c)"))
+      << plan->toString();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
A hash join whose probe is already partitioned on the join key requests hash(K) for its build. When that build is a UNION ALL whose legs all need a shuffle to produce hash(K), `makeUnionPlan` drops the request and plans the legs unpartitioned — intentionally, since a blanket shuffle above the union is no worse than per-leg shuffles in that case. But the blanket shuffle was never added: `makePlan` hardcoded `needsShuffle = false` on the union path, so `joinByHash` believed the build already satisfied `forBuild` and skipped its `Repartition`. The build reached the join as a round-robin `LocalPartition` while the probe was hash-partitioned, so probe and build rows landed on different workers and the join dropped rows silently. `SELECT p.pk FROM p JOIN q ON p.pk = q.qk JOIN (FROM r1 UNION ALL FROM r2) s ON q.qk = s.rk` returned 11 of 40 rows on four workers and all 40 on one.

`finishUnionPlan` now reports whether the union actually came out copartitioned with the requested distribution, and the caller shuffles when it did not. Deriving the flag from the resulting distribution rather than from "did we drop the request" also covers legs that were merely copartitioned rather than identically partitioned, which leaves the union with no common distribution. Nested unions now propagate the flag too, where previously they always reported no shuffle needed.

Only v1 is affected. v2 already emits a hash exchange above the union for this shape, and the new tests assert both optimizers' plan shapes.

Differential Revision: D114817356


