### PR TITLE
fix(sql): Raise default expression nesting depth to 1024

### DIFF
--- a/axiom/sql/presto/ParserOptions.h
+++ b/axiom/sql/presto/ParserOptions.h
@@ -40,7 +40,7 @@ struct ParserOptions : public facebook::velox::config::ConfigProvider {
 
   static constexpr bool kFriendlySqlDefault = true;
   static constexpr bool kParseDecimalLiteralAsDoubleDefault = true;
-  static constexpr uint32_t kMaxExpressionDepthDefault = 512;
+  static constexpr uint32_t kMaxExpressionDepthDefault = 1024;
   static constexpr uint32_t kMaxExpressionWidthDefault = 100'000;
   static constexpr uint32_t kMaxSubqueryDepthDefault = 1024;
 

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -1129,6 +1129,13 @@ TEST_F(ExpressionParserTest, nestingDepthCapped) {
   // A shallow expression parses.
   EXPECT_NE(nullptr, parseExpr(chain("1", " + 0", 8)));
 
+  // Parentheses cost several grammar rules per term.
+  std::string parens = "0 = 0";
+  for (uint32_t i = 1; i < 150; ++i) {
+    parens = fmt::format("{} = 0 OR ({})", i, parens);
+  }
+  EXPECT_NE(nullptr, parseExpr(parens));
+
   // Nesting past the cap fails cleanly, regardless of construct kind.
   const uint32_t past = ParserOptions::kMaxExpressionDepthDefault + 1;
   auto expectRejected = [&](std::string_view head, std::string_view unit) {


### PR DESCRIPTION
Summary:
A boolean filter with 166 parenthesized OR terms fails to parse:

    Expression exceeds maximum nesting depth

Every parenthesis nests the parse tree one more level, so the 512 default rejected chains of a size real queries reach. The same chain written without parentheses parses at 2000 terms.

Raises the default to 1024, matching the neighbouring subquery depth default. Deeper input still fails the depth check rather than overflowing the stack: on an opt build the deepest shapes overflow near 1450 nesting levels, and 1024 admits at most about 1023.

Differential Revision: D114980432


