### PR TITLE
feat(optimizer): Execute DELETE via connector metadata (#1689)

### DIFF
--- a/axiom/cli/SqlQueryRunner.cpp
+++ b/axiom/cli/SqlQueryRunner.cpp
@@ -388,7 +388,11 @@ connector::TablePtr SqlQueryRunner::createTable(
   // finishWrite. Run an empty create-write so the table is persisted.
   if (table != nullptr && !explain) {
     auto handle = metadata->beginWrite(
-        session, table, connector::WriteKind::kCreate, /*explain=*/false);
+        session,
+        table,
+        connector::WriteKind::kCreate,
+        /*scanHandle=*/nullptr,
+        /*explain=*/false);
     // TODO: Make the commit timeout configurable (e.g. via a DdlOptions).
     constexpr std::chrono::seconds kCommitTimeout{60};
     try {
@@ -876,6 +880,8 @@ SqlQueryRunner::co_runExplainStatement(
     logicalPlan = statement->as<presto::SelectStatement>()->plan();
   } else if (statement->isInsert()) {
     logicalPlan = statement->as<presto::InsertStatement>()->plan();
+  } else if (statement->isDelete()) {
+    logicalPlan = statement->as<presto::DeleteStatement>()->plan();
   } else if (statement->isCreateTableAsSelect()) {
     const auto* ctas = statement->as<presto::CreateTableAsSelectStatement>();
     logicalPlan = ctas->plan();
@@ -997,6 +1003,8 @@ SqlQueryRunner::co_runPlanStatement(
     logicalPlan = ctas->plan();
   } else if (sqlStatement.isInsert()) {
     logicalPlan = sqlStatement.as<presto::InsertStatement>()->plan();
+  } else if (sqlStatement.isDelete()) {
+    logicalPlan = sqlStatement.as<presto::DeleteStatement>()->plan();
   } else if (sqlStatement.isSelect()) {
     logicalPlan = sqlStatement.as<presto::SelectStatement>()->plan();
   } else {
@@ -1126,7 +1134,8 @@ SqlQueryRunner::co_runUnchecked(
     co_return;
   }
 
-  if (sqlStatement.isCreateTableAsSelect() || sqlStatement.isInsert()) {
+  if (sqlStatement.isCreateTableAsSelect() || sqlStatement.isInsert() ||
+      sqlStatement.isDelete()) {
     auto generator = co_runPlanStatement(
         sqlStatement, queryId, options, timing, planString, runtimeStats);
     while (auto chunk = co_await generator.next()) {
@@ -1164,10 +1173,6 @@ SqlQueryRunner::co_runUnchecked(
       co_yield std::move(*chunk);
     }
     co_return;
-  }
-
-  if (sqlStatement.isDelete()) {
-    VELOX_NYI("DELETE is not supported yet");
   }
 
   VELOX_CHECK(sqlStatement.isSelect());

--- a/axiom/cli/tests/CMakeLists.txt
+++ b/axiom/cli/tests/CMakeLists.txt
@@ -15,6 +15,7 @@
 add_executable(
   axiom_cli_test
   CatalogPropertiesTest.cpp
+  DeleteTest.cpp
   ExplainIoTest.cpp
   ExplainTest.cpp
   ShowStatsTest.cpp

--- a/axiom/cli/tests/DeleteTest.cpp
+++ b/axiom/cli/tests/DeleteTest.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <folly/json.h>
+#include <gtest/gtest.h>
+
+#include "axiom/cli/Connectors.h"
+#include "axiom/cli/tests/SqlQueryRunnerTestBase.h"
+#include "velox/dwio/common/Options.h"
+#include "velox/exec/tests/utils/TempDirectoryPath.h"
+
+namespace axiom::sql {
+namespace {
+
+using namespace facebook::velox;
+
+// Drives DELETE end to end through the CLI over a Hive connector backed by a
+// temporary directory. Hive removes the rows by dropping partitions.
+class DeleteTest : public SqlQueryRunnerTestBase {
+ protected:
+  static constexpr std::string_view kConnectorId = "hive";
+  static constexpr std::string_view kHiveSchema = "default";
+  static constexpr auto kFileFormat = dwio::common::FileFormat::DWRF;
+
+  void SetUp() override {
+    useV2_ = true;
+    dataPath_ = exec::test::TempDirectoryPath::create();
+
+    runner_ = makeRunner([&]() {
+      connectors_.registerLocalHiveConnector(
+          dataPath_->getPath(),
+          std::string(dwio::common::FileFormatName::toName(kFileFormat)),
+          std::string(kConnectorId));
+      return std::make_pair(
+          std::string(kConnectorId), std::string(kHiveSchema));
+    });
+  }
+
+  // Parses and re-serializes JSON with sorted keys so the comparison does not
+  // depend on key order.
+  static std::string normalizeJson(const std::string& json) {
+    folly::json::serialization_opts opts;
+    opts.pretty_formatting = true;
+    opts.sort_keys = true;
+    return folly::json::serialize(folly::parseJson(json), opts);
+  }
+
+  // Runs 'sql' under EXPLAIN and returns the plan text.
+  std::string runExplain(std::string_view sql) {
+    auto result = run(fmt::format("EXPLAIN {}", sql));
+    VELOX_CHECK(result.message.has_value());
+    return result.message.value();
+  }
+
+  // Runs 'sql' under EXPLAIN (TYPE IO) and returns the normalized IO JSON.
+  std::string runExplainIo(std::string_view sql) {
+    auto result = run(fmt::format("EXPLAIN (TYPE IO) {}", sql));
+    VELOX_CHECK(result.message.has_value());
+    return normalizeJson(result.message.value());
+  }
+
+  // Returns the number of rows selected by 'fromClause', e.g. "FROM test
+  // WHERE pk = 1".
+  int64_t runCount(std::string_view fromClause) {
+    return fetchSingleValue<int64_t>(
+        fmt::format("SELECT count(*) {}", fromClause));
+  }
+
+  std::shared_ptr<exec::test::TempDirectoryPath> dataPath_;
+  facebook::axiom::Connectors connectors_;
+};
+
+// Explains and then runs a delete against one table: creating a Hive table is
+// expensive, so both share it.
+TEST_F(DeleteTest, partitionPredicate) {
+  run("CREATE TABLE test WITH (partitioned_by = ARRAY['pk']) AS "
+      "SELECT x, x % 3 AS pk FROM unnest(array[1, 2, 3, 4, 5, 6]) AS t(x)");
+
+  EXPECT_EQ(
+      runExplain("DELETE FROM test WHERE pk = 1"),
+      R"(Metadata write via connector 'hive': drop partitions of "default"."test" matching pk BigintRange: [1, 1] no nulls)");
+
+  // The rows removed are the rows scanned, so a delete reports the table it
+  // reads and no output table.
+  EXPECT_EQ(
+      runExplainIo("DELETE FROM test WHERE pk = 1"),
+      normalizeJson(
+          R"({
+              "inputTableColumnInfos": [
+                {
+                  "columnConstraints": [
+                    {
+                      "domain": {
+                        "ranges": [
+                          {
+                            "high": {
+                              "bound": "EXACTLY",
+                              "value": 1
+                            },
+                            "low": {
+                              "bound": "EXACTLY",
+                              "value": 1
+                            }
+                          }
+                        ],
+                        "nullsAllowed": false
+                      },
+                      "typeSignature": "INTEGER",
+                      "columnName": "pk"
+                    }
+                  ],
+                  "table": {
+                    "schemaTable": {
+                      "table": "test",
+                      "schema": "default"
+                    },
+                    "catalog": "hive"
+                  }
+                }
+              ]
+            })"));
+
+  // EXPLAIN is side-effect-free.
+  EXPECT_EQ(6, runCount("FROM test"));
+
+  EXPECT_EQ(2, fetchSingleValue<int64_t>("DELETE FROM test WHERE pk = 1"));
+  EXPECT_EQ(4, runCount("FROM test"));
+  EXPECT_EQ(0, runCount("FROM test WHERE pk = 1"));
+
+  // A delete with no predicate selects no partition in particular.
+  EXPECT_EQ(
+      runExplain("DELETE FROM test"),
+      R"(Metadata write via connector 'hive': drop all rows of "default"."test")");
+
+  EXPECT_EQ(
+      runExplainIo("DELETE FROM test"),
+      normalizeJson(
+          R"({
+              "inputTableColumnInfos": [
+                {
+                  "columnConstraints": [],
+                  "table": {
+                    "schemaTable": {
+                      "table": "test",
+                      "schema": "default"
+                    },
+                    "catalog": "hive"
+                  }
+                }
+              ]
+            })"));
+
+  EXPECT_EQ(4, fetchSingleValue<int64_t>("DELETE FROM test"));
+  EXPECT_EQ(0, runCount("FROM test"));
+}
+
+} // namespace
+} // namespace axiom::sql

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.cpp
@@ -46,22 +46,30 @@ std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
     const std::string& connectorId,
     std::function<std::string()> queryIdGenerator,
     PermissionCheck permissionCheck) {
+  return makeRunner(
+      [&]() {
+        testConnector_ =
+            std::make_shared<facebook::axiom::connector::TestConnector>(
+                connectorId);
+        connector::ConnectorRegistry::global().insert(
+            testConnector_->connectorId(), testConnector_);
+        facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
+            testConnector_->connectorId(), testConnector_->metadata());
+
+        connectorIds_.emplace_back(testConnector_->connectorId());
+
+        return std::make_pair(testConnector_->connectorId(), kDefaultSchema);
+      },
+      std::move(queryIdGenerator),
+      std::move(permissionCheck));
+}
+
+std::unique_ptr<SqlQueryRunner> SqlQueryRunnerTestBase::makeRunner(
+    const std::function<std::pair<std::string, std::string>()>& initConnectors,
+    std::function<std::string()> queryIdGenerator,
+    PermissionCheck permissionCheck) {
   auto runner = std::make_unique<SqlQueryRunner>(
       "test_user", &progressScheduler_, useV2_);
-
-  auto initConnectors = [&]() {
-    testConnector_ =
-        std::make_shared<facebook::axiom::connector::TestConnector>(
-            connectorId);
-    connector::ConnectorRegistry::global().insert(
-        testConnector_->connectorId(), testConnector_);
-    facebook::axiom::connector::ConnectorMetadataRegistry::global().insert(
-        testConnector_->connectorId(), testConnector_->metadata());
-
-    connectorIds_.emplace_back(testConnector_->connectorId());
-
-    return std::make_pair(testConnector_->connectorId(), kDefaultSchema);
-  };
 
   runner->initialize(
       initConnectors, std::move(permissionCheck), std::move(queryIdGenerator));

--- a/axiom/cli/tests/SqlQueryRunnerTestBase.h
+++ b/axiom/cli/tests/SqlQueryRunnerTestBase.h
@@ -29,9 +29,10 @@
 
 namespace axiom::sql {
 
-// Shared fixture for tests that drive queries through a SqlQueryRunner backed
-// by a TestConnector. makeRunner() selects the optimizer, so a derived fixture
-// can parameterize over v1/v2.
+// Shared fixture for tests that drive queries through a SqlQueryRunner. It
+// backs the runner with a TestConnector by default; a derived fixture can pass
+// its own connectors to makeRunner(). makeRunner() selects the optimizer, so a
+// derived fixture can parameterize over v1/v2.
 class SqlQueryRunnerTestBase : public ::testing::Test,
                                public facebook::velox::test::VectorTestBase {
  protected:
@@ -42,7 +43,9 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
   // fixture selects v2 by setting useV2_ before calling this.
   void SetUp() override;
 
-  // Destroys runner_ and unregisters every connector makeRunner() created.
+  // Destroys runner_ and unregisters the connectors makeRunner() registered
+  // itself. Connectors registered by a caller-supplied callback are the
+  // caller's to unregister.
   void TearDown() override;
 
   // Builds a SqlQueryRunner over a freshly created TestConnector registered
@@ -51,6 +54,15 @@ class SqlQueryRunnerTestBase : public ::testing::Test,
   // parameterized fixture sets before calling.
   std::unique_ptr<SqlQueryRunner> makeRunner(
       const std::string& connectorId = "test",
+      std::function<std::string()> queryIdGenerator = {},
+      PermissionCheck permissionCheck = {});
+
+  // Builds a SqlQueryRunner over the connectors 'initConnectors' registers; it
+  // returns the connector id and schema to use by default. The caller
+  // unregisters them. Selects the optimizer per 'useV2_'.
+  std::unique_ptr<SqlQueryRunner> makeRunner(
+      const std::function<std::pair<std::string, std::string>()>&
+          initConnectors,
       std::function<std::string()> queryIdGenerator = {},
       PermissionCheck permissionCheck = {});
 

--- a/axiom/connectors/ConnectorMetadata.h
+++ b/axiom/connectors/ConnectorMetadata.h
@@ -808,7 +808,9 @@ enum class WriteKind {
 
 AXIOM_DECLARE_ENUM_NAME(WriteKind);
 
-using RowsFuture = folly::SemiFuture<int64_t>;
+/// Number of rows a write added or removed. Empty when the connector cannot
+/// count them, e.g. a delete it carries out by dropping partitions.
+using RowsFuture = folly::SemiFuture<std::optional<int64_t>>;
 
 /// Base class for table. This is used for name resolution. A TableLayout is
 /// used for accessing physical organization like partitioning and sort order.
@@ -962,10 +964,13 @@ class ConnectorWriteHandle {
 
   virtual ~ConnectorWriteHandle() = default;
 
+  /// Returns null if the connector carries out the write itself in finishWrite,
+  /// in which case there is no writer and no plan.
   const velox::connector::ConnectorInsertTableHandlePtr& veloxHandle() const {
     return veloxHandle_;
   }
 
+  /// Null whenever 'veloxHandle' is null.
   const velox::RowTypePtr& resultType() const {
     return resultType_;
   }
@@ -979,10 +984,24 @@ class ConnectorWriteHandle {
     return kEmpty;
   }
 
+  /// Returns what the connector will do, for EXPLAIN. A handle with no
+  /// 'veloxHandle' must override this: such a write has no plan, so this is
+  /// the only detail EXPLAIN can show for it.
+  virtual std::string toString() const {
+    VELOX_CHECK_NOT_NULL(
+        veloxHandle_, "A write with no plan must describe itself for EXPLAIN");
+    return "carried out by the Velox writer";
+  }
+
   template <typename T>
   const T* as() const {
     return dynamic_cast<const T*>(this);
   }
+
+ protected:
+  // Creates a handle with no 'veloxHandle', for a write the connector carries
+  // out itself. The derived class must carry the description of the write.
+  ConnectorWriteHandle() = default;
 
  private:
   const velox::connector::ConnectorInsertTableHandlePtr veloxHandle_;
@@ -1242,10 +1261,16 @@ class ConnectorMetadata {
   /// When 'explain' is true, the connector must build and return a valid
   /// ConnectorWriteHandle for plan display, but must not allocate staging
   /// directories or acquire resources that need cleanup.
+  /// @param scanHandle For a delete, the handle of the scan the rows come
+  /// from, carrying the filters the connector absorbed. nullptr for other
+  /// write kinds. Fails if the connector cannot delete the rows the handle
+  /// selects; a returned handle with a null 'veloxHandle' means the connector
+  /// removes them in finishWrite, with nothing to execute.
   virtual ConnectorWriteHandlePtr beginWrite(
       const ConnectorSessionPtr& /*session*/,
       const TablePtr& /*table*/,
       WriteKind /*kind*/,
+      const velox::connector::ConnectorTableHandlePtr& /*scanHandle*/,
       bool /*explain*/) {
     VELOX_UNSUPPORTED();
   }

--- a/axiom/connectors/hive/HiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/HiveConnectorMetadata.cpp
@@ -16,6 +16,7 @@
 
 #include "axiom/connectors/hive/HiveConnectorMetadata.h"
 
+#include <fmt/ranges.h>
 #include <folly/Conv.h>
 #include <algorithm>
 #include <utility>
@@ -382,6 +383,37 @@ void HiveTableLayout::foldNonPartitionFilterStats(
       dataFilters, handle.remainingFilter(), columns(), estimator, stats);
 }
 
+std::string HiveDeleteWriteHandle::toString() const {
+  if (filters_.empty()) {
+    return fmt::format("drop all rows of {}", table_->name().toString());
+  }
+
+  // SubfieldFilters is unordered; sort by column so the description is stable.
+  std::vector<std::pair<std::string_view, const velox::common::Filter*>>
+      byColumn;
+  byColumn.reserve(filters_.size());
+  for (const auto& [subfield, filter] : filters_) {
+    byColumn.emplace_back(subfield.baseName(), filter.get());
+  }
+  std::sort(
+      byColumn.begin(),
+      byColumn.end(),
+      [](const auto& left, const auto& right) {
+        return left.first < right.first;
+      });
+
+  std::vector<std::string> predicates;
+  predicates.reserve(byColumn.size());
+  for (const auto& [column, filter] : byColumn) {
+    predicates.push_back(fmt::format("{} {}", column, filter->toString()));
+  }
+
+  return fmt::format(
+      "drop partitions of {} matching {}",
+      table_->name().toString(),
+      fmt::join(predicates, " AND "));
+}
+
 namespace {
 std::shared_ptr<velox::connector::hive::LocationHandle> makeLocationHandle(
     const std::string& targetDirectory,
@@ -391,21 +423,69 @@ std::shared_ptr<velox::connector::hive::LocationHandle> makeLocationHandle(
       writeDirectory.value_or(targetDirectory),
       velox::connector::hive::LocationHandle::TableType::kNew);
 }
+
+// Returns a handle for removing whole partitions. The partitions are resolved
+// at commit by matching the scan's range filters against partition values, so
+// every pushed-down filter must be a range filter on a partition column.
+// TODO: Support a remaining filter over partition columns alone, which also
+// selects whole partitions but cannot be matched this way.
+velox::common::SubfieldFilters deleteFilters(
+    const HiveTableLayout& layout,
+    const velox::connector::ConnectorTableHandlePtr& scanHandle) {
+  auto hiveScan =
+      std::dynamic_pointer_cast<const velox::connector::hive::HiveTableHandle>(
+          scanHandle);
+  VELOX_USER_CHECK_NOT_NULL(hiveScan, "DELETE requires a scan of the table");
+
+  VELOX_USER_CHECK_NULL(
+      hiveScan->remainingFilter(),
+      "DELETE supports only range filters on partition columns: {}",
+      hiveScan->remainingFilter()->toString());
+
+  folly::F14FastSet<std::string_view> partitionColumns;
+  for (const auto* column : layout.hivePartitionColumns()) {
+    partitionColumns.insert(column->name());
+  }
+
+  velox::common::SubfieldFilters filters;
+  for (const auto& [subfield, filter] : hiveScan->subfieldFilters()) {
+    VELOX_USER_CHECK(
+        partitionColumns.contains(subfield.baseName()),
+        "DELETE supports only filters on partition columns: {}",
+        subfield.baseName());
+    filters.emplace(subfield.clone(), filter->clone());
+  }
+
+  return filters;
+}
+
 } // namespace
+
+ConnectorWriteHandlePtr HiveConnectorMetadata::makeDeleteWriteHandle(
+    const TablePtr& table,
+    velox::common::SubfieldFilters filters) const {
+  return std::make_shared<HiveDeleteWriteHandle>(table, std::move(filters));
+}
 
 ConnectorWriteHandlePtr HiveConnectorMetadata::beginWrite(
     const ConnectorSessionPtr& session,
     const TablePtr& table,
     WriteKind kind,
+    const velox::connector::ConnectorTableHandlePtr& scanHandle,
     bool explain) {
   ensureInitialized();
   VELOX_CHECK(
-      kind == WriteKind::kCreate || kind == WriteKind::kInsert,
-      "Only CREATE/INSERT supported, not {}",
+      kind == WriteKind::kCreate || kind == WriteKind::kInsert ||
+          kind == WriteKind::kDelete,
+      "Only CREATE/INSERT/DELETE supported, not {}",
       WriteKindName::toName(kind));
 
   auto* hiveLayout = dynamic_cast<const HiveTableLayout*>(table->layouts()[0]);
   VELOX_CHECK_NOT_NULL(hiveLayout);
+
+  if (kind == WriteKind::kDelete) {
+    return makeDeleteWriteHandle(table, deleteFilters(*hiveLayout, scanHandle));
+  }
   auto storageFormat = hiveLayout->fileFormat();
 
   const auto& serdeParameters = hiveLayout->serdeParameters();

--- a/axiom/connectors/hive/HiveConnectorMetadata.h
+++ b/axiom/connectors/hive/HiveConnectorMetadata.h
@@ -288,6 +288,31 @@ class HiveWriteOptions {
   static constexpr auto kSerializationNullFormat = "serialization.null.format";
 };
 
+/// Write handle for a delete the connector carries out against partition
+/// metadata, with no writer and no plan. Holds the filters that select the
+/// partitions to remove, all of them on partition columns. The filters are
+/// resolved to a partition list at commit, which can be long and so is not
+/// materialized here.
+class HiveDeleteWriteHandle : public ConnectorWriteHandle {
+ public:
+  HiveDeleteWriteHandle(TablePtr table, velox::common::SubfieldFilters filters)
+      : table_{std::move(table)}, filters_{std::move(filters)} {}
+
+  const TablePtr& table() const {
+    return table_;
+  }
+
+  const velox::common::SubfieldFilters& filters() const {
+    return filters_;
+  }
+
+  std::string toString() const override;
+
+ private:
+  const TablePtr table_;
+  const velox::common::SubfieldFilters filters_;
+};
+
 class HiveConnectorMetadata : public ConnectorMetadata {
  public:
   /// @param includeHiddenColumns is an indicator to include hidden columns in
@@ -304,9 +329,17 @@ class HiveConnectorMetadata : public ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const TablePtr& table,
       WriteKind kind,
+      const velox::connector::ConnectorTableHandlePtr& scanHandle,
       bool explain) override;
 
  protected:
+  // Returns the handle for a delete of the rows 'filters' select, all of them
+  // on partition columns. A connector overrides this to carry its own
+  // description of the delete.
+  virtual ConnectorWriteHandlePtr makeDeleteWriteHandle(
+      const TablePtr& table,
+      velox::common::SubfieldFilters filters) const;
+
   virtual void ensureInitialized() const {}
 
   virtual void validateOptions(

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.cpp
@@ -1277,28 +1277,24 @@ std::string parsePartitionValue(
   return dirName.substr(prefix.size());
 }
 
-// Descends the partition directory tree one level per declared partition
-// column, reading the per-partition '.stats' file at each leaf into
-// 'allPartitionStats'. See loadTableWithWriteTimeStats for the layout contract.
-void collectPartitionStats(
+// Partition key values of one partition, keyed by column name.
+using PartitionKeys = folly::F14FastMap<std::string, std::string>;
+
+// Visits the leaves of the partition directory tree rooted at 'dir', which
+// nests one level per entry in 'partitionColumnNames'. Descends into a
+// directory only if 'accept' passes its level and value, and calls 'onLeaf'
+// with each leaf and the key values along the way. See
+// loadTableWithWriteTimeStats for the layout contract.
+void visitPartitions(
     const std::vector<std::string_view>& partitionColumnNames,
-    LocalTable& table,
-    std::vector<PartitionStats>& allPartitionStats,
     const fs::path& dir,
     size_t level,
-    folly::F14FastMap<std::string, std::string> partitionKeys) {
+    PartitionKeys partitionKeys,
+    const std::function<bool(size_t level, const std::string& value)>& accept,
+    const std::function<void(const fs::path& leaf, PartitionKeys keys)>&
+        onLeaf) {
   if (level == partitionColumnNames.size()) {
-    auto persisted = PersistedStats::read(dir.string());
-    VELOX_USER_CHECK(
-        persisted.has_value(),
-        "Partition directory is missing a .stats file: {}",
-        dir.string());
-    table.incrementNumRows(persisted->numRows);
-    allPartitionStats.push_back(
-        PartitionStats{
-            .partitionKeys = std::move(partitionKeys),
-            .numRows = persisted->numRows,
-            .columnStats = std::move(persisted->columns)});
+    onLeaf(dir, std::move(partitionKeys));
     return;
   }
 
@@ -1307,17 +1303,41 @@ void collectPartitionStats(
     if (!entry.is_directory()) {
       continue;
     }
+    auto value = parsePartitionValue(entry.path(), expectedColumn);
+    if (!accept(level, value)) {
+      continue;
+    }
     auto childKeys = partitionKeys;
-    childKeys.emplace(
-        expectedColumn, parsePartitionValue(entry.path(), expectedColumn));
-    collectPartitionStats(
+    childKeys.emplace(expectedColumn, std::move(value));
+    visitPartitions(
         partitionColumnNames,
-        table,
-        allPartitionStats,
         entry.path(),
         level + 1,
-        std::move(childKeys));
+        std::move(childKeys),
+        accept,
+        onLeaf);
   }
+}
+
+// Reads the '.stats' file every partition directory is required to have.
+PersistedStats readPartitionStats(const fs::path& dir) {
+  auto persisted = PersistedStats::read(dir.string());
+  VELOX_USER_CHECK(
+      persisted.has_value(),
+      "Partition directory is missing a .stats file: {}",
+      dir.string());
+  return std::move(persisted.value());
+}
+
+// Names of the partition columns, outermost directory level first.
+std::vector<std::string_view> partitionColumnNames(
+    const HiveTableLayout& layout) {
+  std::vector<std::string_view> names;
+  names.reserve(layout.hivePartitionColumns().size());
+  for (const auto* column : layout.hivePartitionColumns()) {
+    names.push_back(column->name());
+  }
+  return names;
 }
 
 } // namespace
@@ -1356,18 +1376,21 @@ void LocalHiveConnectorMetadata::loadTableWithWriteTimeStats(
     // directory against the expected column, and read the per-partition
     // '.stats' file at the leaf. Driving the depth from the schema guarantees
     // every partition entry carries a value for every partition key.
-    std::vector<std::string_view> partitionColumnNames;
-    partitionColumnNames.reserve(layout->hivePartitionColumns().size());
-    for (const auto* column : layout->hivePartitionColumns()) {
-      partitionColumnNames.push_back(column->name());
-    }
-    collectPartitionStats(
-        partitionColumnNames,
-        *table,
-        allPartitionStats,
+    visitPartitions(
+        partitionColumnNames(*layout),
         tablePath,
         /*level=*/0,
-        /*partitionKeys=*/{});
+        /*partitionKeys=*/{},
+        [](size_t /*level*/, const std::string& /*value*/) { return true; },
+        [&](const fs::path& leaf, PartitionKeys keys) {
+          auto persisted = readPartitionStats(leaf);
+          table->incrementNumRows(persisted.numRows);
+          allPartitionStats.push_back(
+              PartitionStats{
+                  .partitionKeys = std::move(keys),
+                  .numRows = persisted.numRows,
+                  .columnStats = std::move(persisted.columns)});
+        });
   }
   // Otherwise the table is unpartitioned and has no persisted stats yet (e.g.
   // right after a schema change); there is nothing to load.
@@ -1632,12 +1655,116 @@ TablePtr LocalHiveConnectorMetadata::createTable(
   return table;
 }
 
+namespace {
+
+// Removes the directories between 'dir' and 'root' that removing 'dir' left
+// empty. A partition column the delete did not constrain keeps its directory
+// until the last partition under it is gone.
+void removeEmptyParents(const fs::path& dir, const fs::path& root) {
+  // The loop deletes directories and stops at 'root', so 'dir' must be under
+  // 'root'.
+  const auto relative = dir.lexically_relative(root);
+  VELOX_CHECK(
+      !relative.empty() && *relative.begin() != "..",
+      "Partition directory is outside the table: {}",
+      dir.string());
+  for (auto parent = dir.parent_path(); parent != root;
+       parent = parent.parent_path()) {
+    if (!fs::is_empty(parent)) {
+      return;
+    }
+    fs::remove(parent);
+  }
+}
+
+} // namespace
+
+std::optional<int64_t> LocalHiveConnectorMetadata::removePartitions(
+    const HiveDeleteWriteHandle& handle) {
+  // Held across the removal and the reload, as the other mutating paths do, so
+  // no reader sees the table between the two.
+  std::lock_guard<std::mutex> l(mutex_);
+  const auto& table = *handle.table();
+  const auto* layout =
+      dynamic_cast<const HiveTableLayout*>(table.layouts().at(0));
+  VELOX_CHECK_NOT_NULL(layout);
+  const fs::path path = tablePath(table.name());
+
+  const auto& partitionColumns = layout->hivePartitionColumns();
+  if (partitionColumns.empty()) {
+    // Nothing to filter on, so the delete removes every row. The table
+    // directory and its '.schema' stay; the data files and stats go.
+    auto persisted = PersistedStats::read(path.string());
+
+    // Collected before removing any: removing an entry invalidates an open
+    // directory iterator.
+    const auto schemaFile = schemaPath(path.string());
+    std::vector<fs::path> entries;
+    for (const auto& entry : fs::directory_iterator(path)) {
+      if (entry.path().string() != schemaFile) {
+        entries.push_back(entry.path());
+      }
+    }
+    for (const auto& entry : entries) {
+      fs::remove_all(entry);
+    }
+
+    loadTable(table.name().table, path);
+    // Without stats the removed rows cannot be counted.
+    return persisted.has_value() ? std::optional<int64_t>{persisted->numRows}
+                                 : std::nullopt;
+  }
+
+  // One filter per partition column, in the order the directories nest.
+  // Unconstrained columns keep a null entry, matching every value.
+  std::vector<const velox::common::Filter*> filters(
+      partitionColumns.size(), nullptr);
+  for (const auto& [subfield, filter] : handle.filters()) {
+    for (size_t i = 0; i < partitionColumns.size(); ++i) {
+      if (partitionColumns[i]->name() == subfield.baseName()) {
+        filters[i] = filter.get();
+        break;
+      }
+    }
+  }
+
+  std::vector<fs::path> matchedPartitions;
+  int64_t rows{0};
+  visitPartitions(
+      partitionColumnNames(*layout),
+      path,
+      /*level=*/0,
+      /*partitionKeys=*/{},
+      [&](size_t level, const std::string& value) {
+        const auto* filter = filters[level];
+        return filter == nullptr ||
+            testPartitionValue(
+                   *filter, value, *partitionColumns[level]->type());
+      },
+      [&](const fs::path& leaf, const PartitionKeys& /*keys*/) {
+        rows += readPartitionStats(leaf).numRows;
+        matchedPartitions.push_back(leaf);
+      });
+
+  for (const auto& partition : matchedPartitions) {
+    deleteDirectoryRecursive(partition.string());
+    removeEmptyParents(partition, path);
+  }
+
+  loadTable(table.name().table, path);
+  return rows;
+}
+
 RowsFuture LocalHiveConnectorMetadata::finishWrite(
     const ConnectorSessionPtr& /*session*/,
     const ConnectorWriteHandlePtr& handle,
     const std::vector<velox::RowVectorPtr>& writeResults,
     velox::RowVectorPtr groupingKeys,
     std::vector<std::vector<ColumnStatistics>> groupStats) {
+  if (const auto* deleteHandle = handle->as<HiveDeleteWriteHandle>()) {
+    return removePartitions(*deleteHandle);
+  }
+
   uint64_t rows = 0;
   velox::DecodedVector decoded;
   for (const auto& result : writeResults) {
@@ -1715,6 +1842,12 @@ void LocalHiveConnectorMetadata::reloadTableFromPath(
 velox::ContinueFuture LocalHiveConnectorMetadata::abortWrite(
     const ConnectorSessionPtr& /*session*/,
     const ConnectorWriteHandlePtr& handle) noexcept try {
+  if (handle->as<HiveDeleteWriteHandle>() != nullptr) {
+    // Partitions are removed in finishWrite, so an aborted delete leaves
+    // nothing behind.
+    return {};
+  }
+
   std::lock_guard<std::mutex> l(mutex_);
   auto hiveHandle =
       std::dynamic_pointer_cast<const HiveConnectorWriteHandle>(handle);

--- a/axiom/connectors/hive/LocalHiveConnectorMetadata.h
+++ b/axiom/connectors/hive/LocalHiveConnectorMetadata.h
@@ -395,6 +395,11 @@ class LocalHiveConnectorMetadata : public HiveConnectorMetadata {
 
   std::shared_ptr<LocalTable> findTableLocked(std::string_view name) const;
 
+  // Removes the partitions selected by 'handle's filters and returns the
+  // number of rows they held. Every filter is on a partition column, so either
+  // all rows of a partition match or none do.
+  std::optional<int64_t> removePartitions(const HiveDeleteWriteHandle& handle);
+
   mutable std::mutex mutex_;
   mutable bool initialized_{false};
   std::shared_ptr<velox::memory::MemoryPool> rootPool_;

--- a/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
+++ b/axiom/connectors/hive/tests/LocalHiveConnectorMetadataTest.cpp
@@ -134,8 +134,12 @@ class LocalHiveConnectorMetadataTest
       dwio::common::FileFormat format) {
     std::string outputPath = metadata_->tablePath(table->name());
     auto session = makeSession();
-    auto handle =
-        metadata_->beginWrite(session, table, kind, /*explain=*/false);
+    auto handle = metadata_->beginWrite(
+        session,
+        table,
+        kind,
+        /*scanHandle=*/nullptr,
+        /*explain=*/false);
 
     auto builder = exec::test::PlanBuilder().values({values});
     auto insertHandle = std::make_shared<core::InsertTableHandle>(
@@ -672,7 +676,11 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
       /*ifNotExists=*/false,
       /*explain=*/false);
   auto handle = metadata_->beginWrite(
-      session, staged, WriteKind::kCreate, /*explain=*/false);
+      session,
+      staged,
+      WriteKind::kCreate,
+      /*scanHandle=*/nullptr,
+      /*explain=*/false);
   metadata_->finishWrite(session, handle, /*writeResults=*/{}, nullptr, {})
       .get();
 
@@ -701,12 +709,20 @@ TEST_F(LocalHiveConnectorMetadataTest, createThenInsert) {
 
   VELOX_ASSERT_THROW(
       metadata_->beginWrite(
-          session, created, WriteKind::kUpdate, /*explain=*/false),
-      "Only CREATE/INSERT supported, not UPDATE");
+          session,
+          created,
+          WriteKind::kUpdate,
+          /*scanHandle=*/nullptr,
+          /*explain=*/false),
+      "Only CREATE/INSERT/DELETE supported, not UPDATE");
   VELOX_ASSERT_THROW(
       metadata_->beginWrite(
-          session, created, WriteKind::kDelete, /*explain=*/false),
-      "Only CREATE/INSERT supported, not DELETE");
+          session,
+          created,
+          WriteKind::kDelete,
+          /*scanHandle=*/nullptr,
+          /*explain=*/false),
+      "DELETE requires a scan of the table");
 }
 
 TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
@@ -723,7 +739,11 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
       /*ifNotExists=*/false,
       /*explain=*/false);
   auto handle = metadata_->beginWrite(
-      session, table, WriteKind::kCreate, /*explain=*/false);
+      session,
+      table,
+      WriteKind::kCreate,
+      /*scanHandle=*/nullptr,
+      /*explain=*/false);
   EXPECT_TRUE(std::filesystem::exists(tablePath));
 
   VELOX_ASSERT_THROW(
@@ -746,7 +766,11 @@ TEST_F(LocalHiveConnectorMetadataTest, abortCreateWithRetry) {
       /*ifNotExists=*/false,
       /*explain=*/false);
   handle = metadata_->beginWrite(
-      session, table, WriteKind::kCreate, /*explain=*/false);
+      session,
+      table,
+      WriteKind::kCreate,
+      /*scanHandle=*/nullptr,
+      /*explain=*/false);
   metadata_->finishWrite(session, handle, /*writeResults=*/{}, nullptr, {})
       .get();
   EXPECT_TRUE(std::filesystem::exists(tablePath));

--- a/axiom/connectors/tests/TestConnector.cpp
+++ b/axiom/connectors/tests/TestConnector.cpp
@@ -844,6 +844,7 @@ ConnectorWriteHandlePtr TestConnectorMetadata::beginWrite(
     const ConnectorSessionPtr& /*session*/,
     const TablePtr& table,
     WriteKind /*kind*/,
+    const velox::connector::ConnectorTableHandlePtr& /*scanHandle*/,
     bool /*explain*/) {
   auto insertHandle = std::make_shared<TestInsertTableHandle>(table->name());
   return std::make_shared<ConnectorWriteHandle>(
@@ -873,7 +874,7 @@ RowsFuture TestConnectorMetadata::finishWrite(
       }
     }
   }
-  return folly::makeFuture(rows);
+  return folly::makeSemiFuture(std::optional<int64_t>{rows});
 }
 
 bool TestConnectorMetadata::dropTable(

--- a/axiom/connectors/tests/TestConnector.h
+++ b/axiom/connectors/tests/TestConnector.h
@@ -578,6 +578,7 @@ class TestConnectorMetadata : public ConnectorMetadata {
       const ConnectorSessionPtr& session,
       const TablePtr& table,
       WriteKind kind,
+      const velox::connector::ConnectorTableHandlePtr& scanHandle,
       bool explain) override;
 
   RowsFuture finishWrite(

--- a/axiom/optimizer/MultiFragmentPlan.cpp
+++ b/axiom/optimizer/MultiFragmentPlan.cpp
@@ -327,16 +327,28 @@ AXIOM_DEFINE_ENUM_NAME(FragmentType, fragmentTypeNames);
 
 FinishWrite::FinishWrite(
     std::shared_ptr<connector::ConnectorMetadata> metadata,
+    std::string connectorId,
     connector::ConnectorSessionPtr session,
     connector::ConnectorWriteHandlePtr handle,
     WriteStatsMapping statsMapping)
     : metadata_{std::move(metadata)},
+      connectorId_{std::move(connectorId)},
       session_{std::move(session)},
       handle_{std::move(handle)},
       statsMapping_{std::move(statsMapping)} {
   VELOX_CHECK_NOT_NULL(metadata_);
   VELOX_CHECK_NOT_NULL(session_);
   VELOX_CHECK_NOT_NULL(handle_);
+}
+
+std::string FinishWrite::toString() const {
+  if (handle_ == nullptr) {
+    return "";
+  }
+  return fmt::format(
+      "Metadata write via connector '{}': {}",
+      connectorId_,
+      handle_->toString());
 }
 
 FinishWrite::~FinishWrite() {

--- a/axiom/optimizer/MultiFragmentPlan.h
+++ b/axiom/optimizer/MultiFragmentPlan.h
@@ -89,6 +89,7 @@ class FinishWrite {
 
   FinishWrite(
       std::shared_ptr<connector::ConnectorMetadata> metadata,
+      std::string connectorId,
       connector::ConnectorSessionPtr session,
       connector::ConnectorWriteHandlePtr handle,
       WriteStatsMapping statsMapping = {});
@@ -108,8 +109,13 @@ class FinishWrite {
   /// Aborts the write. Must be called if commit is not called.
   [[nodiscard]] velox::ContinueFuture abort() && noexcept;
 
+  /// Returns a description of the write for EXPLAIN, naming the connector and
+  /// leaving the detail to the handle. Empty if there is no write.
+  std::string toString() const;
+
  private:
   std::shared_ptr<connector::ConnectorMetadata> metadata_;
+  std::string connectorId_;
   connector::ConnectorSessionPtr session_;
   connector::ConnectorWriteHandlePtr handle_;
   WriteStatsMapping statsMapping_;

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -33,6 +33,12 @@ namespace lp = facebook::axiom::logical_plan;
 namespace facebook::axiom::optimizer {
 
 std::string PlanAndStats::toString() const {
+  if (plan->fragments().empty()) {
+    // The connector carries out the write itself, so the handle's description
+    // is all there is to show.
+    return finishWrite.toString();
+  }
+
   return plan->toString(
       true,
       [&](const velox::core::PlanNodeId& planNodeId,
@@ -2247,6 +2253,7 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
       session,
       table.shared_from_this(),
       write.kind(),
+      /*scanHandle=*/nullptr,
       optimizerSession_->options().explain);
 
   auto inputType = ROW(inputNames, inputTypes);
@@ -2282,6 +2289,7 @@ velox::core::PlanNodePtr ToVelox::makeWrite(
           connectorId, handle->veloxHandle());
   finishWrite_ = {
       metadata,
+      connectorId,
       std::move(session),
       std::move(handle),
       statsBuilder.statsMapping()};

--- a/axiom/optimizer/tests/CMakeLists.txt
+++ b/axiom/optimizer/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ add_executable(
   ConnectorSubtreePushdownTest.cpp
   ConnectorPushdownPassTest.cpp
   CsvReadWriteTest.cpp
+  DeleteTest.cpp
   DerivedTablePrinterTest.cpp
   DomainTest.cpp
   ExprMatcherTest.cpp

--- a/axiom/optimizer/tests/DeleteTest.cpp
+++ b/axiom/optimizer/tests/DeleteTest.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "axiom/logical_plan/PlanBuilder.h"
+#include "axiom/optimizer/tests/HiveQueriesTestBase.h"
+#include "velox/common/base/tests/GTestUtils.h"
+
+namespace facebook::axiom::optimizer {
+namespace {
+
+using namespace velox;
+namespace lp = facebook::axiom::logical_plan;
+
+// Deletes against Hive, which removes the rows by dropping whole partitions.
+class DeleteTest : public test::HiveQueriesTestBase {
+ protected:
+  const std::string kDefaultSchema{
+      connector::hive::LocalHiveConnectorMetadata::kDefaultSchema};
+
+  void SetUp() override {
+    test::HiveQueriesTestBase::SetUp();
+    useV2_ = true;
+  }
+
+  static void SetUpTestCase() {
+    test::HiveQueriesTestBase::SetUpTestCase();
+    createTpchTables({velox::tpch::Table::TBL_NATION});
+  }
+
+  lp::LogicalPlanNodePtr parseDelete(std::string_view sql) {
+    auto statement = prestoParser().parse(sql);
+    VELOX_CHECK(statement->isDelete());
+    return statement->as<::axiom::sql::presto::DeleteStatement>()->plan();
+  }
+
+  // Runs 'sql' and returns the number of rows it reports removing.
+  int64_t runDelete(std::string_view sql) {
+    SCOPED_TRACE(sql);
+    return runVelox(parseDelete(sql)).getOnlyResult<int64_t>();
+  }
+
+  // Returns the number of rows selected by 'fromClause', e.g. "FROM test
+  // WHERE pk = 1".
+  int64_t runCount(std::string_view fromClause) {
+    const auto sql = fmt::format("SELECT count(*) {}", fromClause);
+    SCOPED_TRACE(sql);
+    return runVelox(parseSelect(sql)).getOnlyResult<int64_t>();
+  }
+};
+
+// Deletes against one table partitioned by two columns: a predicate on both
+// partition columns, then on one, then none at all. Creating a Hive table is
+// expensive, so these share a table.
+TEST_F(DeleteTest, partitionPredicates) {
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("test");
+  };
+
+  runCtas(
+      "CREATE TABLE test WITH (partitioned_by = ARRAY['pk', 'qk']) AS "
+      "SELECT n_nationkey, n_nationkey % 3 AS pk, n_nationkey % 2 AS qk "
+      "FROM nation");
+
+  // A predicate no partition satisfies removes nothing.
+  EXPECT_EQ(0, runDelete("DELETE FROM test WHERE pk IN (7, 8)"));
+  EXPECT_EQ(25, runCount("FROM test"));
+
+  // Both partition columns: one leaf partition.
+  EXPECT_EQ(4, runDelete("DELETE FROM test WHERE pk = 1 AND qk = 0"));
+  EXPECT_EQ(21, runCount("FROM test"));
+
+  // The outer column alone: every partition remaining under it.
+  EXPECT_EQ(4, runDelete("DELETE FROM test WHERE pk = 1"));
+  EXPECT_EQ(17, runCount("FROM test"));
+  EXPECT_EQ(0, runCount("FROM test WHERE pk = 1"));
+
+  VELOX_ASSERT_USER_THROW(
+      runDelete("DELETE FROM test WHERE n_nationkey = 1"),
+      "DELETE supports only filters on partition columns: n_nationkey");
+
+  // A predicate the connector cannot reduce to a partition filter, even though
+  // it reads only a partition column.
+  VELOX_ASSERT_USER_THROW(
+      runDelete("DELETE FROM test WHERE pk % 2 = 0"),
+      "DELETE supports only range filters on partition columns");
+
+  // Deleting from a table other than the one scanned fails. SQL cannot express
+  // this, so build the plan directly.
+  lp::PlanBuilder::Context context{
+      std::string(velox::exec::test::kHiveConnectorId), kDefaultSchema};
+  VELOX_ASSERT_USER_THROW(
+      runVelox(
+          lp::PlanBuilder(context)
+              .tableScan("nation")
+              .tableDelete("test")
+              .build()),
+      R"(DELETE scans the wrong table: deletes "default"."test", scans "default"."nation")");
+
+  // No predicate: every partition.
+  EXPECT_EQ(17, runDelete("DELETE FROM test"));
+  EXPECT_EQ(0, runCount("FROM test"));
+}
+
+// An unpartitioned table has no partitions to drop, so a delete removes the
+// data files and leaves an empty table rather than dropping it.
+TEST_F(DeleteTest, unpartitionedTable) {
+  SCOPE_EXIT {
+    hiveMetadata().dropTableIfExists("test");
+  };
+
+  runCtas("CREATE TABLE test AS SELECT n_nationkey, n_name FROM nation");
+
+  EXPECT_EQ(25, runDelete("DELETE FROM test"));
+  EXPECT_EQ(0, runCount("FROM test"));
+
+  // With the stats gone there is nothing left to count the removed rows from.
+  EXPECT_TRUE(
+      runVelox(parseDelete("DELETE FROM test")).getOnlyResult().isNull());
+  EXPECT_EQ(0, runCount("FROM test"));
+}
+
+} // namespace
+} // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/HiveQueriesTestBase.cpp
+++ b/axiom/optimizer/tests/HiveQueriesTestBase.cpp
@@ -209,7 +209,11 @@ void HiveQueriesTestBase::createEmptyTable(
       /*explain=*/false);
   VELOX_CHECK_NOT_NULL(table);
   auto handle = hiveMetadata().beginWrite(
-      session, table, connector::WriteKind::kCreate, /*explain=*/false);
+      session,
+      table,
+      connector::WriteKind::kCreate,
+      /*scanHandle=*/nullptr,
+      /*explain=*/false);
   hiveMetadata().finishWrite(session, handle, {}, nullptr, {}).get();
 }
 

--- a/axiom/optimizer/tests/WriteTest.cpp
+++ b/axiom/optimizer/tests/WriteTest.cpp
@@ -107,7 +107,11 @@ class WriteTest : public test::HiveQueriesTestBase,
         /*explain=*/false);
     VELOX_CHECK_NOT_NULL(table);
     auto handle = metadata.beginWrite(
-        session, table, connector::WriteKind::kCreate, /*explain=*/false);
+        session,
+        table,
+        connector::WriteKind::kCreate,
+        /*scanHandle=*/nullptr,
+        /*explain=*/false);
     metadata.finishWrite(session, handle, {}, nullptr, {}).get();
     return table;
   }

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -354,6 +354,12 @@ class Emitter {
       const ColumnVector& outputColumns,
       const std::vector<std::string>& outputNames);
 
+  // Returns 'scan's cached handle, building it into 'storage' if there is none.
+  // The reference is valid for as long as 'storage'. Emitting must not write to
+  // the cache: it is keyed by base table, so caching this scan's handle would
+  // hand it to a later scan of the same table with different filters.
+  const ScanHandle& scanHandle(const Scan& scan, ScanHandle& storage);
+
   velox::core::PlanNodePtr emitScan(const Scan& scan);
   velox::core::PlanNodePtr emitFilter(const Filter& filter);
   velox::core::PlanNodePtr emitProject(const Project& project);
@@ -407,6 +413,11 @@ class Emitter {
   // current fragment, wiring the `InputStage` between them.
   velox::core::PlanNodePtr emitExchange(const Exchange& exchange);
   velox::core::PlanNodePtr emitTableWrite(const TableWrite& tableWrite);
+
+  // Returns the handle of the scan whose rows 'tableWrite' deletes. Fails if
+  // that scan's handle does not describe exactly the rows to remove.
+  velox::connector::ConnectorTableHandlePtr deletedRowsHandle(
+      const TableWrite& tableWrite);
 
   // Builds the producer-side `PartitionedOutput` capping 'sourcePlan' for
   // 'partitioning'. A connector-bucketed partitioning that scales to a single
@@ -602,18 +613,22 @@ void collectInputColumnNames(
   collectInputColumnNamesImpl(expr, names, /*boundNames=*/{});
 }
 
+const ScanHandle& Emitter::scanHandle(const Scan& scan, ScanHandle& storage) {
+  if (const ScanHandle* cached = scanHandles_.find(scan)) {
+    return *cached;
+  }
+  storage = ScanHandle::build(scan, session_, evaluator_);
+  return storage;
+}
+
 velox::core::PlanNodePtr Emitter::emitScan(const Scan& scan) {
   // The read schema is the consumer output columns followed by the filter-only
   // columns, with columnHandles aligned to that order. Consumer columns keep
   // their `outputName` (alias) in the scan's row type; the rename happens
   // inside the scan via `assignments[outputName] = handle`. Filter-only
   // columns keep their schema name.
-  const ScanHandle* cached = scanHandles_.find(scan);
   ScanHandle built;
-  if (cached == nullptr) {
-    built = ScanHandle::build(scan, session_, evaluator_);
-  }
-  const ScanHandle& handle = cached != nullptr ? *cached : built;
+  const ScanHandle& handle = scanHandle(scan, built);
   const ColumnVector& consumerColumns = scan.outputColumns();
   const ColumnVector& filterOnlyColumns = handle.filterOnlyColumns;
   const auto& columnHandles = handle.columnHandles;
@@ -1907,17 +1922,62 @@ velox::core::PlanNodePtr Emitter::emitExchange(const Exchange& exchange) {
   return consumer;
 }
 
+velox::connector::ConnectorTableHandlePtr Emitter::deletedRowsHandle(
+    const TableWrite& tableWrite) {
+  // The scan handle is the only description of the rows to remove, so the
+  // write must sit directly on a scan whose filters the connector took in
+  // full.
+  NodeCP input = tableWrite.input();
+  VELOX_USER_CHECK(
+      input->is(NodeType::kScan),
+      "DELETE requires a scan with an optional filter");
+
+  const auto& scan = *input->as<Scan>();
+  // The connector reads the filters as constraints on the table it is about to
+  // change, so the two must be the same table.
+  VELOX_USER_CHECK(
+      scan.baseTable()->schemaTable->connectorTable == tableWrite.table(),
+      "DELETE scans the wrong table: deletes {}, scans {}",
+      tableWrite.table()->name().toString(),
+      scan.baseTable()->schemaTable->connectorTable->name().toString());
+
+  ScanHandle built;
+  const ScanHandle& handle = scanHandle(scan, built);
+  const auto& rejectedFilters = handle.rejectedFilters;
+  VELOX_USER_CHECK(
+      rejectedFilters.empty(),
+      "Connector cannot apply this WHERE clause for DELETE: {}",
+      rejectedFilters.front()->toString());
+
+  return handle.tableHandle;
+}
+
 velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
   const auto& table = *tableWrite.table();
   auto* layout = table.layouts().front();
   const auto& connectorId = layout->connector()->connectorId();
   auto metadata = connector::ConnectorMetadataRegistry::get(connectorId);
   auto connectorSession = session_.toConnectorSession(connectorId);
+
+  const bool isDelete = tableWrite.kind() == connector::WriteKind::kDelete;
   auto handle = metadata->beginWrite(
       connectorSession,
       table.shared_from_this(),
       tableWrite.kind(),
+      isDelete ? deletedRowsHandle(tableWrite) : nullptr,
       session_.options().explain);
+
+  if (isDelete) {
+    if (handle->veloxHandle() != nullptr) {
+      VELOX_NYI(
+          "Row-level delete is not supported: {}", table.name().toString());
+    }
+
+    VELOX_CHECK(!finishWrite_, "Only one TableWrite per query is supported");
+    finishWrite_ = FinishWrite{
+        metadata, connectorId, std::move(connectorSession), std::move(handle)};
+    return nullptr;
+  }
 
   // Parallelize writers only when the input is already distributed; gathering
   // an already-single-task input would add a redundant exchange.
@@ -2011,6 +2071,7 @@ velox::core::PlanNodePtr Emitter::emitTableWrite(const TableWrite& tableWrite) {
           connectorId, handle->veloxHandle());
   finishWrite_ = FinishWrite{
       metadata,
+      connectorId,
       std::move(connectorSession),
       std::move(handle),
       statsBuilder.statsMapping()};
@@ -2096,6 +2157,12 @@ std::vector<ExecutableFragment> Emitter::emitFragments(
     // every other fragment; otherwise emit the write directly.
     currentFragment_ = &top;
     velox::core::PlanNodePtr writePlan = emit(root);
+    if (writePlan == nullptr) {
+      // The connector carries out the write itself, so there is nothing to
+      // execute.
+      currentFragment_ = nullptr;
+      return std::move(stages_);
+    }
     if (options_.remoteOutput) {
       outputProjection = writePlan;
       top.fragment.planNode =

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1988,9 +1988,13 @@ TableWrite::TableWrite(Key key)
       columnExprs_(std::move(key.columnExprs)) {
   VELOX_CHECK_NOT_NULL(input_);
   VELOX_CHECK_NOT_NULL(table_);
-  VELOX_CHECK(
-      !columnExprs_.empty(), "TableWrite must write at least one column");
-  VELOX_CHECK_EQ(columnExprs_.size(), table_->type()->size());
+  if (kind_ == connector::WriteKind::kDelete) {
+    VELOX_CHECK(columnExprs_.empty(), "Delete writes no columns");
+  } else {
+    VELOX_CHECK(
+        !columnExprs_.empty(), "TableWrite must write at least one column");
+    VELOX_CHECK_EQ(columnExprs_.size(), table_->type()->size());
+  }
 }
 
 size_t TableWrite::KeyHash::operator()(const TableWrite* node) const {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1774,8 +1774,8 @@ class TableWrite : public Node {
     const connector::Table* table;
     /// Write form (INSERT / CTAS / ...).
     connector::WriteKind kind;
-    /// Per-target-column values, non-empty and 1:1 with the table schema
-    /// (`table->type()`).
+    /// Per-target-column values, 1:1 with the table schema (`table->type()`).
+    /// Empty for a delete, which writes no columns.
     ExprVector columnExprs;
   };
 

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -633,10 +633,11 @@ Translated Translator::translateTableWrite(
     const lp::TableWriteNode& tableWrite,
     const LpNameSet& /*required*/) {
   const auto kind = static_cast<connector::WriteKind>(tableWrite.writeKind());
-  if (kind != connector::WriteKind::kInsert &&
-      kind != connector::WriteKind::kCreate) {
+  if (kind != connector::WriteKind::kCreate &&
+      kind != connector::WriteKind::kInsert &&
+      kind != connector::WriteKind::kDelete) {
     VELOX_NYI(
-        "TableWrite supports only INSERT and CREATE, got {}",
+        "TableWrite does not support {}",
         connector::WriteKindName::toName(kind));
   }
 
@@ -663,8 +664,10 @@ Translated Translator::translateTableWrite(
   // expression where the column is written, else the column's schema default.
   const auto& writtenNames = tableWrite.columnNames();
   ExprVector columnExprs;
-  columnExprs.reserve(tableSchema.size());
-  for (uint32_t i = 0; i < tableSchema.size(); ++i) {
+  const uint32_t numColumns =
+      kind == connector::WriteKind::kDelete ? 0 : tableSchema.size();
+  columnExprs.reserve(numColumns);
+  for (uint32_t i = 0; i < numColumns; ++i) {
     const auto& columnName = tableSchema.nameOf(i);
     auto it = std::find(writtenNames.begin(), writtenNames.end(), columnName);
     if (it != writtenNames.end()) {

--- a/axiom/runner/LocalRunner.cpp
+++ b/axiom/runner/LocalRunner.cpp
@@ -396,18 +396,22 @@ folly::coro::AsyncGenerator<velox::RowVectorPtr> LocalRunner::execute() {
   }
 }
 
-folly::coro::Task<int64_t> LocalRunner::co_runWrite() {
+folly::coro::Task<std::optional<int64_t>> LocalRunner::co_runWrite() {
   std::vector<velox::RowVectorPtr> result;
   auto finishWrite = std::move(finishWrite_);
   std::exception_ptr drainError;
-  try {
-    while (auto rows = co_await co_pull()) {
-      result.push_back(std::move(rows));
+  // A write the connector carries out itself has no fragments, so there is
+  // nothing to drain and the commit below is the whole operation.
+  if (!fragments_.empty()) {
+    try {
+      while (auto rows = co_await co_pull()) {
+        result.push_back(std::move(rows));
+      }
+    } catch (const std::exception&) {
+      // Capture and handle after the handler: co_await is illegal inside a
+      // catch handler, and the reap below must be awaited.
+      drainError = std::current_exception();
     }
-  } catch (const std::exception&) {
-    // Capture and handle after the handler: co_await is illegal inside a catch
-    // handler, and the reap below must be awaited.
-    drainError = std::current_exception();
   }
   if (drainError) {
     // The drain failed: cancelTasks() (cancellation) or the task onError
@@ -431,7 +435,7 @@ folly::coro::Task<int64_t> LocalRunner::co_runWrite() {
     std::rethrow_exception(drainError);
   }
 
-  int64_t rows{0};
+  std::optional<int64_t> rows;
   try {
     rows = std::move(finishWrite).commit(result).get();
   } catch (const std::exception&) {
@@ -455,10 +459,14 @@ folly::coro::Task<int64_t> LocalRunner::co_runWrite() {
   co_return rows;
 }
 
-velox::RowVectorPtr LocalRunner::makeWriteResult(int64_t rows) {
+velox::RowVectorPtr LocalRunner::makeWriteResult(std::optional<int64_t> rows) {
   auto child = velox::BaseVector::create<velox::FlatVector<int64_t>>(
       velox::BIGINT(), /*size=*/1, params_.outputPool.get());
-  child->set(0, rows);
+  if (rows.has_value()) {
+    child->set(0, rows.value());
+  } else {
+    child->setNull(0, true);
+  }
 
   return std::make_shared<velox::RowVector>(
       params_.outputPool.get(),

--- a/axiom/runner/LocalRunner.h
+++ b/axiom/runner/LocalRunner.h
@@ -192,10 +192,10 @@ class LocalRunner : public Runner,
   // written. Drives the cancelable pull, so it honors the awaiting scope's
   // cancellation during the produce/drain phase (the commit itself is a
   // point of no return and runs to completion).
-  [[nodiscard]] folly::coro::Task<int64_t> co_runWrite();
+  [[nodiscard]] folly::coro::Task<std::optional<int64_t>> co_runWrite();
 
   // Builds a single-row vector with 'rows' in a "rows" BIGINT column.
-  velox::RowVectorPtr makeWriteResult(int64_t rows);
+  velox::RowVectorPtr makeWriteResult(std::optional<int64_t> rows);
 
   void start();
 


### PR DESCRIPTION
Summary:
X-link: https://github.com/facebookincubator/axel/pull/239


A delete now runs against Hive:

    DELETE FROM t WHERE ds = '2026-01-01'

Hive removes the rows by dropping whole partitions. A delete must therefore select the rows with range filters on the partition columns:

    DELETE supports only filters on partition columns: n_nationkey

The connector decides what a delete means. `beginWrite` now takes the scan's `ConnectorTableHandle`. If it returns a write handle with no Velox insert handle, the connector removes the rows itself in `finishWrite`. There is then nothing to execute: the plan has no fragments and the runner goes straight to the commit.

Explaining a delete describes that operation:

    Metadata write via connector 'hive': drop partitions of "default"."test" matching pk BigintRange: [1, 1] no nulls

Row-level delete is deferred. If a connector returns a write handle with a Velox insert handle, planning fails with `Row-level delete is not supported`. Only the v2 optimizer plans a delete.

Differential Revision: D115660575
