### PR TITLE
fix: Remove unreachable `break` statements in fbcode/axiom/optimizer (1 files)

### DIFF
--- a/axiom/optimizer/tests/SubfieldTest.cpp
+++ b/axiom/optimizer/tests/SubfieldTest.cpp
@@ -131,7 +131,6 @@ class SubfieldTest : public HiveQueriesTestBase,
         break;
       default:
         FAIL();
-        break;
     }
     optimizerOptions_.traceFlags = FLAGS_optimizer_trace;
   }


### PR DESCRIPTION
Summary:
Fix `clang-diagnostic-unreachable-code-break` (`-Wunreachable-code-break`).
The diagnostic is currently a warning; existing callsites must be fixed so it can
be promoted to an error. More info: https://fburl.com/clang-warnings-burndown

Each removed `break` directly follows a statement that already leaves the case
(`return`, `throw`, `goto`, `continue`, or a `[[noreturn]]` call), or is the final
case of its switch where a `break` is a no-op. Verified by brace-matching the
enclosing switch, so no removal can introduce a fallthrough. Where a `break` was
only dead in debug builds (a `DCHECK`/`DLOG_ASSERT` that compiles out in release),
the `break` is KEPT and guarded with `#if !DCHECK_IS_ON()` rather than removed.

Pure dead-code removal -- no control flow change.

Differential Revision: D114787744


