### PR TITLE
feat(parser): Parse DELETE statements (#1688)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -1166,6 +1166,10 @@ SqlQueryRunner::co_runUnchecked(
     co_return;
   }
 
+  if (sqlStatement.isDelete()) {
+    VELOX_NYI("DELETE is not supported yet");
+  }
+
   VELOX_CHECK(sqlStatement.isSelect());
   auto generator = co_runPlanStatement(
       sqlStatement, queryId, options, timing, planString, runtimeStats);

--- a/axiom/logical_plan/LogicalPlanNode.cpp
+++ b/axiom/logical_plan/LogicalPlanNode.cpp
@@ -1103,6 +1103,9 @@ TableWriteNode::TableWriteNode(
       writeKind_ == WriteKind::kCreate || writeKind == WriteKind::kInsert ||
           options_.empty(),
       "Options are supported only for create or insert");
+  VELOX_USER_CHECK(
+      writeKind_ != WriteKind::kDelete || columnNames_.empty(),
+      "Delete writes no columns");
 }
 
 void TableWriteNode::accept(

--- a/axiom/logical_plan/LogicalPlanNode.h
+++ b/axiom/logical_plan/LogicalPlanNode.h
@@ -863,8 +863,9 @@ enum class WriteKind {
   // whole rows.
   kInsert = 2,
 
-  // Individual rows are deleted. Only row ids as per
-  // Table::rowIdHandles() are passed to the TableWriter.
+  // Individual rows are deleted. Carries no column names or expressions in the
+  // logical plan: how a row is identified is a physical property of the target
+  // connector, resolved during optimization.
   kDelete = 3,
 
   // Column values in individual rows are changed. The TableWriter
@@ -891,7 +892,7 @@ class TableWriteNode : public LogicalPlanNode {
   /// Correspond 1:1 to 'columnExpressions'. 'columnNames' must refer to columns
   /// in the table but their number or order does not have to correspond to the
   /// table. Missing columns get their default from the table schema. Column
-  /// names must be unique.
+  /// names must be unique. Must be empty for 'kDelete'.
   /// @param columnExpressions Expressions producing the values to write.
   /// Correspond 1:1 to 'columnNames'.
   /// @param options Writer dependent options. May specify compression or

--- a/axiom/logical_plan/PlanBuilder.cpp
+++ b/axiom/logical_plan/PlanBuilder.cpp
@@ -1692,8 +1692,12 @@ PlanBuilder& PlanBuilder::tableWrite(
     const std::vector<ExprApi>& columnExprs,
     folly::F14FastMap<std::string, std::string> options) {
   VELOX_USER_CHECK_NOT_NULL(node_, "Table write node cannot be a leaf node");
-  VELOX_USER_CHECK_GT(columnNames.size(), 0);
   VELOX_USER_CHECK_EQ(columnNames.size(), columnExprs.size());
+  if (kind == WriteKind::kDelete) {
+    VELOX_USER_CHECK_EQ(columnNames.size(), 0, "Delete writes no columns");
+  } else {
+    VELOX_USER_CHECK_GT(columnNames.size(), 0);
+  }
 
   SchemaTableName schemaTableName{std::move(schemaName), std::move(tableName)};
 
@@ -1703,37 +1707,40 @@ PlanBuilder& PlanBuilder::tableWrite(
     columnExpressions.push_back(resolveScalarTypes(expr.expr()));
   }
 
-  if (kind == WriteKind::kInsert) {
-    // Check input types.
+  if (kind == WriteKind::kInsert || kind == WriteKind::kDelete) {
     auto metadata = ConnectorMetadataRegistry::get(connectorId);
     auto table = metadata->findTable(schemaTableName);
     VELOX_USER_CHECK_NOT_NULL(
         table, "Table not found: {}", schemaTableName.toString());
-    const auto& schema = table->type();
 
-    for (auto i = 0; i < columnNames.size(); i++) {
-      const auto& name = columnNames[i];
-      const auto index = schema->getChildIdxIfExists(name);
-      VELOX_USER_CHECK(
-          index.has_value(),
-          "Column not found: '{}' in table {}",
-          name,
-          schemaTableName.toString());
+    if (kind == WriteKind::kInsert) {
+      // Check input types.
+      const auto& schema = table->type();
 
-      const auto& inputType = columnExpressions[i]->type();
-      const auto& schemaType = schema->childAt(index.value());
+      for (auto i = 0; i < columnNames.size(); i++) {
+        const auto& name = columnNames[i];
+        const auto index = schema->getChildIdxIfExists(name);
+        VELOX_USER_CHECK(
+            index.has_value(),
+            "Column not found: '{}' in table {}",
+            name,
+            schemaTableName.toString());
 
-      if (!schemaType->equivalent(*inputType)) {
-        if (coercer_ != nullptr && coercer_->coerce(inputType, schemaType)) {
-          columnExpressions[i] =
-              applyCoercion(columnExpressions[i], schemaType);
-        } else {
-          VELOX_USER_FAIL(
-              "Wrong column type: {} vs. {}, column '{}' in table {}",
-              inputType->toString(),
-              schemaType->toString(),
-              name,
-              schemaTableName.toString());
+        const auto& inputType = columnExpressions[i]->type();
+        const auto& schemaType = schema->childAt(index.value());
+
+        if (!schemaType->equivalent(*inputType)) {
+          if (coercer_ != nullptr && coercer_->coerce(inputType, schemaType)) {
+            columnExpressions[i] =
+                applyCoercion(columnExpressions[i], schemaType);
+          } else {
+            VELOX_USER_FAIL(
+                "Wrong column type: {} vs. {}, column '{}' in table {}",
+                inputType->toString(),
+                schemaType->toString(),
+                name,
+                schemaTableName.toString());
+          }
         }
       }
     }
@@ -1776,6 +1783,28 @@ PlanBuilder& PlanBuilder::tableWrite(
       std::move(columnNames),
       columnExprs,
       std::move(options));
+}
+
+PlanBuilder& PlanBuilder::tableDelete(
+    std::string connectorId,
+    std::string schemaName,
+    std::string tableName) {
+  return tableWrite(
+      std::move(connectorId),
+      std::move(schemaName),
+      std::move(tableName),
+      WriteKind::kDelete,
+      /*columnNames=*/{},
+      /*columnExprs=*/std::vector<ExprApi>{});
+}
+
+PlanBuilder& PlanBuilder::tableDelete(std::string tableName) {
+  VELOX_USER_CHECK(defaultConnectorId_.has_value());
+  VELOX_USER_CHECK(defaultSchema_.has_value());
+  return tableDelete(
+      defaultConnectorId_.value(),
+      defaultSchema_.value(),
+      std::move(tableName));
 }
 
 PlanBuilder& PlanBuilder::sample(

--- a/axiom/logical_plan/PlanBuilder.h
+++ b/axiom/logical_plan/PlanBuilder.h
@@ -668,6 +668,16 @@ class PlanBuilder {
       std::vector<std::string> columnNames,
       folly::F14FastMap<std::string, std::string> options = {});
 
+  /// Adds a TableWrite node that deletes the rows produced by the input from
+  /// 'tableName'.
+  PlanBuilder& tableDelete(
+      std::string connectorId,
+      std::string schemaName,
+      std::string tableName);
+
+  /// @overload Uses the default connector ID and schema.
+  PlanBuilder& tableDelete(std::string tableName);
+
   /// Adds a Sample node that passes each row with the given probability.
   PlanBuilder& sample(double percentage, SampleNode::SampleMethod sampleMethod);
 

--- a/axiom/logical_plan/PlanPrinter.cpp
+++ b/axiom/logical_plan/PlanPrinter.cpp
@@ -813,9 +813,11 @@ class SummarizeToTextVisitor : public PlanNodeVisitor {
                     << std::endl;
       myContext.out << indent << "connector: " << node.connectorId()
                     << std::endl;
-      myContext.out << indent << "columns: " << node.columnNames().size()
-                    << std::endl;
-      appendExpressions(node.columnExpressions(), myContext);
+      if (!node.columnNames().empty()) {
+        myContext.out << indent << "columns: " << node.columnNames().size()
+                      << std::endl;
+        appendExpressions(node.columnExpressions(), myContext);
+      }
     }
 
     appendInputs(node, myContext);

--- a/axiom/logical_plan/tests/PlanPrinterTest.cpp
+++ b/axiom/logical_plan/tests/PlanPrinterTest.cpp
@@ -1518,7 +1518,6 @@ TEST_F(PlanPrinterTest, tableWrite) {
   for (const auto& [expectedKind, actualKind] : {
            std::pair{"CREATE", WriteKind::kCreate},
            {"INSERT", WriteKind::kInsert},
-           {"DELETE", WriteKind::kDelete},
            {"UPDATE", WriteKind::kUpdate},
        }) {
     SCOPED_TRACE(
@@ -1586,6 +1585,54 @@ TEST_F(PlanPrinterTest, tableWrite) {
             testing::Eq("        connector: test"),
             testing::Eq("")));
   }
+}
+
+TEST_F(PlanPrinterTest, tableWriteDelete) {
+  connector_->addTable("events", ROW({"a", "ds"}, {BIGINT(), VARCHAR()}));
+
+  SCOPE_EXIT {
+    connector_->dropTableIfExists({std::string(kDefaultSchema), "events"});
+  };
+
+  auto plan = PlanBuilder(context_)
+                  .tableScan("events", {"a", "ds"})
+                  .filter("ds = '2026-01-01'")
+                  .tableDelete("events")
+                  .build();
+
+  EXPECT_THAT(
+      toLines(plan),
+      testing::ElementsAre(
+          testing::StartsWith("- TableWrite DELETE"),
+          testing::StartsWith("  - Filter: eq(ds, 2026-01-01)"),
+          testing::StartsWith("    - TableScan"),
+          testing::Eq("")));
+
+  EXPECT_THAT(
+      toSummaryLines(plan),
+      testing::ElementsAre(
+          testing::Eq("- TABLE_WRITE DELETE [2]: 1 fields: rows BIGINT"),
+          testing::Eq("      table: \"default\".\"events\""),
+          testing::Eq("      connector: test"),
+          testing::Eq("  - FILTER [1]: 2 fields: a BIGINT, ds VARCHAR"),
+          testing::Eq("        predicate: eq(ds, 2026-01-01)"),
+          testing::Eq("        expressions: call: 1, constant: 1, field: 1"),
+          testing::Eq("        functions: eq: 1"),
+          testing::Eq("        constants: VARCHAR: 1"),
+          testing::Eq("    - TABLE_SCAN [0]: 2 fields: a BIGINT, ds VARCHAR"),
+          testing::Eq("          table: \"default\".\"events\""),
+          testing::Eq("          connector: test"),
+          testing::Eq("")));
+
+  EXPECT_THAT(
+      toSkeletonLines(plan),
+      testing::ElementsAre(
+          testing::Eq("- TABLE_WRITE DELETE [2]: 1 fields"),
+          testing::Eq("  - FILTER [1]: 2 fields"),
+          testing::Eq("    - TABLE_SCAN [0]: 2 fields"),
+          testing::Eq("          table: \"default\".\"events\""),
+          testing::Eq("          connector: test"),
+          testing::Eq("")));
 }
 
 TEST_F(PlanPrinterTest, fixedPointCounter) {

--- a/axiom/sql/presto/PrestoParser.cpp
+++ b/axiom/sql/presto/PrestoParser.cpp
@@ -341,6 +341,17 @@ class RelationPlanner : public AstVisitor {
     builder_->tableWrite(std::forward<Args>(args)...);
   }
 
+  void planDelete(
+      const Delete& node,
+      const std::string& connectorId,
+      const facebook::axiom::SchemaTableName& table) {
+    processTable(node.location(), *node.table());
+    addFilter(node.where());
+
+    displayNames_.lastNames.clear();
+    builder_->tableDelete(connectorId, table.schema, table.table);
+  }
+
   const ViewMap& views() const {
     return views_;
   }
@@ -607,19 +618,22 @@ class RelationPlanner : public AstVisitor {
   }
 
   void processTable(const Table& table) {
-    const auto tableName = canonicalizeName(table.name()->suffix());
+    processTable(table.location(), *table.name());
+  }
+
+  void processTable(const NodeLocation& location, const QualifiedName& name) {
+    const auto tableName = canonicalizeName(name.suffix());
 
     // Only an unqualified single-part name can name a CTE; a qualified
     // catalog.schema.table reference is always a base table or view, even if
     // its last component matches a CTE name.
-    if (table.name()->parts().size() == 1 &&
-        tryProcessCteReference(tableName)) {
+    if (name.parts().size() == 1 && tryProcessCteReference(tableName)) {
       return;
     }
 
     // Regular base-table reference.
     const auto [connectorId, connectorTable] = toConnectorTable(
-        *table.name(), context_.defaultConnectorId.value(), defaultSchema_);
+        name, context_.defaultConnectorId.value(), defaultSchema_);
 
     auto metadata =
         facebook::axiom::connector::ConnectorMetadataRegistry::get(connectorId);
@@ -646,12 +660,12 @@ class RelationPlanner : public AstVisitor {
       processQuery(dynamic_cast<Query*>(query.get()));
     } else {
       AXIOM_PRESTO_SEMANTIC_FAIL(
-          table.location(),
+          location,
           // Use suffix (unqualified name) as token — the user rarely writes
           // the fully qualified form.
-          table.name()->suffix(),
+          name.suffix(),
           "Table not found: {}",
-          table.name()->fullyQualifiedName());
+          name.fullyQualifiedName());
     }
 
     builder_->findOrAssignOutputNames(/*includeHiddenColumns=*/false);
@@ -2559,6 +2573,32 @@ SqlStatementPtr parseInsert(
       });
 }
 
+SqlStatementPtr parseDelete(
+    const std::string& user,
+    const Delete& deleteNode,
+    const std::string& defaultConnectorId,
+    const std::string& defaultSchema,
+    const std::function<std::shared_ptr<axiom::sql::presto::Statement>(
+        std::string_view /*sql*/)>& parseSql) {
+  const auto [connectorId, connectorTable] =
+      toConnectorTable(*deleteNode.table(), defaultConnectorId, defaultSchema);
+
+  // Reject a missing target before planning the scan, which would otherwise
+  // resolve a view of that name and write to a table that does not exist.
+  findTable(*deleteNode.table(), connectorId, connectorTable);
+
+  RelationPlanner planner(user, defaultConnectorId, defaultSchema, parseSql);
+  planner.planDelete(deleteNode, connectorId, connectorTable);
+
+  return std::make_shared<DeleteStatement>(
+      planner.plan(),
+      planner.views(),
+      ReferencedTables{
+          planner.inputTables(),
+          facebook::axiom::CatalogSchemaTableName{connectorId, connectorTable},
+      });
+}
+
 std::unordered_map<std::string, lp::ExprPtr> parseTableProperties(
     const std::string& user,
     const std::vector<std::shared_ptr<Property>>& props) {
@@ -3127,6 +3167,15 @@ SqlStatementPtr doPlan(
     return parseInsert(
         user,
         *query->as<Insert>(),
+        defaultConnectorId,
+        defaultSchema,
+        parseSql);
+  }
+
+  if (query->is(NodeType::kDelete)) {
+    return parseDelete(
+        user,
+        *query->as<Delete>(),
         defaultConnectorId,
         defaultSchema,
         parseSql);

--- a/axiom/sql/presto/SqlStatement.cpp
+++ b/axiom/sql/presto/SqlStatement.cpp
@@ -31,6 +31,7 @@ const auto& statementKindNames() {
       {SqlStatementKind::kCreateTable, "CREATE TABLE"},
       {SqlStatementKind::kCreateTableAsSelect, "CREATE TABLE AS SELECT"},
       {SqlStatementKind::kInsert, "INSERT"},
+      {SqlStatementKind::kDelete, "DELETE"},
       {SqlStatementKind::kDropTable, "DROP TABLE"},
       {SqlStatementKind::kCreateSchema, "CREATE SCHEMA"},
       {SqlStatementKind::kDropSchema, "DROP SCHEMA"},

--- a/axiom/sql/presto/SqlStatement.h
+++ b/axiom/sql/presto/SqlStatement.h
@@ -38,6 +38,7 @@ enum class SqlStatementKind {
   kCreateTable,
   kCreateTableAsSelect,
   kInsert,
+  kDelete,
   kDropTable,
   kCreateSchema,
   kDropSchema,
@@ -95,6 +96,10 @@ class SqlStatement {
 
   bool isInsert() const {
     return kind_ == SqlStatementKind::kInsert;
+  }
+
+  bool isDelete() const {
+    return kind_ == SqlStatementKind::kDelete;
   }
 
   bool isDropTable() const {
@@ -209,6 +214,28 @@ class InsertStatement : public SqlStatement {
       ReferencedTables referencedTables)
       : SqlStatement(
             SqlStatementKind::kInsert,
+            std::move(views),
+            std::move(referencedTables)),
+        plan_{std::move(plan)} {}
+
+  const facebook::axiom::logical_plan::LogicalPlanNodePtr& plan() const {
+    return plan_;
+  }
+
+ private:
+  const facebook::axiom::logical_plan::LogicalPlanNodePtr plan_;
+};
+
+/// DELETE statement. 'plan' is a TableWriteNode with WriteKind::kDelete over
+/// the filtered scan of the target table.
+class DeleteStatement : public SqlStatement {
+ public:
+  DeleteStatement(
+      facebook::axiom::logical_plan::LogicalPlanNodePtr plan,
+      ViewMap views,
+      ReferencedTables referencedTables)
+      : SqlStatement(
+            SqlStatementKind::kDelete,
             std::move(views),
             std::move(referencedTables)),
         plan_{std::move(plan)} {}

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -788,7 +788,11 @@ std::any AstBuilder::visitInsertInto(PrestoSqlParser::InsertIntoContext* ctx) {
 
 std::any AstBuilder::visitDelete(PrestoSqlParser::DeleteContext* ctx) {
   trace("visitDelete");
-  return visitChildren("visitDelete", ctx);
+
+  return std::static_pointer_cast<Statement>(std::make_shared<Delete>(
+      getLocation(ctx),
+      getQualifiedName(ctx->qualifiedName()),
+      visitExpression(ctx->booleanExpression())));
 }
 
 std::any AstBuilder::visitTruncateTable(

--- a/axiom/sql/presto/tests/DdlParserTest.cpp
+++ b/axiom/sql/presto/tests/DdlParserTest.cpp
@@ -61,6 +61,21 @@ TEST_F(DdlParserTest, insertIntoTable) {
       "Column not found: 'no_such_col' in table \"default\".\"nation\"");
 }
 
+TEST_F(DdlParserTest, deleteFromTable) {
+  {
+    auto matcher = matchScan("nation").tableWrite();
+    testDelete("DELETE FROM nation", matcher);
+  }
+
+  {
+    auto matcher = matchScan("nation").filter().tableWrite();
+    testDelete("DELETE FROM nation WHERE n_regionkey = 1", matcher);
+  }
+
+  AXIOM_EXPECT_PRESTO_SEMANTIC_ERROR(
+      parseSql("DELETE FROM no_such_table"), "Table not found: no_such_table");
+}
+
 TEST_F(DdlParserTest, createTableAsSelect) {
   {
     auto ctasMetadata =

--- a/axiom/sql/presto/tests/PrestoParserTestBase.cpp
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "axiom/sql/presto/tests/PrestoParserTestBase.h"
+#include <gmock/gmock.h>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/logical_plan/ExprPrinter.h"
 #include "velox/common/base/tests/GTestUtils.h"
@@ -145,6 +146,26 @@ void PrestoParserTestBase::testInsert(
 
   auto logicalPlan = insertStatement->plan();
   ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
+}
+
+void PrestoParserTestBase::testDelete(
+    std::string_view sql,
+    lp::test::LogicalPlanMatcherBuilder& matcher) {
+  SCOPED_TRACE(sql);
+  auto parser = makeParser();
+
+  auto statement = parser.parse(sql);
+  ASSERT_TRUE(statement->isDelete());
+
+  auto deleteStatement = statement->as<DeleteStatement>();
+
+  auto logicalPlan = deleteStatement->plan();
+  ASSERT_TRUE(matcher.build()->match(logicalPlan)) << logicalPlan->toString();
+
+  const auto* write = logicalPlan->as<lp::TableWriteNode>();
+  EXPECT_EQ(lp::WriteKind::kDelete, write->writeKind());
+  EXPECT_THAT(write->columnNames(), testing::IsEmpty());
+  EXPECT_THAT(write->columnExpressions(), testing::IsEmpty());
 }
 
 void PrestoParserTestBase::testCtas(

--- a/axiom/sql/presto/tests/PrestoParserTestBase.h
+++ b/axiom/sql/presto/tests/PrestoParserTestBase.h
@@ -80,6 +80,12 @@ class PrestoParserTestBase : public testing::Test {
       std::string_view sql,
       facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher);
 
+  /// Parses a DELETE statement and verifies the logical plan matches, and
+  /// that its root is a kDelete write carrying no columns.
+  void testDelete(
+      std::string_view sql,
+      facebook::axiom::logical_plan::test::LogicalPlanMatcherBuilder& matcher);
+
   /// Parses a CREATE TABLE AS SELECT statement and verifies the table name,
   /// schema, logical plan, and optional table properties.
   void testCtas(


### PR DESCRIPTION
Summary:

`DELETE FROM t WHERE ds = '2026-01-01'` used to fail in the parser with an internal error:

    visitChildren called with more than one child: 5 (visitDelete)

It now parses into a logical plan. Running one reports `DELETE is not supported yet`.

A delete plans as a `TableWriteNode` with `WriteKind::kDelete` over the filtered scan of the target table, carrying no column names or expressions. How a row is identified is a physical property of the target connector, so it is resolved during optimization rather than named in the logical plan.

A write with no columns is new, so the write path no longer assumes every write names them: `PlanBuilder` gained a `tableDelete` entry point that rejects columns, and the printer omits the column section when there is nothing to print. The table-existence check that only insert performed now covers delete too.

Reviewed By: amitkdutta

Differential Revision: D115642309
