### PR TITLE
feat(optimizer): Precompute single-side join filter parts (#1683)

### DIFF
--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -122,6 +122,7 @@ add_executable(
   HiveAggregationQueriesTest.cpp
   HiveLimitQueriesTest.cpp
   HiveQueriesTest.cpp
+  JoinFilterProjectionTest.cpp
   JoinTest.cpp
   MetadataCountsTest.cpp
   MultiFragmentPlanTest.cpp

--- a/axiom/optimizer/tests/ExprMatcher.cpp
+++ b/axiom/optimizer/tests/ExprMatcher.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/tests/ExprMatcher.h"
 #include <gtest/gtest.h>
 #include "velox/core/Expressions.h"
+#include "velox/parse/ExprRewriter.h"
 #include "velox/parse/Expressions.h"
 
 namespace facebook::velox::core {
@@ -304,13 +305,16 @@ bool matchImpl(const TypedExprPtr& actual, const ExprPtr& expected) {
     EXPECT_EQ(actualNames.size(), expectedNames.size());
     AXIOM_RETURN_FALSE_IF_FAILURE
 
+    // Parameter names are generated, so bind the expected ones to the actual
+    // ones by position and compare the bodies through that binding.
+    std::unordered_map<std::string, std::string> parameters;
     for (size_t i = 0; i < actualNames.size(); ++i) {
-      EXPECT_EQ(actualNames[i], expectedNames[i])
-          << "Lambda parameter mismatch at index " << i << ".";
-      AXIOM_RETURN_FALSE_IF_FAILURE
+      parameters.emplace(expectedNames[i], actualNames[i]);
     }
 
-    matchImpl(lambda->body(), expectedLambda->body());
+    matchImpl(
+        lambda->body(),
+        ExprMatcher::rewriteInputNames(expectedLambda->body(), parameters));
     return !::testing::Test::HasNonfatalFailure();
   }
 
@@ -336,6 +340,22 @@ bool matchImpl(const TypedExprPtr& actual, const ExprPtr& expected) {
 #undef AXIOM_RETURN_FALSE_IF_FAILURE
 
 } // namespace
+
+core::ExprPtr ExprMatcher::rewriteInputNames(
+    const core::ExprPtr& expr,
+    const std::unordered_map<std::string, std::string>& mapping) {
+  return core::ExprRewriter::rewrite(
+      expr, [&](const core::ExprPtr& e) -> core::ExprPtr {
+        if (const auto* field = core::FieldAccessExpr::tryAsRootColumn(e)) {
+          auto it = mapping.find(field->name());
+          if (it != mapping.end()) {
+            return std::make_shared<core::FieldAccessExpr>(
+                it->second, field->alias());
+          }
+        }
+        return e;
+      });
+}
 
 bool ExprMatcher::match(const TypedExprPtr& actual, const ExprPtr& expected) {
   return matchImpl(actual, expected);

--- a/axiom/optimizer/tests/ExprMatcher.h
+++ b/axiom/optimizer/tests/ExprMatcher.h
@@ -33,6 +33,14 @@ class ExprMatcher {
   /// Returns true if the trees match. On mismatch, sets gtest failures
   /// with SCOPED_TRACE context showing the path through the tree.
   static bool match(const TypedExprPtr& actual, const core::ExprPtr& expected);
+
+  /// Returns 'expr' with every root column reference named in 'mapping'
+  /// replaced by the name it maps to. Used to bind the names a test writes to
+  /// the names the optimizer generated, so expected expressions never spell
+  /// out an internal name.
+  static core::ExprPtr rewriteInputNames(
+      const core::ExprPtr& expr,
+      const std::unordered_map<std::string, std::string>& mapping);
 };
 
 } // namespace facebook::velox::core

--- a/axiom/optimizer/tests/JoinFilterProjectionTest.cpp
+++ b/axiom/optimizer/tests/JoinFilterProjectionTest.cpp
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/optimizer/tests/PlanMatcher.h"
+#include "axiom/optimizer/tests/QueryTestBase.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+
+// A join evaluates its filter once per candidate pair, so v2 moves the parts
+// of the filter that read a single side into that side's input, where they are
+// evaluated once per row. v1 leaves the filter intact, so these plans are
+// v2-only.
+class JoinFilterProjectionTest : public test::QueryTestBase {
+ protected:
+  JoinFilterProjectionTest() {
+    useV2_ = true;
+  }
+
+  void SetUp() override {
+    test::QueryTestBase::SetUp();
+    testConnector_->addTable("t", ROW({"a", "b"}, {BIGINT(), VARCHAR()}));
+    testConnector_->addTable("u", ROW({"x", "y"}, {BIGINT(), VARCHAR()}));
+  }
+
+  core::PlanNodePtr plan(const std::string& sql) {
+    return toSingleNodePlan(parseSelect(sql, kTestConnectorId));
+  }
+};
+
+// An operand reading one side moves into that side's input and the join
+// compares columns. An operand reading both sides stays, with its single-side
+// arguments moved. The inputs project only what the join needs, dropping the
+// columns that fed the moved expressions.
+TEST_F(JoinFilterProjectionTest, basic) {
+  auto matcher =
+      matchScan("t")
+          .project({"a", "length(b) as pt"})
+          .nestedLoopJoin(
+              matchScan("u").project({"x", "length(y) as pu"}).build(),
+              core::JoinType::kInner,
+              "\"and\"(pt < pu, pt + pu > 10, a < x)")
+          .build();
+
+  AXIOM_ASSERT_PLAN(
+      plan(
+          "SELECT a, x FROM t, u "
+          "WHERE length(b) < length(y) AND length(b) + length(y) > 10 AND a < x"),
+      matcher);
+}
+
+// A lambda whose body reads the other side keeps the call in the filter. Only
+// the call's other arguments move, and the outer columns the body reads have to
+// reach the join -- here 'x', which the join does not output.
+TEST_F(JoinFilterProjectionTest, lambdaReadingBothSides) {
+  auto matcher = matchScan("t")
+                     .project({"a", "sequence(1, a + 10) as arr"})
+                     .nestedLoopJoin(
+                         matchScan("u").build(),
+                         core::JoinType::kInner,
+                         "cardinality(filter(arr, z -> x < z)) > 0")
+                     .build();
+
+  AXIOM_ASSERT_PLAN(
+      plan(
+          "SELECT a FROM t, u "
+          "WHERE cardinality(filter(sequence(1, a + 10), z -> z > x)) > 0"),
+      matcher);
+}
+
+// A call whose lambda reads only one side moves as a whole, leaving the join
+// comparing columns.
+TEST_F(JoinFilterProjectionTest, lambdaReadingOneSide) {
+  auto matcher =
+      matchScan("t")
+          .project(
+              {"a",
+               "cardinality(filter(sequence(1, a + 10), z -> a < z)) as c"})
+          .nestedLoopJoin(
+              matchScan("u").build(), core::JoinType::kInner, "x < c")
+          .build();
+
+  AXIOM_ASSERT_PLAN(
+      plan(
+          "SELECT a FROM t, u "
+          "WHERE cardinality(filter(sequence(1, a + 10), z -> z > a)) > x"),
+      matcher);
+}
+
+// A non-deterministic call produces a new value per evaluation, so moving it
+// out of the filter would change results. It stays, while the deterministic
+// operands around it move.
+TEST_F(JoinFilterProjectionTest, nonDeterministic) {
+  auto matcher = matchScan("t")
+                     .project({"a", "cast(length(b) as DOUBLE) as pt"})
+                     .nestedLoopJoin(
+                         matchScan("u")
+                             .project({"x", "cast(length(y) as DOUBLE) as pu"})
+                             .build(),
+                         core::JoinType::kInner,
+                         "pt + random() < pu")
+                     .build();
+
+  AXIOM_ASSERT_PLAN(
+      plan("SELECT a, x FROM t, u WHERE length(b) + random() < length(y)"),
+      matcher);
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/PlanMatcher.cpp
+++ b/axiom/optimizer/tests/PlanMatcher.cpp
@@ -172,23 +172,6 @@ std::pair<std::string, std::string> parseEqualityColumnPair(
   return {lhs->name(), rhs->name()};
 }
 
-velox::core::ExprPtr rewriteInputNames(
-    const velox::core::ExprPtr& expr,
-    const std::unordered_map<std::string, std::string>& mapping) {
-  return core::ExprRewriter::rewrite(
-      expr, [&](const core::ExprPtr& e) -> core::ExprPtr {
-        if (const auto* field =
-                velox::core::FieldAccessExpr::tryAsRootColumn(e)) {
-          auto it = mapping.find(field->name());
-          if (it != mapping.end()) {
-            return std::make_shared<velox::core::FieldAccessExpr>(
-                it->second, field->alias());
-          }
-        }
-        return e;
-      });
-}
-
 class TableScanMatcher : public PlanMatcherImpl<TableScanNode> {
  public:
   explicit TableScanMatcher() : PlanMatcherImpl<TableScanNode>() {}
@@ -354,7 +337,7 @@ class FilterMatcher : public PlanMatcherImpl<FilterNode> {
     if (predicate_.has_value()) {
       auto expected = parseExpr(predicate_.value());
       if (!symbols.empty()) {
-        expected = rewriteInputNames(expected, symbols);
+        expected = ExprMatcher::rewriteInputNames(expected, symbols);
       }
       ExprMatcher::match(plan.filter(), expected->dropAlias());
     }
@@ -403,7 +386,7 @@ class ProjectMatcher : public PlanMatcherImpl<ProjectNode> {
         }
 
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
 
         ExprMatcher::match(plan.projections()[i], expected->dropAlias());
@@ -494,7 +477,7 @@ class UnnestMatcher : public PlanMatcherImpl<UnnestNode> {
       for (auto i = 0; i < replicateExprs_->size(); ++i) {
         auto expected = parseExpr((*replicateExprs_)[i]);
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
 
         EXPECT_EQ(
@@ -510,7 +493,7 @@ class UnnestMatcher : public PlanMatcherImpl<UnnestNode> {
       for (auto i = 0; i < unnestExprs_->size(); ++i) {
         auto expected = parseExpr((*unnestExprs_)[i]);
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
 
         EXPECT_EQ(plan.unnestVariables()[i]->toString(), expected->toString());
@@ -625,7 +608,7 @@ class OrderByMatcher : public PlanMatcherImpl<OrderByNode> {
             parse::DuckSqlExpressionsParser().parseOrderByExpr(ordering_[i]);
         auto expectedExpr = expected.expr;
         if (!symbols.empty()) {
-          expectedExpr = rewriteInputNames(expectedExpr, symbols);
+          expectedExpr = ExprMatcher::rewriteInputNames(expectedExpr, symbols);
         }
 
         EXPECT_EQ(plan.sortingKeys()[i]->toString(), expectedExpr->toString());
@@ -712,7 +695,7 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
       for (auto i = 0; i < groupingKeys_.size(); ++i) {
         auto expected = parseExpr(groupingKeys_[i]);
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
         EXPECT_EQ(plan.groupingKeys()[i]->toString(), expected->toString());
       }
@@ -724,7 +707,8 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
 
       for (auto i = 0; i < aggregates_.size(); ++i) {
         auto aggregateExpr = duckdb::parseAggregateExpr(aggregates_[i], {});
-        auto expected = rewriteInputNames(aggregateExpr, newSymbols);
+        auto expected =
+            ExprMatcher::rewriteInputNames(aggregateExpr, newSymbols);
         if (expected->alias()) {
           newSymbols[expected->alias().value()] = plan.aggregateNames()[i];
         }
@@ -749,7 +733,8 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
 
         if (expectedMask) {
           if (!symbols.empty()) {
-            expectedMask = rewriteInputNames(expectedMask, symbols);
+            expectedMask =
+                ExprMatcher::rewriteInputNames(expectedMask, symbols);
           }
           EXPECT_EQ(mask->toString(), expectedMask->toString())
               << "Mask mismatch for aggregate " << i;
@@ -767,7 +752,7 @@ class AggregationMatcher : public PlanMatcherImpl<AggregationNode> {
         for (auto j = 0; j < expectedOrderBy.size(); ++j) {
           auto expectedKey = expectedOrderBy[j].expr;
           if (!symbols.empty()) {
-            expectedKey = rewriteInputNames(expectedKey, symbols);
+            expectedKey = ExprMatcher::rewriteInputNames(expectedKey, symbols);
           }
 
           EXPECT_EQ(sortingKeys[j]->toString(), expectedKey->toString())
@@ -915,7 +900,7 @@ class HashJoinMatcher : public PlanMatcherImpl<HashJoinNode> {
 
         auto expected = parseExpr(filter_.value());
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
         ExprMatcher::match(plan.filter(), expected->dropAlias());
       }
@@ -964,9 +949,11 @@ class NestedLoopJoinMatcher : public PlanMatcherImpl<NestedLoopJoinNode> {
   NestedLoopJoinMatcher(
       const std::shared_ptr<PlanMatcher>& left,
       const std::shared_ptr<PlanMatcher>& right,
-      JoinType joinType)
+      JoinType joinType,
+      std::optional<std::string> joinCondition)
       : PlanMatcherImpl<NestedLoopJoinNode>({left, right}),
-        joinType_{joinType} {}
+        joinType_{joinType},
+        joinCondition_{std::move(joinCondition)} {}
 
   MatchResult matchDetails(
       const NestedLoopJoinNode& plan,
@@ -982,12 +969,29 @@ class NestedLoopJoinMatcher : public PlanMatcherImpl<NestedLoopJoinNode> {
 
     AXIOM_TEST_RETURN_IF_FAILURE
 
+    if (joinCondition_.has_value()) {
+      if (joinCondition_->empty()) {
+        EXPECT_EQ(plan.joinCondition(), nullptr);
+      } else {
+        EXPECT_NE(plan.joinCondition(), nullptr);
+        AXIOM_TEST_RETURN_IF_FAILURE
+
+        auto expected = parseExpr(joinCondition_.value());
+        if (!symbols.empty()) {
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
+        }
+        ExprMatcher::match(plan.joinCondition(), expected->dropAlias());
+      }
+      AXIOM_TEST_RETURN_IF_FAILURE
+    }
+
     // Propagate existing aliases from source matchers.
     return MatchResult::success(symbols);
   }
 
  private:
   const std::optional<JoinType> joinType_;
+  const std::optional<std::string> joinCondition_;
 };
 
 // Type of shuffle boundary for matching.
@@ -1143,7 +1147,7 @@ void verifyMergeOrdering(
         parse::DuckSqlExpressionsParser().parseOrderByExpr(ordering[i]);
     auto expectedExpr = expected.expr;
     if (!symbols.empty()) {
-      expectedExpr = rewriteInputNames(expectedExpr, symbols);
+      expectedExpr = ExprMatcher::rewriteInputNames(expectedExpr, symbols);
     }
     EXPECT_EQ(merge.sortingKeys()[i]->toString(), expectedExpr->toString());
     EXPECT_EQ(merge.sortingOrders()[i].isAscending(), expected.ascending);
@@ -1352,7 +1356,7 @@ class EnforceDistinctMatcher : public PlanMatcherImpl<EnforceDistinctNode> {
       for (auto i = 0; i < distinctKeys_.size(); ++i) {
         auto expected = parseExpr(distinctKeys_[i]);
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
         EXPECT_EQ(plan.distinctKeys()[i]->toString(), expected->toString());
       }
@@ -1460,7 +1464,7 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
     for (auto i = 0; i < expected->partitionKeys().size(); ++i) {
       auto expectedKey = expected->partitionKeys()[i];
       if (!symbols.empty()) {
-        expectedKey = rewriteInputNames(expectedKey, symbols);
+        expectedKey = ExprMatcher::rewriteInputNames(expectedKey, symbols);
       }
       EXPECT_EQ(plan.partitionKeys()[i]->toString(), expectedKey->toString())
           << "Partition key mismatch at index " << i;
@@ -1478,7 +1482,7 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
     for (auto i = 0; i < expected->orderByKeys().size(); ++i) {
       auto expectedKey = expected->orderByKeys()[i].expr;
       if (!symbols.empty()) {
-        expectedKey = rewriteInputNames(expectedKey, symbols);
+        expectedKey = ExprMatcher::rewriteInputNames(expectedKey, symbols);
       }
       EXPECT_EQ(plan.sortingKeys()[i]->toString(), expectedKey->toString())
           << "Order by key mismatch at index " << i;
@@ -1512,7 +1516,7 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
       }
 
       if (!symbols.empty()) {
-        expectedCall = rewriteInputNames(expectedCall, symbols);
+        expectedCall = ExprMatcher::rewriteInputNames(expectedCall, symbols);
       }
 
       // Compare just the function call (name + args), not the window spec.
@@ -1553,7 +1557,8 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
 
       auto expectedStartValue = expected.startValue;
       if (!symbols.empty()) {
-        expectedStartValue = rewriteInputNames(expectedStartValue, symbols);
+        expectedStartValue =
+            ExprMatcher::rewriteInputNames(expectedStartValue, symbols);
       }
       EXPECT_EQ(actual.startValue->toString(), expectedStartValue->toString())
           << "Frame start value mismatch at index " << index;
@@ -1571,7 +1576,8 @@ class WindowMatcher : public PlanMatcherImpl<WindowNode> {
 
       auto expectedEndValue = expected.endValue;
       if (!symbols.empty()) {
-        expectedEndValue = rewriteInputNames(expectedEndValue, symbols);
+        expectedEndValue =
+            ExprMatcher::rewriteInputNames(expectedEndValue, symbols);
       }
       EXPECT_EQ(actual.endValue->toString(), expectedEndValue->toString())
           << "Frame end value mismatch at index " << index;
@@ -1859,7 +1865,7 @@ class GroupIdMatcher : public PlanMatcherImpl<GroupIdNode> {
       for (auto i = 0; i < aggregationInputs_->size(); ++i) {
         auto expected = parseExpr((*aggregationInputs_)[i]);
         if (!symbols.empty()) {
-          expected = rewriteInputNames(expected, symbols);
+          expected = ExprMatcher::rewriteInputNames(expected, symbols);
         }
         EXPECT_EQ(
             plan.aggregationInputs()[i]->toString(), expected->toString());
@@ -2124,10 +2130,11 @@ PlanMatcherBuilder& PlanMatcherBuilder::hashJoin(
 
 PlanMatcherBuilder& PlanMatcherBuilder::nestedLoopJoin(
     const std::shared_ptr<PlanMatcher>& rightMatcher,
-    JoinType joinType) {
+    JoinType joinType,
+    std::optional<std::string> joinCondition) {
   VELOX_USER_CHECK_NOT_NULL(matcher_);
-  matcher_ =
-      std::make_shared<NestedLoopJoinMatcher>(matcher_, rightMatcher, joinType);
+  matcher_ = std::make_shared<NestedLoopJoinMatcher>(
+      matcher_, rightMatcher, joinType, std::move(joinCondition));
   return *this;
 }
 

--- a/axiom/optimizer/tests/PlanMatcher.h
+++ b/axiom/optimizer/tests/PlanMatcher.h
@@ -454,9 +454,12 @@ class PlanMatcherBuilder {
   /// join type.
   /// @param rightMatcher Matcher for the right side of the join.
   /// @param joinType Type of join (defaults to kInner).
+  /// @param joinCondition When set, asserts the join condition (e.g., "a > b").
+  /// Empty string asserts no join condition, i.e. a plain cross join.
   PlanMatcherBuilder& nestedLoopJoin(
       const std::shared_ptr<PlanMatcher>& rightMatcher,
-      JoinType joinType = JoinType::kInner);
+      JoinType joinType = JoinType::kInner,
+      std::optional<std::string> joinCondition = std::nullopt);
 
   /// Matches any LocalPartition node.
   PlanMatcherBuilder& localPartition();

--- a/axiom/optimizer/tests/UnnestTest.cpp
+++ b/axiom/optimizer/tests/UnnestTest.cpp
@@ -1263,10 +1263,12 @@ TEST_P(UnnestTest, crossJoinSingleRowAggregateAndUnnest) {
   auto logicalPlan = parseSelect(query, kTestConnectorId);
   auto plan = toSingleNodePlan(logicalPlan);
 
-  // v2 fuses the filter into the join; v1 keeps it separate.
+  // v2 fuses the filter into the join and computes the join condition's
+  // single-side cast in the input; v1 keeps the filter separate.
   AXIOM_ASSERT_PLAN(
       plan,
       matchScan("t")
+          .projectIf(useV2_, {"a", "ids", "a::BIGINT"})
           .nestedLoopJoin(
               matchScan("u").singleAggregation({}, {"count(*) as c"}).build())
           .filterIf(!useV2_, "c > a::BIGINT")

--- a/axiom/optimizer/tests/sql/join.sql
+++ b/axiom/optimizer/tests/sql/join.sql
@@ -170,3 +170,10 @@ JOIN (VALUES (1, 2)) AS b (k, v) ON s.k = b.k
 -- Cross join where one relation has no equi-predicate and is connected
 -- only by an inequality: the theta predicate must still be applied.
 SELECT t1.a, t2.a FROM t t1, t t2, t t3 WHERE t1.a = t3.a AND t1.b < t2.b
+----
+-- A join filter discards an error raised by one conjunct for a row that
+-- another conjunct evaluates to false. v2 computes 1000 / (150 - t1.b) in the
+-- input instead, where nothing masks it, so the row with t1.b = 150 fails --
+-- even though no pair containing it satisfies t1.b < t2.b.
+-- error_v2: division by zero
+SELECT t1.a, t2.a FROM t t1, t t2 WHERE t1.b < t2.b AND 1000 / (150 - t1.b) > t2.a

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -156,11 +156,9 @@ ExprCP ExprFactory::makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr) {
 namespace {
 
 // Rebuilds `call` with each argument substituted, sharing the original
-// when no argument changed. Substituted calls go through `Builder::makeCall`
-// so hash-consing stays canonical.
+// when no argument changed.
 ExprCP substituteCall(
     ExprFactory& factory,
-    Builder& builder,
     const Call* call,
     const ColumnVector& sources,
     const ExprVector& targets) {
@@ -178,16 +176,11 @@ ExprCP substituteCall(
     return call;
   }
 
-  const bool specialForm = SpecialFormCallNames::isSpecialForm(call->name());
-  const FunctionSet functions =
-      Call::unionArgFunctions(functionBits(call->name(), specialForm), newArgs);
-  return builder.makeCall(
-      call->name(), call->value(), std::move(newArgs), functions);
+  return factory.rebuildCall(call, std::move(newArgs));
 }
 
-// Rebuilds `field` with its base substituted. Field is arena-allocated
-// (not hash-consed in Builder), so it goes through `make`,
-// which is safe in v2-only contexts.
+// Rebuilds `field` with its base substituted, sharing the original when the
+// base did not change.
 ExprCP substituteField(
     ExprFactory& factory,
     const Field* field,
@@ -197,10 +190,7 @@ ExprCP substituteField(
   if (newBase == field->base()) {
     return field;
   }
-  if (field->field() != nullptr) {
-    return make<Field>(field->value().type, newBase, field->field());
-  }
-  return make<Field>(field->value().type, newBase, field->index());
+  return factory.rebuildField(field, newBase);
 }
 
 // Rebuilds `lambda` with its body substituted. The lambda's bound args
@@ -259,8 +249,7 @@ ExprCP ExprFactory::substitute(
     case PlanType::kLiteralExpr:
       return expr;
     case PlanType::kCallExpr:
-      return substituteCall(
-          *this, builder_, expr->as<Call>(), sources, targets);
+      return substituteCall(*this, expr->as<Call>(), sources, targets);
     case PlanType::kFieldExpr:
       return substituteField(*this, expr->as<Field>(), sources, targets);
     case PlanType::kLambdaExpr:
@@ -282,6 +271,21 @@ ExprVector ExprFactory::substitute(
     substituted.push_back(substitute(expr, sources, targets));
   }
   return substituted;
+}
+
+ExprCP ExprFactory::rebuildField(const Field* field, ExprCP base) {
+  if (field->field() != nullptr) {
+    return make<Field>(field->value().type, base, field->field());
+  }
+  return make<Field>(field->value().type, base, field->index());
+}
+
+ExprCP ExprFactory::rebuildCall(const Call* call, ExprVector args) {
+  const bool specialForm = SpecialFormCallNames::isSpecialForm(call->name());
+  const FunctionSet functions =
+      Call::unionArgFunctions(functionBits(call->name(), specialForm), args);
+  return builder_.makeCall(
+      call->name(), call->value(), std::move(args), functions);
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -116,6 +116,17 @@ class ExprFactory {
       const ColumnVector& sources,
       const ExprVector& targets);
 
+  /// Returns `call` with its arguments replaced by 'args', preserving
+  /// the name, value and special-form-ness and recomputing the
+  /// `FunctionSet` from the new arguments. Goes through
+  /// `Builder::makeCall` so hash-consing stays canonical.
+  ExprCP rebuildCall(const Call* call, ExprVector args);
+
+  /// Returns `field` with its base replaced by 'base', preserving whether
+  /// the field is named or positional. `Field` is arena-allocated rather
+  /// than hash-consed, so this goes through `make`.
+  ExprCP rebuildField(const Field* field, ExprCP base);
+
   /// Left-folds a non-empty sequence of boolean predicates with
   /// `makeAnd`: `[p1, p2, p3]` → `AND(AND(p1, p2), p3)`. Single-element
   /// input returns the predicate unchanged. The empty case is a

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -118,6 +118,7 @@ ExprCP PrecomputeProjections::toColumn(
   if (allowConstant && expr->is(PlanType::kLiteralExpr)) {
     return expr;
   }
+
   if (expr->is(PlanType::kColumnExpr)) {
     // In narrowing mode the project is not seeded with the input columns, so a
     // referenced passthrough column must be added explicitly. This is not a
@@ -127,19 +128,23 @@ ExprCP PrecomputeProjections::toColumn(
     }
     return expr;
   }
+
   // Lambdas are consumed by their parent higher-order function directly
   // and cannot be evaluated by a Project node.
   if (expr->is(PlanType::kLambdaExpr)) {
     return expr;
   }
+
   if (auto it = seen_.find(expr); it != seen_.end()) {
     return it->second;
   }
+
   if (alias != nullptr) {
     addToProject(expr, alias);
     needsProject_ = true;
     return alias;
   }
+
   // A compound expression materializes into a column named after its id, so the
   // same expression always lifts to the same name. If a column of that name is
   // already in the input — e.g. an exchange below this consumer lifted the same
@@ -152,6 +157,7 @@ ExprCP PrecomputeProjections::toColumn(
       return column;
     }
   }
+
   ColumnCP column = make<Column>(name, nullptr, expr->value());
   addToProject(expr, column);
   needsProject_ = true;
@@ -171,6 +177,151 @@ void PrecomputeProjections::addToProject(ExprCP expr, ColumnCP column) {
   seen_.emplace(expr, column);
   outColumns_.emplace_back(column);
   outExprs_.emplace_back(expr);
+}
+
+// Moves the single-side parts of a join filter into the inputs. See
+// PrecomputeProjectionsPass for why and for the effect on error masking.
+//
+// A subexpression moves when it reads at least one column, reads no column from
+// the other side, and is deterministic. The walk moves the highest such node
+// and does not descend into it, so a subexpression moves as a whole rather than
+// piecewise.
+class JoinFilterRewriter {
+ public:
+  JoinFilterRewriter(
+      PrecomputeProjections& leftPrecompute,
+      PrecomputeProjections& rightPrecompute,
+      const PlanObjectSet& leftColumns,
+      const PlanObjectSet& rightColumns,
+      Builder& builder)
+      : leftPrecompute_{leftPrecompute},
+        rightPrecompute_{rightPrecompute},
+        leftColumns_{leftColumns},
+        rightColumns_{rightColumns},
+        builder_{builder} {}
+
+  // Returns 'filter' with each maximal single-side subexpression replaced by
+  // the column it was moved to. Every column the result still reads is added to
+  // its side's projection, so the caller need not keep filter columns alive
+  // separately.
+  ExprVector rewrite(const ExprVector& filter);
+
+ private:
+  ExprCP rewrite(ExprCP expr);
+  ExprCP rewriteCall(const Call* call);
+  ExprCP rewriteField(const Field* field);
+
+  // Computes 'expr' in the input that supplies all of its columns and returns
+  // the column it became there. Returns nullptr, leaving 'expr' in the filter,
+  // when no single input supplies its columns or 'expr' is non-deterministic.
+  ExprCP tryPrecompute(ExprCP expr);
+
+  // Adds 'column' to the projection of the input that produces it.
+  void keep(ColumnCP column);
+
+  PrecomputeProjections& leftPrecompute_;
+  PrecomputeProjections& rightPrecompute_;
+  const PlanObjectSet& leftColumns_;
+  const PlanObjectSet& rightColumns_;
+  Builder& builder_;
+};
+
+ExprVector JoinFilterRewriter::rewrite(const ExprVector& filter) {
+  ExprVector result;
+  result.reserve(filter.size());
+  for (ExprCP conjunct : filter) {
+    result.push_back(rewrite(conjunct));
+  }
+  return result;
+}
+
+ExprCP JoinFilterRewriter::rewrite(ExprCP expr) {
+  switch (expr->type()) {
+    case PlanType::kCallExpr:
+      return rewriteCall(expr->as<Call>());
+    case PlanType::kFieldExpr:
+      return rewriteField(expr->as<Field>());
+    case PlanType::kColumnExpr:
+      keep(expr->as<Column>());
+      return expr;
+    case PlanType::kLiteralExpr:
+      // No columns to keep and nothing to compute.
+      return expr;
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected expression in a join filter: {}", expr->toString());
+  }
+}
+
+ExprCP JoinFilterRewriter::rewriteCall(const Call* call) {
+  if (ExprCP column = tryPrecompute(call)) {
+    return column;
+  }
+
+  ExprVector newArgs;
+  newArgs.reserve(call->args().size());
+  bool changed = false;
+  for (ExprCP arg : call->args()) {
+    if (arg->is(PlanType::kLambdaExpr)) {
+      // A Project cannot evaluate a Lambda on its own, so it stays with the
+      // call that binds its arguments. Its columns are the outer ones the body
+      // reads -- `Lambda` excludes the bound arguments from that set -- and
+      // those still have to reach the join.
+      arg->columns().forEach<Column>([&](ColumnCP column) { keep(column); });
+      newArgs.push_back(arg);
+      continue;
+    }
+    ExprCP newArg = rewrite(arg);
+    changed |= newArg != arg;
+    newArgs.push_back(newArg);
+  }
+  if (!changed) {
+    return call;
+  }
+  return ExprFactory(builder_).rebuildCall(call, std::move(newArgs));
+}
+
+ExprCP JoinFilterRewriter::rewriteField(const Field* field) {
+  if (ExprCP column = tryPrecompute(field)) {
+    return column;
+  }
+  ExprCP newBase = rewrite(field->base());
+  if (newBase == field->base()) {
+    return field;
+  }
+  return ExprFactory(builder_).rebuildField(field, newBase);
+}
+
+ExprCP JoinFilterRewriter::tryPrecompute(ExprCP expr) {
+  // A non-deterministic expression has to produce a new value per pair.
+  if (expr->containsNonDeterministic()) {
+    return nullptr;
+  }
+  // A constant is the same for every row; projecting it would only add a
+  // column.
+  if (expr->columns().empty()) {
+    return nullptr;
+  }
+  if (leftColumns_.containsColumns(expr)) {
+    return leftPrecompute_.toColumn(expr);
+  }
+  if (rightColumns_.containsColumns(expr)) {
+    return rightPrecompute_.toColumn(expr);
+  }
+  // 'expr' reads both inputs.
+  return nullptr;
+}
+
+void JoinFilterRewriter::keep(ColumnCP column) {
+  if (leftColumns_.contains(column)) {
+    leftPrecompute_.toColumn(column);
+  } else {
+    VELOX_CHECK(
+        rightColumns_.contains(column),
+        "Join filter reads a column neither input produces: {}",
+        column->toString());
+    rightPrecompute_.toColumn(column);
+  }
 }
 
 // Returns a new ColumnVector with the first `oldPrefixLength` elements
@@ -397,8 +548,8 @@ NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
   }
 
   // Keep each side's passthrough columns: those it contributes to the join
-  // output or references in the join filter. A column produced by the join
-  // itself (e.g. a semijoin mark) belongs to neither input and is skipped.
+  // output. A column produced by the join itself (e.g. a semijoin mark) belongs
+  // to neither input and is skipped.
   const auto leftColumns = PlanObjectSet::fromObjects(newLeft->outputColumns());
   const auto rightColumns =
       PlanObjectSet::fromObjects(newRight->outputColumns());
@@ -412,8 +563,17 @@ NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
   for (ColumnCP column : join->outputColumns()) {
     keepPassthrough(column);
   }
-  for (ExprCP conjunct : join->filter()) {
-    conjunct->columns().forEach<Column>(keepPassthrough);
+
+  ExprVector newFilter;
+  if (newLeftKeys.empty()) {
+    JoinFilterRewriter rewriter{
+        leftPrecompute, rightPrecompute, leftColumns, rightColumns, builder()};
+    newFilter = rewriter.rewrite(join->filter());
+  } else {
+    newFilter = join->filter();
+    for (ExprCP conjunct : newFilter) {
+      conjunct->columns().forEach<Column>(keepPassthrough);
+    }
   }
 
   return builder().make<Join>(
@@ -422,7 +582,7 @@ NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
        join->joinType(),
        std::move(newLeftKeys),
        std::move(newRightKeys),
-       join->filter(),
+       std::move(newFilter),
        join->nullAware(),
        join->nullAsValue(),
        join->outputColumns()});

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.h
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.h
@@ -21,21 +21,47 @@
 
 namespace facebook::axiom::optimizer::v2 {
 
-/// Lifts compound expressions into `Project`s wherever Velox requires a column
-/// or literal.
+/// Moves expressions a consumer references into a `Project` over its input.
 class PrecomputeProjectionsPass {
  public:
-  /// Returns the tree rooted at 'node' rewritten so every position where Velox
-  /// demands a `FieldAccessTypedExpr` (or, where allowed, a constant) carries a
-  /// `Column` (or `Literal`) instead of a compound expression. Such compound
-  /// expressions are lifted into a `Project` inserted between the consumer and
-  /// its input, and the consumer is rebuilt to reference the projected column.
-  /// Affected consumer kinds and positions:
+  /// Returns the tree rooted at 'node' rewritten so the expressions listed
+  /// below are computed by a `Project` inserted between the consumer and its
+  /// input, with the consumer rebuilt to reference the projected column.
+  ///
+  /// Most positions are moved because Velox demands a `FieldAccessTypedExpr`
+  /// (or, where allowed, a constant) there:
   ///   - Aggregate: grouping keys, aggregate args, FILTER mask, ORDER BY keys
   ///   - Window:    partition keys, order keys, function args
   ///   - Sort:      order keys
   ///   - Unnest:    unnest expressions
-  /// Returns the original tree unchanged when no lifting is required.
+  ///   - Join:      join keys
+  ///   - Exchange:  hash partitioning keys
+  ///
+  /// A join filter is the one exception: Velox accepts any expression there,
+  /// so the move is an optimization rather than a requirement.
+  ///
+  /// A join with no equi keys evaluates its filter once for every pair of
+  /// input rows. A subexpression of the filter that reads only one side has
+  /// the same value for every pair built from a given row of that side, so
+  /// computing it in that side's input costs one evaluation per row instead of
+  /// one per pair. Each maximal such subexpression is moved. A
+  /// non-deterministic one is not: it has to produce a new value per pair.
+  ///
+  /// A join with equi keys is left alone, because its filter runs only on the
+  /// pairs that match on the keys, and there can be far fewer of those than
+  /// either input has rows.
+  ///
+  /// TODO: Decide from the estimated number of pairs reaching the filter
+  /// rather than from the absence of equi keys.
+  ///
+  /// Moving a subexpression out of a filter takes it out of the filter's error
+  /// masking, where an error from one conjunct is discarded for a row that
+  /// another conjunct evaluates to false. `a <> 0 AND 1000 / a > x` does not
+  /// fail as a filter, but does once `1000 / a` is computed by a `Project`.
+  /// SQL does not define an evaluation order, so that masking is not a
+  /// property the optimizer preserves.
+  ///
+  /// Returns the original tree unchanged when nothing needs to move.
   static NodeCP run(NodeCP node, Builder& builder);
 };
 


### PR DESCRIPTION
Summary:

A join with no equi keys evaluates its filter once for every pair of input rows, so a filter expression that reads only one side is evaluated far more often than it needs to be. For example:

    SELECT a.x, b.x FROM t a, t b WHERE length(upper(a.s)) <= length(lower(b.s))

with 200 rows on each side evaluates each `length(upper(...))` 40,000 times rather than 200.

Each maximal subexpression of the filter that reads a single side now moves into that side's `Project`, and the filter compares the resulting columns. A non-deterministic subexpression stays where it is, since it has to produce a new value per pair.

Joins with equi keys are left alone. Their filter runs only on the pairs that match on the keys, and there can be far fewer of those than either input has rows, so moving the work can cost more than it saves. Choosing by the estimated pair count instead needs an estimate this pass does not have; a TODO records it.

One behavior change: a filter discards an error raised by one conjunct for a row that another conjunct rejects. Computing the expression in an input removes that protection, so `a <> 0 AND 1000 / a > x` in a join condition can now fail where it previously returned rows. SQL does not define an evaluation order, so that masking is not a property the optimizer preserves.

Differential Revision: D115488115
