### PR TITLE
fix(optimizer): Estimate joins with their filter

### DIFF
--- a/axiom/optimizer/v2/Builder.cpp
+++ b/axiom/optimizer/v2/Builder.cpp
@@ -160,4 +160,36 @@ void Builder::addEquivalences(const Join::Key& key) {
   }
 }
 
+std::pair<NodeCP, ExprVector> Builder::materializeKeys(
+    NodeCP input,
+    const ExprVector& keys) {
+  if (std::all_of(keys.begin(), keys.end(), [](ExprCP key) {
+        return key->is(PlanType::kColumnExpr);
+      })) {
+    return {input, keys};
+  }
+
+  ExprVector exprs;
+  ColumnVector columns;
+  for (ColumnCP column : input->outputColumns()) {
+    exprs.push_back(column);
+    columns.push_back(column);
+  }
+  ExprVector newKeys;
+  newKeys.reserve(keys.size());
+  for (ExprCP key : keys) {
+    if (key->is(PlanType::kColumnExpr)) {
+      newKeys.push_back(key);
+      continue;
+    }
+    ColumnCP column = Column::create("__p", key->value());
+    exprs.push_back(key);
+    columns.push_back(column);
+    newKeys.push_back(column);
+  }
+  return {
+      make<Project>({input, std::move(exprs), std::move(columns)}),
+      std::move(newKeys)};
+}
+
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -144,6 +144,17 @@ class Builder {
     return functionNames_;
   }
 
+  /// Computes any key in 'keys' that is not already a column, returning
+  /// 'input' wrapped in a `Project` that adds those columns alongside its own,
+  /// and 'keys' with each such key replaced by its column. An `Exchange`
+  /// requires column keys; materializing before the shuffle is placed lets the
+  /// consumer above read the same column instead of computing the value a
+  /// second time. Returns 'input' and 'keys' unchanged when every key is
+  /// already a column.
+  std::pair<NodeCP, ExprVector> materializeKeys(
+      NodeCP input,
+      const ExprVector& keys);
+
  private:
   // For a binary `Call` whose 'name' is in `reversibleFunctions_`,
   // swaps 'args' (and renames to the reverse) when `args[0]` should

--- a/axiom/optimizer/v2/CostModel.cpp
+++ b/axiom/optimizer/v2/CostModel.cpp
@@ -77,6 +77,11 @@ std::optional<float> sideRowCount(
 // derived NDV of an aggregate output) with the column's base `value()` as
 // fallback. An unknown key NDV makes it unknown; a zero-NDV key makes it 0
 // (empty join).
+//
+// `JoinFanout::estimateJoinCardinality` answers the same question for a join
+// that is already built, from one joint NDV over all keys capped by the operand
+// cardinalities. That form depends on how the cover was split, so it cannot be
+// used here.
 std::optional<float> innerEdgeSelectivity(
     const JoinEdge& edge,
     const JoinHypergraph& graph,
@@ -106,6 +111,27 @@ std::optional<float> innerEdgeSelectivity(
     jointNdvRight = std::min(jointNdvRight, *rightRows);
   }
   return 1.0f / std::max(jointNdvLeft, jointNdvRight);
+}
+
+// The conjuncts this join evaluates: for an inner join those the emitter places
+// here — within this cover but within neither child's, so no child has applied
+// them — and for any other type the edge's own filter. Assigning a conjunct to
+// the lowest cover containing it keeps a cover's estimate independent of how
+// the cover was split, as the edge selectivities are.
+ExprVector appliedConjuncts(const JoinOp& join, const JoinHypergraph& graph) {
+  const auto& edge = graph.edges()[join.edgeIndex];
+  if (edge.joinType() != velox::core::JoinType::kInner) {
+    return ExprVector{edge.filter()};
+  }
+  ExprVector result;
+  for (const auto& conjunct : graph.filterConjuncts()) {
+    if (conjunct.relations.isSubset(join.cover()) &&
+        !conjunct.relations.isSubset(join.left->cover()) &&
+        !conjunct.relations.isSubset(join.right->cover())) {
+      result.push_back(conjunct.expr);
+    }
+  }
+  return result;
 }
 
 // Product of the operand cardinalities and the selectivities of the edges
@@ -242,19 +268,18 @@ joinEstimate(const JoinOp& join, const JoinHypergraph& graph, BySetMap& bySet) {
 
   const std::optional<float> matched = innerMatchCardinality(
       join, graph, result.constraints, left.cardinality, right.cardinality);
-  if (edge.joinType() == velox::core::JoinType::kInner) {
-    result.cardinality = maxOf(1.0f, matched);
-  } else {
-    const bool edgeLeftIsPhysicalLeft =
-        edge.left().isSubset(join.left->cover());
-    result.cardinality = maxOf(
-        1.0f,
-        JoinFanout::outputCardinality(
-            edge.joinType(),
-            edgeLeftIsPhysicalLeft ? left.cardinality : right.cardinality,
-            edgeLeftIsPhysicalLeft ? right.cardinality : left.cardinality,
-            matched));
-  }
+  // Operands are passed in the edge's orientation, which `outputCardinality`
+  // requires for kAnti: a reversed antijoin swaps them but has no flipped type.
+  const bool edgeLeftIsPhysicalLeft = edge.left().isSubset(join.left->cover());
+  result.cardinality = maxOf(
+      1.0f,
+      JoinFanout::outputCardinality(
+          edge.joinType(),
+          edgeLeftIsPhysicalLeft ? left.cardinality : right.cardinality,
+          edgeLeftIsPhysicalLeft ? right.cardinality : left.cardinality,
+          matched,
+          appliedConjuncts(join, graph),
+          result.constraints));
   return bySet.emplace(cover, std::move(result)).first->second;
 }
 

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -264,7 +264,12 @@ Estimate EstimateProvider::compute(NodeCP node) {
           join->rightKeys(),
           result.constraints);
       const std::optional<float> cardinality = JoinFanout::outputCardinality(
-          join->joinType(), left.cardinality, right.cardinality, matched);
+          join->joinType(),
+          left.cardinality,
+          right.cardinality,
+          matched,
+          join->filter(),
+          result.constraints);
       result.cardinality = maxOf(1.0f, cardinality);
       return result;
     }

--- a/axiom/optimizer/v2/ExprFactory.cpp
+++ b/axiom/optimizer/v2/ExprFactory.cpp
@@ -155,19 +155,18 @@ ExprCP ExprFactory::makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr) {
 
 namespace {
 
-// Rebuilds `call` with each argument substituted, sharing the original
+// Rebuilds `call` with each argument replaced, sharing the original
 // when no argument changed.
-ExprCP substituteCall(
+ExprCP replaceInCall(
     ExprFactory& factory,
     const Call* call,
-    const ColumnVector& sources,
-    const ExprVector& targets) {
+    const ExprFactory::ExprSubstitution& mapping) {
   ExprVector newArgs;
   newArgs.reserve(call->args().size());
 
   bool anyChange = false;
   for (ExprCP arg : call->args()) {
-    ExprCP newArg = factory.substitute(arg, sources, targets);
+    ExprCP newArg = factory.replace(arg, mapping);
     anyChange |= newArg != arg;
     newArgs.push_back(newArg);
   }
@@ -179,98 +178,109 @@ ExprCP substituteCall(
   return factory.rebuildCall(call, std::move(newArgs));
 }
 
-// Rebuilds `field` with its base substituted, sharing the original when the
+// Rebuilds `field` with its base replaced, sharing the original when the
 // base did not change.
-ExprCP substituteField(
+ExprCP replaceInField(
     ExprFactory& factory,
     const Field* field,
-    const ColumnVector& sources,
-    const ExprVector& targets) {
-  ExprCP newBase = factory.substitute(field->base(), sources, targets);
+    const ExprFactory::ExprSubstitution& mapping) {
+  ExprCP newBase = factory.replace(field->base(), mapping);
   if (newBase == field->base()) {
     return field;
   }
   return factory.rebuildField(field, newBase);
 }
 
-// Rebuilds `lambda` with its body substituted. The lambda's bound args
-// shadow any same-named outer column, so they are removed from the
-// source mapping before recursing — a caller's substitution set can't
-// rebind them.
-ExprCP substituteLambda(
+// Rebuilds `lambda` with its body replaced. The lambda's bound args shadow
+// anything outside, so they are dropped from the mapping before recursing.
+ExprCP replaceInLambda(
     ExprFactory& factory,
     const Lambda* lambda,
-    const ColumnVector& sources,
-    const ExprVector& targets) {
-  ColumnVector filteredSources;
-  ExprVector filteredTargets;
-  filteredSources.reserve(sources.size());
-  filteredTargets.reserve(targets.size());
-  const auto& boundArgs = lambda->args();
-  for (size_t i = 0; i < sources.size(); ++i) {
+    const ExprFactory::ExprSubstitution& mapping) {
+  ExprFactory::ExprSubstitution visible;
+  visible.reserve(mapping.size());
+  for (const auto& [source, target] : mapping) {
     bool isBound = false;
-    for (ColumnCP boundArg : boundArgs) {
-      if (boundArg == sources[i]) {
+    for (ColumnCP boundArg : lambda->args()) {
+      if (boundArg == source) {
         isBound = true;
         break;
       }
     }
     if (!isBound) {
-      filteredSources.push_back(sources[i]);
-      filteredTargets.push_back(targets[i]);
+      visible.emplace(source, target);
     }
   }
-  ExprCP newBody =
-      factory.substitute(lambda->body(), filteredSources, filteredTargets);
+  ExprCP newBody = factory.replace(lambda->body(), visible);
   if (newBody == lambda->body()) {
     return lambda;
   }
   return make<Lambda>(lambda->args(), lambda->value().type, newBody);
 }
 
+ExprFactory::ExprSubstitution toSubstitution(
+    const ColumnVector& sources,
+    const ExprVector& targets) {
+  VELOX_CHECK_EQ(sources.size(), targets.size());
+  ExprFactory::ExprSubstitution mapping;
+  mapping.reserve(sources.size());
+  for (size_t i = 0; i < sources.size(); ++i) {
+    const bool inserted = mapping.emplace(sources[i], targets[i]).second;
+    VELOX_CHECK(
+        inserted, "Duplicate substitution source: {}", sources[i]->toString());
+  }
+  return mapping;
+}
+
 } // namespace
+
+ExprCP ExprFactory::replace(ExprCP expr, const ExprSubstitution& mapping) {
+  if (expr == nullptr) {
+    return nullptr;
+  }
+  if (auto it = mapping.find(expr); it != mapping.end()) {
+    return it->second;
+  }
+  switch (expr->type()) {
+    case PlanType::kColumnExpr:
+    case PlanType::kLiteralExpr:
+      return expr;
+    case PlanType::kCallExpr:
+      return replaceInCall(*this, expr->as<Call>(), mapping);
+    case PlanType::kFieldExpr:
+      return replaceInField(*this, expr->as<Field>(), mapping);
+    case PlanType::kLambdaExpr:
+      return replaceInLambda(*this, expr->as<Lambda>(), mapping);
+    default:
+      VELOX_NYI(
+          "ExprFactory::replace: unsupported expression type {}",
+          expr->typeName());
+  }
+}
+
+ExprVector ExprFactory::replace(
+    const ExprVector& exprs,
+    const ExprSubstitution& mapping) {
+  ExprVector result;
+  result.reserve(exprs.size());
+  for (ExprCP expr : exprs) {
+    result.push_back(replace(expr, mapping));
+  }
+  return result;
+}
 
 ExprCP ExprFactory::substitute(
     ExprCP expr,
     const ColumnVector& sources,
     const ExprVector& targets) {
-  if (expr == nullptr) {
-    return nullptr;
-  }
-  switch (expr->type()) {
-    case PlanType::kColumnExpr: {
-      for (size_t i = 0; i < sources.size(); ++i) {
-        if (sources[i] == expr) {
-          return targets[i];
-        }
-      }
-      return expr;
-    }
-    case PlanType::kLiteralExpr:
-      return expr;
-    case PlanType::kCallExpr:
-      return substituteCall(*this, expr->as<Call>(), sources, targets);
-    case PlanType::kFieldExpr:
-      return substituteField(*this, expr->as<Field>(), sources, targets);
-    case PlanType::kLambdaExpr:
-      return substituteLambda(*this, expr->as<Lambda>(), sources, targets);
-    default:
-      VELOX_NYI(
-          "ExprFactory::substitute: unsupported expression type {}",
-          expr->typeName());
-  }
+  return replace(expr, toSubstitution(sources, targets));
 }
 
 ExprVector ExprFactory::substitute(
     const ExprVector& exprs,
     const ColumnVector& sources,
     const ExprVector& targets) {
-  ExprVector substituted;
-  substituted.reserve(exprs.size());
-  for (ExprCP expr : exprs) {
-    substituted.push_back(substitute(expr, sources, targets));
-  }
-  return substituted;
+  return replace(exprs, toSubstitution(sources, targets));
 }
 
 ExprCP ExprFactory::rebuildField(const Field* field, ExprCP base) {

--- a/axiom/optimizer/v2/ExprFactory.h
+++ b/axiom/optimizer/v2/ExprFactory.h
@@ -91,6 +91,20 @@ class ExprFactory {
   /// does not verify.
   ExprCP makeIf(ExprCP condition, ExprCP thenExpr, ExprCP elseExpr);
 
+  /// Maps a subexpression to what it should be replaced by.
+  using ExprSubstitution = folly::F14FastMap<ExprCP, ExprCP>;
+
+  /// Returns `expr` with every subexpression that is a key of `mapping`
+  /// replaced by the mapped value. Matching is by pointer identity, exact
+  /// because expressions are hash-consed. A replaced subexpression is not
+  /// descended into. A lambda's bound arguments are dropped from the mapping
+  /// before its body is visited, since they shadow anything outside.
+  ExprCP replace(ExprCP expr, const ExprSubstitution& mapping);
+
+  /// Applies `replace` to each element of `exprs`, returning the rewritten
+  /// vector in the same order.
+  ExprVector replace(const ExprVector& exprs, const ExprSubstitution& mapping);
+
   /// Substitutes the i-th source `Column*` with the i-th `target`
   /// Expr in `expr`, returning a rewritten Expr. Handles
   /// Column/Literal/Call/Field/Lambda. Columns not in `sources` pass

--- a/axiom/optimizer/v2/JoinFanout.cpp
+++ b/axiom/optimizer/v2/JoinFanout.cpp
@@ -61,7 +61,10 @@ std::optional<float> JoinFanout::estimateJoinCardinality(
       std::max(jointNdvLeft, jointNdvRight);
 }
 
-std::optional<float> JoinFanout::outputCardinality(
+namespace {
+
+// The per-join-type shaping `JoinFanout::outputCardinality` documents.
+std::optional<float> shapeByJoinType(
     velox::core::JoinType joinType,
     std::optional<float> leftCardinality,
     std::optional<float> rightCardinality,
@@ -88,6 +91,26 @@ std::optional<float> JoinFanout::outputCardinality(
     default:
       return matched;
   }
+}
+
+} // namespace
+
+std::optional<float> JoinFanout::outputCardinality(
+    velox::core::JoinType joinType,
+    std::optional<float> leftCardinality,
+    std::optional<float> rightCardinality,
+    std::optional<float> matched,
+    const ExprVector& filter,
+    ConstraintMap& constraints) {
+  if (!filter.empty()) {
+    const auto selectivity = conjunctsSelectivity(
+        constraints,
+        std::span<const ExprCP>{filter.data(), filter.size()},
+        /*updateConstraints=*/true);
+    matched = selectivity.has_value() ? mul(matched, selectivity->trueFraction)
+                                      : std::nullopt;
+  }
+  return shapeByJoinType(joinType, leftCardinality, rightCardinality, matched);
 }
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinFanout.h
+++ b/axiom/optimizer/v2/JoinFanout.h
@@ -42,21 +42,27 @@ class JoinFanout {
       const ExprVector& rightKeys,
       const ConstraintMap& constraints);
 
-  /// Shapes an inner-join match count 'matched' into a join's output
-  /// cardinality according to 'joinType'. 'leftCardinality' /
-  /// 'rightCardinality' are the join's left / right operand cardinalities.
+  /// Output cardinality of a join that admits 'matched' row pairs before
+  /// 'filter' is applied. The filter is part of the match condition, so
+  /// it reduces the matches for every join type; the type then decides the
+  /// output:
   ///   - inner: matched.
-  ///   - left / right: at least every preserved-side row (max with matched).
+  ///   - left / right: matched, and at least one row per left / right row.
   ///   - full: both sides minus the matched overlap.
-  ///   - left/right semi filter: preserved side bounded by matched.
-  ///   - left/right semi project: every preserved-side row (a mark is added).
-  ///   - anti: preserved-side rows with no match.
-  /// Unknown inputs propagate to nullopt.
+  ///   - left/right semi filter: left / right rows that matched.
+  ///   - left/right semi project: every left / right row (a mark is added).
+  ///   - anti: left rows with no match.
+  ///
+  /// 'leftCardinality' and 'rightCardinality' are the join's operands in the
+  /// order 'joinType' names them. 'constraints' is refined by the filter, as
+  /// for a `Filter` node. Unknown inputs propagate to nullopt.
   static std::optional<float> outputCardinality(
       velox::core::JoinType joinType,
       std::optional<float> leftCardinality,
       std::optional<float> rightCardinality,
-      std::optional<float> matched);
+      std::optional<float> matched,
+      const ExprVector& filter,
+      ConstraintMap& constraints);
 };
 
 } // namespace facebook::axiom::optimizer::v2

--- a/axiom/optimizer/v2/JoinTreeEmitter.cpp
+++ b/axiom/optimizer/v2/JoinTreeEmitter.cpp
@@ -34,7 +34,8 @@ namespace {
 // equi-group to one representative — exactly the set the cost model charges
 // for, so the executed plan matches its estimated width. Left-then-right order
 // is preserved. A column produced by no relation in `cover` (e.g. a semijoin
-// mark synthesized below) is outside the demand universe and is always kept.
+// mark synthesized below, or a key a shuffle materialized) is outside the
+// demand universe and is always kept.
 ColumnVector coverNarrowedColumns(
     const JoinHypergraph& graph,
     const RelationSet& cover,
@@ -74,19 +75,34 @@ ExprVector takeReadyConjuncts(
 }
 
 struct EmitState {
+  EmitState(const JoinHypergraph& graph, Builder& builder)
+      : graph{graph},
+        builder{builder},
+        exprs{builder},
+        fired(graph.filterConjuncts().size(), false) {}
+
   const JoinHypergraph& graph;
   Builder& builder;
   ExprFactory exprs;
   std::vector<bool> fired;
 };
 
-NodeCP emitOp(MemoOpCP op, EmitState& state);
+// A subtree's root node together with the key expressions its shuffles
+// materialized into columns. A consumer rewrites its own keys and filter
+// through `materialized`, so it reads the column the shuffle already computed
+// instead of evaluating the same expression a second time. An entry is carried
+// upward only while its column stays in the emitting node's output.
+struct Emitted {
+  NodeCP node;
+  ExprFactory::ExprSubstitution materialized;
+};
+
+Emitted emitOp(MemoOpCP op, EmitState& state);
 
 // A join's children each emit one representative per equivalence group, so a
 // column equated and collapsed in a child is gone from that child's output.
 // `mergedChildReps` maps every such column to the surviving representative
-// across both child covers; `remapToReps` rewrites key/filter expressions to
-// reference the survivor, keeping the emitted node's column references valid.
+// across both child covers.
 folly::F14FastMap<ColumnCP, ColumnCP> mergedChildReps(
     const JoinOp* join,
     EmitState& state) {
@@ -96,22 +112,98 @@ folly::F14FastMap<ColumnCP, ColumnCP> mergedChildReps(
   return reps;
 }
 
-ExprVector remapToReps(
-    const ExprVector& exprs,
-    const folly::F14FastMap<ColumnCP, ColumnCP>& reps,
-    EmitState& state) {
-  ColumnVector sources;
-  ExprVector targets;
+// The collapsed entries of `reps` as a substitution, so an expression
+// referencing a collapsed column is rewritten to the survivor present in the
+// child's output.
+ExprFactory::ExprSubstitution collapsedColumns(
+    const folly::F14FastMap<ColumnCP, ColumnCP>& reps) {
+  ExprFactory::ExprSubstitution substitution;
   for (const auto& [column, rep] : reps) {
     if (rep != column) {
-      sources.push_back(column);
-      targets.push_back(rep);
+      substitution.emplace(column, rep);
     }
   }
-  if (sources.empty()) {
+  return substitution;
+}
+
+// Returns the union of two substitutions. A key expression reads columns of one
+// cover only and sibling covers are disjoint, so the same `ExprCP` cannot be
+// materialized on two sides.
+ExprFactory::ExprSubstitution merge(
+    ExprFactory::ExprSubstitution into,
+    const ExprFactory::ExprSubstitution& from) {
+  for (const auto& [expr, column] : from) {
+    const bool inserted = into.emplace(expr, column).second;
+    VELOX_CHECK(
+        inserted, "Two inputs materialized the same key: {}", expr->toString());
+  }
+  return into;
+}
+
+ExprVector rewrite(
+    const ExprVector& exprs,
+    const ExprFactory::ExprSubstitution& substitution,
+    EmitState& state) {
+  if (substitution.empty()) {
     return exprs;
   }
-  return state.exprs.substitute(exprs, sources, targets);
+  return state.exprs.replace(exprs, substitution);
+}
+
+// Drops entries whose column `node` does not emit: a semi/anti join keeps only
+// one side's columns, so a key the other side materialized is unreadable above.
+void retainVisible(ExprFactory::ExprSubstitution& substitution, NodeCP node) {
+  if (substitution.empty()) {
+    return;
+  }
+  folly::F14FastSet<ExprCP> visible;
+  visible.reserve(node->outputColumns().size());
+  for (ColumnCP column : node->outputColumns()) {
+    visible.insert(column);
+  }
+  for (auto it = substitution.begin(); it != substitution.end();) {
+    it = visible.contains(it->second) ? std::next(it) : substitution.erase(it);
+  }
+}
+
+// True when an equivalence collapse replaced one of `targets` by a
+// representative, so the emitting node cannot carry the target name itself.
+bool hasCollapsedTarget(
+    const folly::F14FastMap<ColumnCP, ColumnCP>& reps,
+    const ColumnVector& targets) {
+  for (ColumnCP target : targets) {
+    const auto it = reps.find(target);
+    if (it != reps.end() && it->second != target) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Wraps `node` in a Project that re-materializes each target name from its
+// representative, restoring the demanded output schema and order.
+NodeCP restoreTargets(
+    NodeCP node,
+    const folly::F14FastMap<ColumnCP, ColumnCP>& reps,
+    const ColumnVector& targets,
+    EmitState& state) {
+  ExprVector exprs;
+  exprs.reserve(targets.size());
+  for (ColumnCP target : targets) {
+    const auto it = reps.find(target);
+    exprs.push_back(it != reps.end() ? it->second : target);
+  }
+  return state.builder.make<Project>(
+      Project::Key{node, std::move(exprs), ColumnVector{targets}});
+}
+
+void checkAllConjunctsPlaced(const EmitState& state) {
+  const size_t unplaced =
+      std::count(state.fired.begin(), state.fired.end(), false);
+  VELOX_CHECK_EQ(
+      unplaced,
+      0,
+      "Filter conjuncts were not all placed; required relations exceed the emitted cover");
 }
 
 NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
@@ -125,13 +217,13 @@ NodeCP emitLeaf(const LeafOp* leaf, EmitState& state) {
 // `ordinalityColumn` come from the original Unnest IR node stored on
 // the Unnest relation. `replicatedColumns` conservatively forwards
 // every input column.
-NodeCP buildUnnest(const JoinOp* join, NodeCP leftNode, EmitState& state) {
+Emitted buildUnnest(const JoinOp* join, Emitted input, EmitState& state) {
   const auto& edge = state.graph.edges()[join->edgeIndex];
   const int8_t unnestRelId = edge.right().min();
   const auto* origUnnest =
       state.graph.relation(unnestRelId).node()->as<Unnest>();
 
-  ColumnVector replicatedColumns{leftNode->outputColumns()};
+  ColumnVector replicatedColumns{input.node->outputColumns()};
 
   ColumnVector outputColumns{replicatedColumns};
   for (const auto& perExpr : origUnnest->unnestColumns()) {
@@ -143,20 +235,21 @@ NodeCP buildUnnest(const JoinOp* join, NodeCP leftNode, EmitState& state) {
     outputColumns.push_back(origUnnest->ordinalityColumn());
   }
 
-  // A column collapsed in the input is gone from `leftNode`'s output; point the
-  // unnest arguments at its surviving representative.
-  ExprVector unnestExpressions = remapToReps(
-      origUnnest->unnestExpressions(),
-      state.graph.coverColumnReps(join->left->cover()),
-      state);
+  const auto substitution = merge(
+      collapsedColumns(state.graph.coverColumnReps(join->left->cover())),
+      input.materialized);
+  ExprVector unnestExpressions =
+      rewrite(origUnnest->unnestExpressions(), substitution, state);
 
-  return state.builder.make<Unnest>(Unnest::Key{
-      leftNode,
+  NodeCP node = state.builder.make<Unnest>(Unnest::Key{
+      input.node,
       std::move(unnestExpressions),
       std::move(replicatedColumns),
       origUnnest->unnestColumns(),
       origUnnest->ordinalityColumn(),
       std::move(outputColumns)});
+  retainVisible(input.materialized, node);
+  return {node, std::move(input.materialized)};
 }
 
 // Narrows `outputColumns` for semi/anti joins, which emit only the semi'd
@@ -197,17 +290,17 @@ std::optional<ColumnVector> narrowSemiAntiOutput(
   }
 }
 
-NodeCP buildJoin(
+Emitted buildJoin(
     const JoinOp* join,
-    NodeCP leftNode,
-    NodeCP rightNode,
+    const Emitted& left,
+    const Emitted& right,
     ColumnVector outputColumns,
     EmitState& state) {
   const auto& edge = state.graph.edges()[join->edgeIndex];
   const bool isInner = edge.joinType() == velox::core::JoinType::kInner;
 
   if (auto narrowed = narrowSemiAntiOutput(
-          join->joinType, leftNode, rightNode, edge.markColumn())) {
+          join->joinType, left.node, right.node, edge.markColumn())) {
     outputColumns = std::move(*narrowed);
   }
 
@@ -241,16 +334,16 @@ NodeCP buildJoin(
     filter = ExprVector{edge.filter()};
   }
 
-  // A key/filter may reference a column a child collapsed into its
-  // representative; rewrite it to the survivor present in the child's output.
-  const auto reps = mergedChildReps(join, state);
-  leftKeys = remapToReps(leftKeys, reps, state);
-  rightKeys = remapToReps(rightKeys, reps, state);
-  filter = remapToReps(filter, reps, state);
+  auto materialized = merge(left.materialized, right.materialized);
+  const auto substitution =
+      merge(collapsedColumns(mergedChildReps(join, state)), materialized);
+  leftKeys = rewrite(leftKeys, substitution, state);
+  rightKeys = rewrite(rightKeys, substitution, state);
+  filter = rewrite(filter, substitution, state);
 
-  return state.builder.make<Join>(Join::Key{
-      leftNode,
-      rightNode,
+  NodeCP node = state.builder.make<Join>(Join::Key{
+      left.node,
+      right.node,
       join->joinType,
       std::move(leftKeys),
       std::move(rightKeys),
@@ -258,49 +351,51 @@ NodeCP buildJoin(
       edge.nullAware(),
       edge.nullAsValue(),
       std::move(outputColumns)});
+  retainVisible(materialized, node);
+  return {node, std::move(materialized)};
 }
 
 // Lowers an antijoin played in its reversed (build-on-the-preserved-side)
 // orientation. There is no `kAnti` build-side flip in Velox, so synthesize
-// it: a kRightSemiProject (probe = `probeNode`, the edge's right side; build
-// = `buildNode`, the preserved left side) emits each build row plus a mark
-// for a probe match; `Filter(not mark)` keeps the unmatched rows (the
-// antijoin result); a Project drops the mark, restoring the antijoin schema.
-// The mark is fresh and never escapes this subtree.
+// it: a kRightSemiProject (probe = `probe`, the edge's right side; build =
+// `build`, the preserved left side) emits each build row plus a mark for a
+// probe match; `Filter(not mark)` keeps the unmatched rows (the antijoin
+// result); a Project drops the mark, restoring the antijoin schema. The mark is
+// fresh and never escapes this subtree.
 //
 // TODO: Replace this synthesis (and the reversedAnti orientation marker)
 // with a plain kRightAnti relabel once Velox adds that join type:
 // https://github.com/facebookincubator/velox/issues/17815.
-NodeCP buildReversedAnti(
+Emitted buildReversedAnti(
     const JoinOp* join,
-    NodeCP probeNode,
-    NodeCP buildNode,
+    const Emitted& probe,
+    const Emitted& build,
     EmitState& state) {
   const auto& edge = state.graph.edges()[join->edgeIndex];
 
-  const ColumnVector antiOutput{buildNode->outputColumns()};
+  const ColumnVector antiOutput{build.node->outputColumns()};
   ColumnCP mark = Column::createBoolean("mark");
   ColumnVector joinOutput{antiOutput};
   joinOutput.push_back(mark);
 
   // edge.leftKeys reference the preserved (build) side, rightKeys the probe
-  // side. The IR Join's leftKeys must reference its left (probe) input. A key
-  // referencing a column collapsed in a child is rewritten to the survivor.
-  const auto reps = mergedChildReps(join, state);
+  // side. The IR Join's leftKeys must reference its left (probe) input.
+  auto materialized = merge(probe.materialized, build.materialized);
+  const auto substitution =
+      merge(collapsedColumns(mergedChildReps(join, state)), materialized);
   NodeCP rightSemiProject = state.builder.make<Join>(Join::Key{
-      probeNode,
-      buildNode,
+      probe.node,
+      build.node,
       velox::core::JoinType::kRightSemiProject,
-      remapToReps(ExprVector{edge.rightKeys()}, reps, state),
-      remapToReps(ExprVector{edge.leftKeys()}, reps, state),
-      remapToReps(ExprVector{edge.filter()}, reps, state),
+      rewrite(ExprVector{edge.rightKeys()}, substitution, state),
+      rewrite(ExprVector{edge.leftKeys()}, substitution, state),
+      rewrite(ExprVector{edge.filter()}, substitution, state),
       edge.nullAware(),
       edge.nullAsValue(),
       std::move(joinOutput)});
 
-  ExprFactory exprFactory{state.builder};
   NodeCP filtered = state.builder.make<Filter>(
-      Filter::Key{rightSemiProject, ExprVector{exprFactory.makeNot(mark)}});
+      Filter::Key{rightSemiProject, ExprVector{state.exprs.makeNot(mark)}});
 
   // Project away the mark, restoring the antijoin's output schema. Every
   // entry is a pass-through of the preserved-side column.
@@ -309,80 +404,92 @@ NodeCP buildReversedAnti(
   for (ColumnCP column : antiOutput) {
     projectExprs.push_back(column);
   }
-  return state.builder.make<Project>(
+  NodeCP node = state.builder.make<Project>(
       Project::Key{filtered, std::move(projectExprs), antiOutput});
+  retainVisible(materialized, node);
+  return {node, std::move(materialized)};
 }
 
-NodeCP emitOp(MemoOpCP op, EmitState& state) {
+// Emits a join op and everything below it. `rootOutputColumns` is non-null only
+// for the cluster root, whose output must be exactly those columns; an
+// equivalence collapse that dropped a target in favor of its representative is
+// undone by a Project on top.
+Emitted emitJoin(
+    const JoinOp* join,
+    EmitState& state,
+    const ColumnVector* rootOutputColumns) {
+  const auto& edge = state.graph.edges()[join->edgeIndex];
+  Emitted left = emitOp(join->left, state);
+  if (edge.isUnnest()) {
+    return buildUnnest(join, std::move(left), state);
+  }
+  Emitted right = emitOp(join->right, state);
+  if (join->reversedAnti) {
+    return buildReversedAnti(join, left, right, state);
+  }
+
+  if (rootOutputColumns == nullptr) {
+    return buildJoin(
+        join,
+        left,
+        right,
+        coverNarrowedColumns(state.graph, join->cover(), left.node, right.node),
+        state);
+  }
+
+  const auto rootReps = state.graph.coverColumnReps(join->cover());
+  if (!hasCollapsedTarget(rootReps, *rootOutputColumns)) {
+    return buildJoin(
+        join, left, right, ColumnVector{*rootOutputColumns}, state);
+  }
+
+  Emitted result = buildJoin(
+      join,
+      left,
+      right,
+      coverNarrowedColumns(state.graph, join->cover(), left.node, right.node),
+      state);
+  result.node =
+      restoreTargets(result.node, rootReps, *rootOutputColumns, state);
+  retainVisible(result.materialized, result.node);
+  return result;
+}
+
+// A shuffle partitions on columns of the row it shuffles, so an expression key
+// is computed on the producer side and recorded, letting the consumer above
+// read that column instead of evaluating the expression again.
+Emitted emitExchange(const ExchangeOp* exchange, EmitState& state) {
+  Emitted input = emitOp(exchange->input, state);
+  Partitioning partitioning = exchange->outputPartitioning();
+  auto [keyed, columnKeys] =
+      state.builder.materializeKeys(input.node, partitioning.keys);
+  for (size_t i = 0; i < partitioning.keys.size(); ++i) {
+    if (columnKeys[i] == partitioning.keys[i]) {
+      continue;
+    }
+    const bool inserted =
+        input.materialized.emplace(partitioning.keys[i], columnKeys[i]).second;
+    VELOX_CHECK(
+        inserted,
+        "Key already materialized below: {}",
+        partitioning.keys[i]->toString());
+  }
+  partitioning.keys = std::move(columnKeys);
+  NodeCP node = state.builder.make<Exchange>(
+      Exchange::Key{keyed, std::move(partitioning)});
+  return {node, std::move(input.materialized)};
+}
+
+Emitted emitOp(MemoOpCP op, EmitState& state) {
   switch (op->kind()) {
     case MemoOpKind::kLeaf:
-      return emitLeaf(op->as<LeafOp>(), state);
-    case MemoOpKind::kJoin: {
-      const auto* join = op->as<JoinOp>();
-      const auto& edge = state.graph.edges()[join->edgeIndex];
-      NodeCP leftNode = emitOp(join->left, state);
-      if (edge.isUnnest()) {
-        return buildUnnest(join, leftNode, state);
-      }
-      NodeCP rightNode = emitOp(join->right, state);
-      if (join->reversedAnti) {
-        return buildReversedAnti(join, leftNode, rightNode, state);
-      }
-      return buildJoin(
-          join,
-          leftNode,
-          rightNode,
-          coverNarrowedColumns(state.graph, join->cover(), leftNode, rightNode),
-          state);
-    }
-    case MemoOpKind::kExchange: {
-      const auto* exchange = op->as<ExchangeOp>();
-      NodeCP inputNode = emitOp(exchange->input, state);
-      return state.builder.make<Exchange>(
-          Exchange::Key{inputNode, exchange->outputPartitioning()});
-    }
+      return {emitLeaf(op->as<LeafOp>(), state), {}};
+    case MemoOpKind::kJoin:
+      return emitJoin(op->as<JoinOp>(), state, /*rootOutputColumns=*/nullptr);
+    case MemoOpKind::kExchange:
+      return emitExchange(op->as<ExchangeOp>(), state);
   }
   VELOX_UNREACHABLE();
-}
-
-// Emits the cluster root. The root join carries exactly `rootOutputColumns`
-// unless an equivalence collapse dropped a target column in favor of its
-// representative; then the join emits representatives and a Project
-// re-materializes each target name (and restores output order).
-NodeCP buildRoot(
-    const JoinOp* join,
-    NodeCP leftNode,
-    NodeCP rightNode,
-    const ColumnVector& rootOutputColumns,
-    EmitState& state) {
-  const auto rootReps = state.graph.coverColumnReps(join->cover());
-  bool collapsed = false;
-  for (ColumnCP target : rootOutputColumns) {
-    const auto it = rootReps.find(target);
-    if (it != rootReps.end() && it->second != target) {
-      collapsed = true;
-      break;
-    }
-  }
-  if (!collapsed) {
-    return buildJoin(
-        join, leftNode, rightNode, ColumnVector{rootOutputColumns}, state);
-  }
-
-  NodeCP joinNode = buildJoin(
-      join,
-      leftNode,
-      rightNode,
-      coverNarrowedColumns(state.graph, join->cover(), leftNode, rightNode),
-      state);
-  ExprVector exprs;
-  exprs.reserve(rootOutputColumns.size());
-  for (ColumnCP target : rootOutputColumns) {
-    const auto it = rootReps.find(target);
-    exprs.push_back(it != rootReps.end() ? it->second : target);
-  }
-  return state.builder.make<Project>(Project::Key{
-      joinNode, std::move(exprs), ColumnVector{rootOutputColumns}});
 }
 
 } // namespace
@@ -393,45 +500,22 @@ NodeCP JoinTreeEmitter::emit(
     const ColumnVector& rootOutputColumns,
     Builder& builder) {
   VELOX_CHECK_NOT_NULL(root);
-  EmitState state{
-      graph,
-      builder,
-      ExprFactory{builder},
-      std::vector<bool>(graph.filterConjuncts().size(), false)};
+  EmitState state{graph, builder};
   NodeCP result{nullptr};
   switch (root->kind()) {
     case MemoOpKind::kLeaf:
       result = emitLeaf(root->as<LeafOp>(), state);
       break;
-    case MemoOpKind::kJoin: {
-      const auto* join = root->as<JoinOp>();
-      const auto& edge = state.graph.edges()[join->edgeIndex];
-      NodeCP leftNode = emitOp(join->left, state);
-      if (edge.isUnnest()) {
-        result = buildUnnest(join, leftNode, state);
-      } else {
-        NodeCP rightNode = emitOp(join->right, state);
-        if (join->reversedAnti) {
-          result = buildReversedAnti(join, leftNode, rightNode, state);
-        } else {
-          result =
-              buildRoot(join, leftNode, rightNode, rootOutputColumns, state);
-        }
-      }
+    case MemoOpKind::kJoin:
+      result = emitJoin(root->as<JoinOp>(), state, &rootOutputColumns).node;
       break;
-    }
     case MemoOpKind::kExchange:
       // The chosen join-tree root is never an exchange: a final gather is added
       // by the fragment splitter, not enumerated into the memo.
       VELOX_UNREACHABLE("Join-tree root cannot be an exchange");
   }
   VELOX_CHECK_NOT_NULL(result);
-  const size_t unplaced =
-      std::count(state.fired.begin(), state.fired.end(), false);
-  VELOX_CHECK_EQ(
-      unplaced,
-      0,
-      "Filter conjuncts were not all placed; required relations exceed the root cover");
+  checkAllConjunctsPlaced(state);
   return result;
 }
 
@@ -445,18 +529,14 @@ NodeCP JoinTreeEmitter::emitComponents(
       componentRoots.size(),
       2,
       "emitComponents requires at least two components");
-  EmitState state{
-      graph,
-      builder,
-      ExprFactory{builder},
-      std::vector<bool>(graph.filterConjuncts().size(), false)};
+  EmitState state{graph, builder};
 
   // Emit each component subtree first, sharing one `fired` vector so a
   // cross-component conjunct is placed once, at a fold below.
-  std::vector<NodeCP> nodes;
-  nodes.reserve(componentRoots.size());
+  std::vector<Emitted> emitted;
+  emitted.reserve(componentRoots.size());
   for (MemoOpCP root : componentRoots) {
-    nodes.push_back(emitOp(root, state));
+    emitted.push_back(emitOp(root, state));
   }
 
   // Largest component drives as the bottom-left probe; the rest join as
@@ -490,19 +570,17 @@ NodeCP JoinTreeEmitter::emitComponents(
     fullCover.unionSet(root->cover());
   }
   const auto rootReps = graph.coverColumnReps(fullCover);
-  bool collapsed = false;
-  for (ColumnCP target : rootOutputColumns) {
-    const auto it = rootReps.find(target);
-    if (it != rootReps.end() && it->second != target) {
-      collapsed = true;
-      break;
-    }
-  }
+  const bool collapsed = hasCollapsedTarget(rootReps, rootOutputColumns);
 
-  NodeCP result = nodes[order[0]];
+  NodeCP result = emitted[order[0]].node;
   RelationSet cover{componentRoots[order[0]]->cover()};
+  // Grows with the fold, so a conjunct is rewritten only through what is
+  // already below it.
+  auto materialized = emitted[order[0]].materialized;
   for (size_t i = 1; i < order.size(); ++i) {
-    NodeCP build = nodes[order[i]];
+    NodeCP build = emitted[order[i]].node;
+    materialized =
+        merge(std::move(materialized), emitted[order[i]].materialized);
     // A cross product is keyless: broadcast the build so the probe keeps its
     // partitioning and a single-task (Values / global-aggregate) or scan build
     // is isolated in its own fragment instead of co-locating with the probe.
@@ -515,37 +593,28 @@ NodeCP JoinTreeEmitter::emitComponents(
     ColumnVector columns = (isLast && !collapsed)
         ? ColumnVector{rootOutputColumns}
         : coverNarrowedColumns(state.graph, cover, result, build);
-    const auto reps = graph.coverColumnReps(cover);
+    const auto substitution =
+        merge(collapsedColumns(graph.coverColumnReps(cover)), materialized);
     result = builder.make<Join>(Join::Key{
         result,
         build,
         velox::core::JoinType::kInner,
         /*leftKeys=*/ExprVector{},
         /*rightKeys=*/ExprVector{},
-        remapToReps(
-            takeReadyConjuncts(state.graph, cover, state.fired), reps, state),
+        rewrite(
+            takeReadyConjuncts(state.graph, cover, state.fired),
+            substitution,
+            state),
         /*nullAware=*/false,
         /*nullAsValue=*/false,
         std::move(columns)});
   }
 
   if (collapsed) {
-    ExprVector projectExprs;
-    projectExprs.reserve(rootOutputColumns.size());
-    for (ColumnCP target : rootOutputColumns) {
-      const auto it = rootReps.find(target);
-      projectExprs.push_back(it != rootReps.end() ? it->second : target);
-    }
-    result = builder.make<Project>(Project::Key{
-        result, std::move(projectExprs), ColumnVector{rootOutputColumns}});
+    result = restoreTargets(result, rootReps, rootOutputColumns, state);
   }
 
-  const size_t unplaced =
-      std::count(state.fired.begin(), state.fired.end(), false);
-  VELOX_CHECK_EQ(
-      unplaced,
-      0,
-      "Filter conjuncts were not all placed across cross-product components");
+  checkAllConjunctsPlaced(state);
   return result;
 }
 

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1533,6 +1533,9 @@ TopNRowNumber::TopNRowNumber(Key key)
       rankColumn_(key.rankColumn) {
   VELOX_CHECK_NOT_NULL(input_);
   VELOX_CHECK(!orderKeys_.empty(), "TopNRowNumber must have order keys");
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + (rankColumn_ != nullptr ? 1 : 0));
   VELOX_CHECK_EQ(orderKeys_.size(), orderTypes_.size());
   VELOX_CHECK_GT(limit_, 0);
   VELOX_CHECK_EQ(
@@ -1923,6 +1926,16 @@ Exchange::Exchange(Key key)
       input_(key.input),
       partitioning_(std::move(key.partitioning)) {
   VELOX_CHECK_NOT_NULL(input_);
+
+  // A partition key must be a column the input produces: whoever places the
+  // shuffle materializes an expression key first, so the value is computed
+  // once and the consumer above reads that same column.
+  for (ExprCP partitionKey : partitioning_.keys) {
+    VELOX_CHECK(
+        partitionKey->is(PlanType::kColumnExpr),
+        "Exchange partitioning key must be a column: {}",
+        partitionKey->toString());
+  }
 }
 
 size_t Exchange::KeyHash::operator()(const Exchange* node) const {

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -24,6 +24,7 @@
 #include "axiom/optimizer/v2/CostModel.h"
 #include "axiom/optimizer/v2/DPhyp.h"
 #include "axiom/optimizer/v2/EstimateProvider.h"
+#include "axiom/optimizer/v2/ExprFactory.h"
 #include "axiom/optimizer/v2/HypergraphBuilder.h"
 #include "axiom/optimizer/v2/JoinCluster.h"
 #include "axiom/optimizer/v2/JoinTreeEmitter.h"
@@ -129,7 +130,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       : NodeRewriter(builder),
         options_{options},
         numWorkers_{numWorkers},
-        numDrivers_{numDrivers} {}
+        numDrivers_{numDrivers},
+        exprFactory_{builder} {}
 
  protected:
   // Rebuilds a join that DPhyp does not plan (non-clusterable cross / theta /
@@ -144,6 +146,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   NodeCP rewriteUnclusteredJoin(const Join* node, NoContext& context) {
     NodeCP newLeft = rewrite(node->left(), context);
     NodeCP newRight = rewrite(node->right(), context);
+    ExprVector leftKeys{node->leftKeys()};
+    ExprVector rightKeys{node->rightKeys()};
     if (numWorkers_ > 1) {
       if (!node->leftKeys().empty()) {
         // A null-aware anti/semi join (NOT IN / IN) needs the existence side's
@@ -155,12 +159,13 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         // null-aware anti/semi: a bucketed existence side confines a null key
         // to one bucket, so it must shuffle-replicate.
         if (nullAware ||
-            !coBucketJoinSides(
-                newLeft, newRight, node->leftKeys(), node->rightKeys())) {
-          newLeft =
-              partition(newLeft, node->leftKeys(), nullAware && !rightIsBuild);
-          newRight =
-              partition(newRight, node->rightKeys(), nullAware && rightIsBuild);
+            !coBucketJoinSides(newLeft, newRight, leftKeys, rightKeys)) {
+          std::tie(newLeft, leftKeys) =
+              builder().materializeKeys(newLeft, leftKeys);
+          std::tie(newRight, rightKeys) =
+              builder().materializeKeys(newRight, rightKeys);
+          newLeft = partition(newLeft, leftKeys, nullAware && !rightIsBuild);
+          newRight = partition(newRight, rightKeys, nullAware && rightIsBuild);
         }
       } else if (canBroadcastBuild(node->joinType())) {
         newRight = broadcast(newRight);
@@ -176,8 +181,8 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         .left = newLeft,
         .right = newRight,
         .joinType = node->joinType(),
-        .leftKeys = node->leftKeys(),
-        .rightKeys = node->rightKeys(),
+        .leftKeys = leftKeys,
+        .rightKeys = rightKeys,
         .filter = node->filter(),
         .nullAware = node->nullAware(),
         .nullAsValue = node->nullAsValue(),
@@ -332,11 +337,14 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   // true and updates 'left'/'right' when co-location applies; false when
   // neither side is bucketed, or both are bucketed but not copartitionable — in
   // either case the caller falls back to the standard shuffle.
+  // Updates 'leftKeys' / 'rightKeys' when a side is repartitioned to the
+  // other's bucketing: the shuffle needs column keys, so an expression key is
+  // computed first and the join reads that column.
   bool coBucketJoinSides(
       NodeCP& left,
       NodeCP& right,
-      const ExprVector& leftKeys,
-      const ExprVector& rightKeys) {
+      ExprVector& leftKeys,
+      ExprVector& rightKeys) {
     const auto& leftPart = left->physicalProperties().globalPartition;
     const auto& rightPart = right->physicalProperties().globalPartition;
     const bool leftBucketed = leftPart.isBucketedOn(leftKeys);
@@ -346,10 +354,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
           nullptr;
     }
     if (leftBucketed) {
+      std::tie(right, rightKeys) = builder().materializeKeys(right, rightKeys);
       right = partitionTo(right, rightKeys, leftPart.partitionType);
       return true;
     }
     if (rightBucketed) {
+      std::tie(left, leftKeys) = builder().materializeKeys(left, leftKeys);
       left = partitionTo(left, leftKeys, rightPart.partitionType);
       return true;
     }
@@ -364,17 +374,6 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   static bool isGathered(NodeCP input) {
     return input->physicalProperties().globalPartition.is(
         PartitionKind::kGather);
-  }
-
-  // True when every expression in 'sub' is also in 'super'.
-  static bool isSubset(const ExprVector& sub, const ExprVector& super) {
-    const auto superSet = PlanObjectSet::fromObjects(super);
-    for (ExprCP expr : sub) {
-      if (!superSet.contains(expr)) {
-        return false;
-      }
-    }
-    return true;
   }
 
   // Ensures all rows reach one task: reuse when 'input' is already gathered,
@@ -392,20 +391,40 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   // reuse when 'input' is already gathered (one task co-locates any keys) or
   // already co-located on 'keys', else a remote hash exchange. Empty 'keys' is
   // one global group, satisfied by a gather. A no-op at a single worker.
-  NodeCP ensureCoLocated(NodeCP input, const ExprVector& keys) {
+  // Returns the co-located input and the keys it is co-located on: a shuffle
+  // needs column keys, so an expression key is computed into one here, and the
+  // consumer reads that column rather than computing the value again.
+  std::pair<NodeCP, ExprVector> ensureCoLocated(
+      NodeCP input,
+      const ExprVector& keys) {
     if (numWorkers_ == 1 || isGathered(input)) {
-      return input;
+      return {input, keys};
     }
 
     if (keys.empty()) {
-      return gather(input);
+      return {gather(input), keys};
     }
 
     if (input->physicalProperties().globalPartition.coLocates(keys)) {
-      return input;
+      return {input, keys};
     }
 
-    return partition(input, keys);
+    auto [keyed, columnKeys] = builder().materializeKeys(input, keys);
+    return {partition(keyed, columnKeys), columnKeys};
+  }
+
+  // Returns 'node's output columns with the leading input-column prefix
+  // replaced by 'newInput's columns, for a node whose output is its input's
+  // columns followed by what it appends (Window, TopNRowNumber).
+  ColumnVector outputFollowingInput(const Node* node, NodeCP newInput) {
+    ColumnVector result{newInput->outputColumns()};
+    const auto& oldOutput = node->outputColumns();
+    for (size_t i = node->inputs()[0]->outputColumns().size();
+         i < oldOutput.size();
+         ++i) {
+      result.push_back(oldOutput[i]);
+    }
+    return result;
   }
 
   NodeCP rewriteAggregate(const Aggregate* node, NoContext& context) override {
@@ -426,7 +445,34 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         return rewriteAggregateSplit(node, input, /*remoteExchange=*/false);
       }
     }
-    return rewriteAggregateCoLocated(node, input, /*requiredCoLocation=*/{});
+    // A global () grouping set emits a default row over empty input; a
+    // single-stage aggregate must gather (empty keys) so that row is produced
+    // once, not once per worker.
+    const ExprVector keys = node->globalGroupingSets().empty()
+        ? node->groupingKeys()
+        : ExprVector{};
+    auto [coLocatedInput, coLocatedKeys] = ensureCoLocated(input, keys);
+    if (coLocatedInput == node->input()) {
+      return node;
+    }
+    ExprFactory::ExprSubstitution materialized;
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (coLocatedKeys[i] != keys[i]) {
+        materialized.emplace(keys[i], coLocatedKeys[i]);
+      }
+    }
+    ExprVector groupingKeys{node->groupingKeys()};
+    if (!materialized.empty()) {
+      groupingKeys = exprFactory_.replace(groupingKeys, materialized);
+    }
+    return builder().make<Aggregate>(Aggregate::Key{
+        .input = coLocatedInput,
+        .groupingKeys = groupingKeys,
+        .aggregates = node->aggregates(),
+        .outputColumns = node->outputColumns(),
+        .step = node->step(),
+        .groupId = node->groupId(),
+        .globalGroupingSets = node->globalGroupingSets()});
   }
 
   // True when 'node' can two-stage into partial + final, independent of whether
@@ -534,45 +580,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         .globalGroupingSets = node->globalGroupingSets()});
   }
 
-  // Rewrites an aggregate, co-locating its input on 'requiredCoLocation' when
-  // that is a non-empty subset of the grouping keys: such a subset still lands
-  // every group on one task, and choosing it lets a consumer that needs the
-  // coarser partition reuse it without a reshuffle. Otherwise co-locates on the
-  // grouping keys (empty for a global aggregate, which gathers).
-  NodeCP rewriteAggregateCoLocated(
-      const Aggregate* node,
-      NodeCP newInput,
-      const ExprVector& requiredCoLocation) {
-    ExprVector keys;
-    // A global () grouping set emits a default row over empty input; a
-    // single-stage aggregate must gather (empty keys) so that row is produced
-    // once, not once per worker.
-    if (node->globalGroupingSets().empty()) {
-      keys = !requiredCoLocation.empty() &&
-              isSubset(requiredCoLocation, node->groupingKeys())
-          ? requiredCoLocation
-          : node->groupingKeys();
-    }
-    NodeCP input = ensureCoLocated(newInput, keys);
-    if (input == node->input()) {
-      return node;
-    }
-    return builder().make<Aggregate>(Aggregate::Key{
-        .input = input,
-        .groupingKeys = node->groupingKeys(),
-        .aggregates = node->aggregates(),
-        .outputColumns = node->outputColumns(),
-        .step = node->step(),
-        .groupId = node->groupId(),
-        .globalGroupingSets = node->globalGroupingSets()});
-  }
-
   // Distributes a window: its input must be partitioned on the PARTITION BY
   // keys so each partition is computed on one task (an unpartitioned window
   // gathers to one task). Runs bottom-up, so the input is already physically
   // planned.
   NodeCP rewriteWindow(const Window* node, NoContext& context) override {
-    NodeCP input =
+    auto [input, partitionKeys] =
         ensureCoLocated(rewrite(node->input(), context), node->partitionKeys());
     if (input == node->input()) {
       return node;
@@ -580,17 +593,17 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     return builder().make<Window>(
         {input,
          node->functions(),
-         node->partitionKeys(),
+         partitionKeys,
          node->orderKeys(),
          node->orderTypes(),
-         node->outputColumns()});
+         outputFollowingInput(node, input)});
   }
 
   // Distributes a per-partition top-n (row_number / rank): like a window, its
   // input must be partitioned on the PARTITION BY keys (gather when none).
   NodeCP rewriteTopNRowNumber(const TopNRowNumber* node, NoContext& context)
       override {
-    NodeCP input =
+    auto [input, partitionKeys] =
         ensureCoLocated(rewrite(node->input(), context), node->partitionKeys());
     if (input == node->input()) {
       return node;
@@ -598,12 +611,12 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     return builder().make<TopNRowNumber>(
         {input,
          node->rankFunction(),
-         node->partitionKeys(),
+         partitionKeys,
          node->orderKeys(),
          node->orderTypes(),
          node->limit(),
          node->rankColumn(),
-         node->outputColumns()});
+         outputFollowingInput(node, input)});
   }
 
   // Distributes a global ORDER BY (Sort). At numWorkers>1 each task sorts its
@@ -638,35 +651,18 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
     return builder().make<EnforceSingleRow>({input});
   }
 
-  // Rewrites 'node' so its output is co-located on 'keys', pushing the
-  // requirement into a producer that can satisfy it by its own partition choice
-  // — an aggregate co-locating on a subset of its grouping keys — so no
-  // reshuffle is added above it. Other producers fall back to a co-locating
-  // exchange.
-  NodeCP
-  rewriteCoLocatedOn(NodeCP node, const ExprVector& keys, NoContext& context) {
-    if (numWorkers_ > 1 && node->is(NodeType::kAggregate)) {
-      const auto* aggregate = node->as<Aggregate>();
-      return ensureCoLocated(
-          rewriteAggregateCoLocated(
-              aggregate, rewrite(aggregate->input(), context), keys),
-          keys);
-    }
-    return ensureCoLocated(rewrite(node, context), keys);
-  }
-
   // EnforceDistinct asserts at most one row per distinct key across all input.
   // A per-task check only sees duplicates that share a task, so the input must
   // be co-located on the distinct keys.
   NodeCP rewriteEnforceDistinct(const EnforceDistinct* node, NoContext& context)
       override {
-    NodeCP input =
-        rewriteCoLocatedOn(node->input(), node->distinctKeys(), context);
+    auto [input, distinctKeys] =
+        ensureCoLocated(rewrite(node->input(), context), node->distinctKeys());
     if (input == node->input()) {
       return node;
     }
     return builder().make<EnforceDistinct>(
-        {input, node->distinctKeys(), node->errorMessage()});
+        {input, distinctKeys, node->errorMessage()});
   }
 
   // Distributes a LIMIT: at numWorkers>1 a per-task partial keeps the first
@@ -817,6 +813,9 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   NodeCP rewriteTableWrite(const TableWrite* node, NoContext& context)
       override {
     NodeCP newInput = rewrite(node->input(), context);
+    // A partition key computed for the shuffle is written from that column
+    // rather than evaluated a second time.
+    ExprFactory::ExprSubstitution materialized;
     if (numWorkers_ > 1) {
       const auto* layout = node->table()->layouts().front();
       const auto& partitionColumns = layout->partitionColumns();
@@ -831,15 +830,25 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
         }
         const auto& partition = newInput->physicalProperties().globalPartition;
         if (!partition.isBucketedCompatibleWith(keys, *targetType)) {
-          newInput = partitionTo(newInput, keys, targetType);
+          auto [keyed, columnKeys] = builder().materializeKeys(newInput, keys);
+          newInput = partitionTo(keyed, columnKeys, targetType);
+          for (size_t i = 0; i < keys.size(); ++i) {
+            if (columnKeys[i] != keys[i]) {
+              materialized.emplace(keys[i], columnKeys[i]);
+            }
+          }
         }
       }
     }
     if (newInput == node->input()) {
       return node;
     }
+    ExprVector columnExprs{node->columnExprs()};
+    if (!materialized.empty()) {
+      columnExprs = exprFactory_.replace(columnExprs, materialized);
+    }
     return builder().make<TableWrite>(
-        {newInput, node->table(), node->kind(), node->columnExprs()});
+        {newInput, node->table(), node->kind(), std::move(columnExprs)});
   }
 
  private:
@@ -848,6 +857,7 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   // separately.
   const int32_t numWorkers_;
   const int32_t numDrivers_;
+  ExprFactory exprFactory_;
 
   // Shared across all clusters of this query so a leaf (or hash-consed
   // duplicate) subtree is estimated once.

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -51,6 +51,24 @@ NodeCP makeProject(
       {input, std::move(exprs), std::move(outColumns)});
 }
 
+// Returns a new ColumnVector with the first `oldPrefixLength` elements
+// of `oldOutputColumns` replaced by `newPrefix`.
+ColumnVector replacePrefix(
+    const ColumnVector& oldOutputColumns,
+    size_t oldPrefixLength,
+    const ColumnVector& newPrefix) {
+  VELOX_DCHECK_LE(oldPrefixLength, oldOutputColumns.size());
+  ColumnVector result;
+  result.reserve(newPrefix.size() + oldOutputColumns.size() - oldPrefixLength);
+  for (ColumnCP column : newPrefix) {
+    result.push_back(column);
+  }
+  for (size_t i = oldPrefixLength; i < oldOutputColumns.size(); ++i) {
+    result.push_back(oldOutputColumns[i]);
+  }
+  return result;
+}
+
 // Per-consumer builder that lifts compound sub-expressions into a Project
 // inserted between the consumer and its existing input.
 class PrecomputeProjections {
@@ -145,20 +163,7 @@ ExprCP PrecomputeProjections::toColumn(
     return alias;
   }
 
-  // A compound expression materializes into a column named after its id, so the
-  // same expression always lifts to the same name. If a column of that name is
-  // already in the input — e.g. an exchange below this consumer lifted the same
-  // join/grouping key — reuse it instead of projecting a second column with the
-  // same name (which would be a duplicate output column).
-  const auto name = toName(fmt::format("__p{}", expr->id()));
-  for (ColumnCP column : input_->outputColumns()) {
-    if (column->name() == name) {
-      seen_.emplace(expr, column);
-      return column;
-    }
-  }
-
-  ColumnCP column = make<Column>(name, nullptr, expr->value());
+  ColumnCP column = Column::create("__p", expr->value());
   addToProject(expr, column);
   needsProject_ = true;
   return column;
@@ -324,24 +329,6 @@ void JoinFilterRewriter::keep(ColumnCP column) {
   }
 }
 
-// Returns a new ColumnVector with the first `oldPrefixLength` elements
-// of `oldOutputColumns` replaced by `newPrefix`.
-ColumnVector replacePrefix(
-    const ColumnVector& oldOutputColumns,
-    size_t oldPrefixLength,
-    const ColumnVector& newPrefix) {
-  VELOX_DCHECK_LE(oldPrefixLength, oldOutputColumns.size());
-  ColumnVector result;
-  result.reserve(newPrefix.size() + oldOutputColumns.size() - oldPrefixLength);
-  for (ColumnCP column : newPrefix) {
-    result.push_back(column);
-  }
-  for (size_t i = oldPrefixLength; i < oldOutputColumns.size(); ++i) {
-    result.push_back(oldOutputColumns[i]);
-  }
-  return result;
-}
-
 // Lifts compound expressions at restricted positions of Aggregate /
 // Window / Sort / Unnest into a Project below the consumer.
 class Rewriter : public NodeRewriter<> {
@@ -355,7 +342,6 @@ class Rewriter : public NodeRewriter<> {
   NodeCP rewriteSort(const Sort* sort, NoContext& context) override;
   NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
   NodeCP rewriteJoin(const Join* join, NoContext& context) override;
-  NodeCP rewriteExchange(const Exchange* exchange, NoContext& context) override;
   NodeCP rewriteUnionAll(const UnionAll* unionAll, NoContext& context) override;
   NodeCP rewriteApply(const Apply* /*apply*/, NoContext& /*context*/) override {
     VELOX_UNREACHABLE(
@@ -475,6 +461,8 @@ NodeCP Rewriter::rewriteWindow(const Window* window, NoContext& context) {
     newFunctions.push_back({newCall, newFrame, windowFunction.ignoreNulls});
   }
 
+  // A Window emits its input's columns followed by its function results, so
+  // materializing a frame bound or an order key extends its output too.
   const size_t oldPrefixLength = window->input()->outputColumns().size();
   newInput = std::move(precompute).node();
   ColumnVector newOutputColumns = replacePrefix(
@@ -502,29 +490,6 @@ NodeCP Rewriter::rewriteSort(const Sort* sort, NoContext& context) {
        sort->orderTypes()});
 }
 
-NodeCP Rewriter::rewriteExchange(const Exchange* exchange, NoContext& context) {
-  NodeCP newInput = rewrite(exchange->input(), context);
-  const Partitioning& partitioning = exchange->partitioning();
-  // Only hash partitioning carries keys, and emit requires them to be column
-  // references; lift any compound key expression into a projected column.
-  if (partitioning.kind != PartitionKind::kPartitioned) {
-    if (newInput == exchange->input()) {
-      return exchange;
-    }
-    return builder().make<Exchange>({newInput, partitioning});
-  }
-  PrecomputeProjections precompute{newInput, builder()};
-  ExprVector newKeys;
-  newKeys.reserve(partitioning.keys.size());
-  for (ExprCP key : partitioning.keys) {
-    newKeys.push_back(precompute.toColumn(key));
-  }
-  Partitioning newPartitioning = partitioning;
-  newPartitioning.keys = std::move(newKeys);
-  return builder().make<Exchange>(
-      {std::move(precompute).node(), std::move(newPartitioning)});
-}
-
 NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
   NodeCP newLeft = rewrite(join->left(), context);
   NodeCP newRight = rewrite(join->right(), context);
@@ -545,6 +510,26 @@ NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
   newRightKeys.reserve(join->rightKeys().size());
   for (ExprCP key : join->rightKeys()) {
     newRightKeys.push_back(rightPrecompute.toColumn(key));
+  }
+
+  // A key that was lifted is now computed by the input, so the filter must
+  // read that column rather than compute the same expression per pair.
+  ExprFactory::ExprSubstitution lifted;
+  const auto recordLifted = [&](const ExprVector& keys,
+                                const ExprVector& newKeys) {
+    for (size_t i = 0; i < keys.size(); ++i) {
+      if (newKeys[i] != keys[i]) {
+        lifted.emplace(keys[i], newKeys[i]);
+      }
+    }
+  };
+  recordLifted(join->leftKeys(), newLeftKeys);
+  recordLifted(join->rightKeys(), newRightKeys);
+  ExprFactory factory{builder()};
+  ExprVector joinFilter;
+  joinFilter.reserve(join->filter().size());
+  for (ExprCP conjunct : join->filter()) {
+    joinFilter.push_back(factory.replace(conjunct, lifted));
   }
 
   // Keep each side's passthrough columns: those it contributes to the join
@@ -568,9 +553,9 @@ NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {
   if (newLeftKeys.empty()) {
     JoinFilterRewriter rewriter{
         leftPrecompute, rightPrecompute, leftColumns, rightColumns, builder()};
-    newFilter = rewriter.rewrite(join->filter());
+    newFilter = rewriter.rewrite(joinFilter);
   } else {
-    newFilter = join->filter();
+    newFilter = joinFilter;
     for (ExprCP conjunct : newFilter) {
       conjunct->columns().forEach<Column>(keepPassthrough);
     }

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.h
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.h
@@ -35,7 +35,6 @@ class PrecomputeProjectionsPass {
   ///   - Sort:      order keys
   ///   - Unnest:    unnest expressions
   ///   - Join:      join keys
-  ///   - Exchange:  hash partitioning keys
   ///
   /// A join filter is the one exception: Velox accepts any expression there,
   /// so the move is an optimization rather than a requirement.


### PR DESCRIPTION
Summary:
A join carrying a non-equi filter was estimated as if the filter were not there. For `SELECT count(*) FROM lineitem l, orders o WHERE l.l_orderkey = o.o_orderkey AND l.l_extendedprice > o.o_totalprice` at sf1, v2 estimated the join at 5,817,190 rows — the match count with the filter ignored — while v1, which puts the same predicate in a `Filter` above the join, estimated 546,306. v2 now reaches the same 546,306. Join order is chosen from these numbers, so a filtered join and everything above it were costed against a row count the filter never touched.

`JoinFanout::outputCardinality` takes the filter and reduces the match count by its selectivity before shaping the result by join type. The filter is part of the match condition for every join type, so it reduces matches in all of them, and the join type bounds what that does to the output — a left join still emits at least one row per left row. Both v2 estimators call it — the cost model that picks join order and the estimate provider that reads a built plan — so the rule cannot differ between the plan chosen and the plan measured.

The two match-count formulas stay separate, and each now says why: the plan search needs a value that does not depend on how a cover was split, which a caller holding only a built tree cannot reproduce.

Differential Revision: D115573025
