### PR TITLE
fix(parser): Handle HAVING and ORDER BY without GROUP BY

### DIFF
--- a/axiom/optimizer/tests/sql/aggregation.sql
+++ b/axiom/optimizer/tests/sql/aggregation.sql
@@ -111,3 +111,13 @@ SELECT count(*) AS c FROM t ORDER BY c DESC
 ----
 -- Global aggregation with HAVING and ORDER BY together.
 SELECT count(*) AS c FROM t HAVING count(*) > 1 ORDER BY count(*)
+----
+-- An aggregate in HAVING forms a global aggregation on its own.
+SELECT 1 AS x FROM t HAVING sum(a) > 10
+----
+-- An aggregate in ORDER BY forms a global aggregation on its own.
+SELECT 1 AS x FROM t ORDER BY sum(a)
+----
+-- HAVING with no aggregate filters rows like WHERE; DuckDB rejects it.
+-- duckdb: SELECT a FROM t WHERE b > 140
+SELECT a FROM t HAVING b > 140

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -496,8 +496,9 @@ SELECT (SELECT max(t.a) + 1 FROM u WHERE u.a > 0) FROM t
 -- the body's FROM/WHERE as the EXISTS gate.
 SELECT (SELECT max(t.a) - min(t.a) FROM u WHERE u.a > 0) FROM t
 ----
--- Pure-outer aggregate inside an ORDER BY key is not yet supported.
--- error: Cannot replace inputs on AggregateCallExpr with filter
+-- Pure-outer aggregate inside an ORDER BY key is not yet supported. The
+-- aggregate makes the block a global aggregation, leaving 't.a' non-grouped.
+-- error: Cannot resolve column: a
 SELECT t.a FROM t ORDER BY (SELECT max(t.a))
 ----
 -- Multiple aggregates, each referencing an outer column.

--- a/axiom/sql/presto/GroupByPlanner.cpp
+++ b/axiom/sql/presto/GroupByPlanner.cpp
@@ -241,6 +241,13 @@ class ExprAnalyzer : public DefaultTraversalVisitor {
     return numAggregates_ > 0;
   }
 
+  // Returns true if 'expression' contains an aggregate call.
+  static bool containsAggregate(const ExpressionPtr& expression) {
+    ExprAnalyzer analyzer;
+    expression->accept(&analyzer);
+    return analyzer.hasAggregate();
+  }
+
  protected:
   void visitExistsPredicate(ExistsPredicate* node) override {
     // Aggregate function calls within a subquery do not count.
@@ -469,18 +476,27 @@ bool GroupByPlanner::tryPlanGlobalAgg(
     }
   }
 
-  // Count visible aggregates, including outer-scope aggregates in
-  // lift-candidate scalar subqueries. `ExprAnalyzer` rejects nested
-  // aggregates as a side effect of the walk.
+  // Count visible aggregates in SELECT, HAVING and ORDER BY, including
+  // outer-scope aggregates in lift-candidate scalar subqueries.
+  // `ExprAnalyzer` rejects nested aggregates as a side effect of the walk.
   bool hasAggregate{false};
+
   for (const auto& item : selectItems) {
     VELOX_CHECK(item->is(NodeType::kSingleColumn));
-    ExprAnalyzer exprAnalyzer;
-    item->as<SingleColumn>()->expression()->accept(&exprAnalyzer);
-    if (exprAnalyzer.hasAggregate()) {
-      hasAggregate = true;
+    hasAggregate |=
+        ExprAnalyzer::containsAggregate(item->as<SingleColumn>()->expression());
+  }
+
+  if (having != nullptr) {
+    hasAggregate |= ExprAnalyzer::containsAggregate(having);
+  }
+
+  if (orderBy != nullptr) {
+    for (const auto& sortItem : orderBy->sortItems()) {
+      hasAggregate |= ExprAnalyzer::containsAggregate(sortItem->sortKey());
     }
   }
+
   if (!hasAggregate) {
     return false;
   }

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -1548,12 +1548,17 @@ class RelationPlanner : public AstVisitor {
         // ORDER BY over the aggregates. DISTINCT is a no-op since a global
         // aggregation without a GROUP BY produces one row.
         displayNames_.captureLastNames(selectItems);
-      } else if (distinct) {
-        addDistinctAndOrderBy(selectItems, orderBy);
       } else {
-        // Widen the projection to include any ORDER BY columns not in the
-        // SELECT list, sort, then project again using only the SELECT list.
-        addProjectAndOrderBy(selectItems, orderBy);
+        // Without an aggregation, HAVING filters rows like WHERE.
+        addFilter(node->having());
+
+        if (distinct) {
+          addDistinctAndOrderBy(selectItems, orderBy);
+        } else {
+          // Widen the projection to include any ORDER BY columns not in the
+          // SELECT list, sort, then project again using only the SELECT list.
+          addProjectAndOrderBy(selectItems, orderBy);
+        }
       }
     }
   }

--- a/axiom/sql/presto/tests/AggregationParserTest.cpp
+++ b/axiom/sql/presto/tests/AggregationParserTest.cpp
@@ -947,6 +947,62 @@ TEST_F(AggregationParserTest, having) {
       "HAVING clause cannot reference column: n_nationkey");
 }
 
+// An aggregate in HAVING forms a global aggregation on its own.
+TEST_F(AggregationParserTest, havingWithoutGroupBy) {
+  testSelect(
+      "SELECT 1 FROM nation HAVING sum(n_regionkey) > 100",
+      matchScan()
+          .aggregate({}, {"sum(n_regionkey)"})
+          .filter("sum > 100::bigint")
+          .project({"1"})
+          .output());
+
+  // The aggregate carries a FILTER clause.
+  testSelect(
+      "SELECT 1 FROM nation HAVING count(*) FILTER (WHERE n_regionkey = 1) > 0",
+      matchScan()
+          .aggregate({}, {"count() FILTER (WHERE n_regionkey = 1::bigint)"})
+          .filter("count > 0::bigint")
+          .project({"1"})
+          .output());
+
+  // HAVING makes the query an aggregation, so a bare column is not selectable.
+  VELOX_ASSERT_THROW(
+      parseSql("SELECT n_name FROM nation HAVING sum(n_regionkey) > 10"),
+      "Cannot resolve column: n_name");
+}
+
+// HAVING with no aggregate anywhere filters rows like WHERE.
+TEST_F(AggregationParserTest, havingWithoutGroupByOrAggregate) {
+  testSelect(
+      "SELECT n_name FROM nation HAVING n_regionkey > 2",
+      matchScan()
+          .filter("n_regionkey > 2::bigint")
+          .project({"n_name"})
+          .output());
+
+  // The predicate applies before DISTINCT.
+  testSelect(
+      "SELECT DISTINCT n_name FROM nation HAVING n_regionkey > 2",
+      matchScan()
+          .filter("n_regionkey > 2::bigint")
+          .project({"n_name"})
+          .distinct()
+          .output());
+}
+
+// An aggregate in ORDER BY forms a global aggregation on its own.
+TEST_F(AggregationParserTest, orderByAggregateWithoutGroupBy) {
+  testSelect(
+      "SELECT 1 AS x FROM nation ORDER BY sum(n_regionkey)",
+      matchScan()
+          .aggregate({}, {"sum(n_regionkey)"})
+          .project({"1", "sum"})
+          .sort({"sum"})
+          .project({"x"})
+          .output());
+}
+
 TEST_F(AggregationParserTest, scalarOverAgg) {
   auto matcher = matchScan().aggregate().project().output();
 


### PR DESCRIPTION
Summary:
A query with a HAVING clause but no GROUP BY dropped the predicate and returned every input row. For example:

    SELECT 1 FROM (VALUES 1, 2, 3) t(a) HAVING sum(a) > 100

returned 3 rows instead of 0.

A query block became a global aggregation only when the SELECT list held an aggregate. It now also becomes one when HAVING or ORDER BY holds an aggregate. When no clause holds an aggregate, HAVING filters rows like WHERE, so `SELECT a FROM t HAVING b > 1` keeps only the rows where `b > 1`.

Two side effects of the same rule: `SELECT 1 FROM t ORDER BY sum(a)` previously failed with `Scalar function doesn't exist: sum` and now returns one row, and a HAVING that references an unknown column used to be ignored and now fails to resolve.


Not addressed: the analyzer does not verify that SELECT expressions are grouping keys or aggregates; the invalid cases are caught later, during plan building. That check applies to every GROUP BY query, so it belongs in its own change.

Differential Revision: D115168595


