### PR TITLE
feat(optimizer): Plan ranking queries in v2 as well as v1 (#1690)

### DIFF
--- a/axiom/optimizer/DerivedTable.h
+++ b/axiom/optimizer/DerivedTable.h
@@ -204,6 +204,12 @@ struct DerivedTable : public TableObject {
   ExprVector orderKeys;
   OrderTypeVector orderTypes;
 
+  /// True when an ORDER BY was dropped from 'orderKeys' because a Window over
+  /// one partition already emits its rows in that order. A ranking node in that
+  /// Window's place emits each partition greatest-rank first, so whoever puts
+  /// one there has to sort again.
+  bool windowOrderDropped{false};
+
   /// Limit and offset.
   int64_t limit{-1};
   int64_t offset{0};

--- a/axiom/optimizer/Optimization.cpp
+++ b/axiom/optimizer/Optimization.cpp
@@ -17,6 +17,7 @@
 #include "axiom/optimizer/Optimization.h"
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include <utility>
 #include "axiom/connectors/ConnectorMetadataRegistry.h"
 #include "axiom/optimizer/AggregationPlanner.h"
@@ -1702,12 +1703,19 @@ RelationOpPtr makeWindowOp(
           std::move(columns));
     }
 
-    // Use the minimum of DT limit and ranking filter limit.
+    // Use the minimum of DT limit and ranking filter limit. The query returns
+    // rows offset..offset + limit, so a partition must supply that many before
+    // the offset drops any. INT64_MAX is `OFFSET n` with no `LIMIT`, which
+    // bounds no partition.
     auto topNLimit = rankingFilterLimit;
-    if (dt->hasLimit() && !dt->hasOrderBy()) {
+    const int64_t rowsBeforeOffset = dt->limit >= INT64_MAX - dt->offset
+        ? INT64_MAX
+        : dt->limit + dt->offset;
+    if (dt->hasLimit() && !dt->hasOrderBy() &&
+        rowsBeforeOffset <= std::numeric_limits<int32_t>::max()) {
       topNLimit = topNLimit.has_value()
-          ? std::min(*topNLimit, static_cast<int32_t>(dt->limit))
-          : std::optional<int32_t>(dt->limit);
+          ? std::min(*topNLimit, static_cast<int32_t>(rowsBeforeOffset))
+          : std::optional<int32_t>(rowsBeforeOffset);
     }
     if (rankFunction.has_value() && !group.orderKeys.empty() &&
         topNLimit.has_value()) {
@@ -1831,10 +1839,17 @@ bool Optimization::addWindow(
       // needed. row_number never produces ties, so the limit is fully
       // absorbed. rank() and dense_rank() may produce ties, so a Limit is
       // added after TopNRowNumber.
+      // The ranking caps each partition at offset + count, so the offset and
+      // the final count still apply above it. Only a row_number with no offset
+      // needs nothing: its cap is exactly the rows the query keeps.
       limitConsumed = true;
-      addLimitAfterTopN = !isRowNumber(functionName);
+      addLimitAfterTopN = !isRowNumber(functionName) || dt->offset > 0;
     }
   }
+
+  // Order keys of the last group emitted, as columns of its input.
+  ExprVector resortKeys;
+  OrderTypeVector resortTypes;
 
   // Emit Window operators.
   for (size_t groupIndex = 0; groupIndex < groups.size(); ++groupIndex) {
@@ -1858,6 +1873,9 @@ bool Optimization::addWindow(
 
     auto partitionKeys = precompute.toColumns(group.partitionKeys);
     auto orderKeys = precompute.toColumns(group.orderKeys);
+    // A sort restored below reads the same columns this group orders by.
+    resortKeys = orderKeys;
+    resortTypes = group.orderTypes;
     auto planBeforeProject = plan;
     plan = std::move(precompute).maybeProject();
 
@@ -1898,11 +1916,6 @@ bool Optimization::addWindow(
         dt->windowPlan->rankingLimit());
     state.addCost(*plan);
 
-    if (addLimitAfterTopN) {
-      plan = make<Limit>(plan, dt->limit, dt->offset);
-      state.addCost(*plan);
-    }
-
     // Map original window function expressions to their output columns and
     // mark them as placed so that downstreamColumns() is recomputed for the
     // next group.
@@ -1910,6 +1923,29 @@ bool Optimization::addWindow(
       state.addExprToColumn(group.functions[i], group.outputColumns[i]);
       state.place(group.functions[i]);
     }
+  }
+
+  // Only the last group's output reaches the consumer, so these apply once, to
+  // the node the loop ended on.
+  //
+  // An ORDER BY dropped as redundant relied on the group being a Window. A
+  // ranking node in its place emits each partition greatest-rank first, so sort
+  // again — and let that sort apply the limit, since picking rows before
+  // sorting would keep an arbitrary set of any tied ones. Drop the sort if
+  // https://github.com/facebookincubator/velox/issues/18494 makes the two
+  // operators agree on output order.
+  if (dt->windowOrderDropped && plan->is(RelType::kTopNRowNumber)) {
+    plan = make<OrderBy>(
+        plan,
+        std::move(resortKeys),
+        std::move(resortTypes),
+        dt->hasLimit() ? dt->limit : std::numeric_limits<int64_t>::max(),
+        dt->offset);
+    state.addCost(*plan);
+    limitConsumed = dt->hasLimit();
+  } else if (addLimitAfterTopN) {
+    plan = make<Limit>(plan, dt->limit, dt->offset);
+    state.addCost(*plan);
   }
 
   return limitConsumed;

--- a/axiom/optimizer/ToGraph.cpp
+++ b/axiom/optimizer/ToGraph.cpp
@@ -1964,6 +1964,7 @@ void ToGraph::addOrderBy(const lp::SortNode& order) {
   }
 
   if (allWindowsMatch.value_or(false)) {
+    currentDt_->windowOrderDropped = true;
     return;
   }
 

--- a/axiom/optimizer/ToVelox.cpp
+++ b/axiom/optimizer/ToVelox.cpp
@@ -1124,7 +1124,10 @@ velox::core::PlanNodePtr ToVelox::makeOrderBy(
   // An unbounded sort (ORDER BY with no LIMIT) is a full sort; a trailing Limit
   // applies any offset (its no-limit count keeps every remaining row). A
   // bounded sort is a TopN over offset + count.
-  if (isSingle_) {
+  //
+  // An input already gathered onto one task sorts in place; no second fragment
+  // is needed.
+  if (isSingle_ || op.input()->distribution().isGather()) {
     auto input = makeFragment(op.input(), fragment, stages);
 
     if (options_.numDrivers == 1) {

--- a/axiom/optimizer/tests/RankingTest.cpp
+++ b/axiom/optimizer/tests/RankingTest.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/core.h>
 
+#include <limits>
+
 #include "axiom/optimizer/tests/QueryTestBase.h"
 
 namespace facebook::axiom::optimizer {
@@ -23,8 +25,17 @@ namespace {
 
 using namespace velox;
 
-class RankingTest : public test::QueryTestBase {
+// A Limit's count when the query has OFFSET but no LIMIT.
+constexpr int64_t kNoLimit = std::numeric_limits<int64_t>::max();
+
+class RankingTest : public test::QueryTestBase,
+                    public ::testing::WithParamInterface<bool> {
  protected:
+  void SetUp() override {
+    useV2_ = GetParam();
+    test::QueryTestBase::SetUp();
+  }
+
   velox::core::PlanNodePtr toSingleNodePlan(
       std::string_view sql,
       int32_t numDrivers = 1) {
@@ -38,7 +49,7 @@ class RankingTest : public test::QueryTestBase {
   }
 };
 
-TEST_F(RankingTest, rowNumberWithoutOrderBy) {
+TEST_P(RankingTest, rowNumberWithoutOrderBy) {
   // row_number() without ORDER BY uses a specialized RowNumberNode.
   constexpr auto sql = "SELECT n_name, row_number() OVER () as rn FROM nation";
 
@@ -52,7 +63,7 @@ TEST_F(RankingTest, rowNumberWithoutOrderBy) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rowNumberWithPartitionByWithoutOrderBy) {
+TEST_P(RankingTest, rowNumberWithPartitionByWithoutOrderBy) {
   // row_number() with PARTITION BY but no ORDER BY uses RowNumberNode.
   constexpr auto sql =
       "SELECT n_name, row_number() OVER (PARTITION BY n_regionkey) as rn "
@@ -80,7 +91,7 @@ TEST_F(RankingTest, rowNumberWithPartitionByWithoutOrderBy) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rowNumberWithLimit) {
+TEST_P(RankingTest, rowNumberWithLimit) {
   // row_number() without ORDER BY + LIMIT. LIMIT is pushed below RowNumber
   // because the row numbering is non-deterministic.
   constexpr auto sql =
@@ -99,7 +110,7 @@ TEST_F(RankingTest, rowNumberWithLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rowNumberWithPartitionByAndLimit) {
+TEST_P(RankingTest, rowNumberWithPartitionByAndLimit) {
   // LIMIT pushed below RowNumber.
   constexpr auto sql =
       "SELECT n_name, row_number() OVER (PARTITION BY n_regionkey) as rn "
@@ -126,7 +137,7 @@ TEST_F(RankingTest, rowNumberWithPartitionByAndLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rowNumberWithOrderByAndLimit) {
+TEST_P(RankingTest, rowNumberWithOrderByAndLimit) {
   // row_number() with ORDER BY + LIMIT → TopNRowNumber. No partition keys and
   // row_number never produces ties, so the LIMIT is fully absorbed.
   constexpr auto sql =
@@ -146,7 +157,7 @@ TEST_F(RankingTest, rowNumberWithOrderByAndLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rankWithOrderByAndLimit) {
+TEST_P(RankingTest, rankWithOrderByAndLimit) {
   // rank() with ORDER BY + LIMIT → TopNRowNumber with LIMIT on top because
   // rank may produce ties.
   constexpr auto sql =
@@ -170,7 +181,7 @@ TEST_F(RankingTest, rankWithOrderByAndLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rowNumberWithPartitionAndOrderByAndLimit) {
+TEST_P(RankingTest, rowNumberWithPartitionAndOrderByAndLimit) {
   // With partition keys, LIMIT stays on top because per-partition limit differs
   // from global limit.
   constexpr auto sql =
@@ -202,7 +213,7 @@ TEST_F(RankingTest, rowNumberWithPartitionAndOrderByAndLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, multipleWindowFunctionsWithLimitNoOptimization) {
+TEST_P(RankingTest, multipleWindowFunctionsWithLimitNoOptimization) {
   // Multiple window functions in the same group — no ranking optimization.
   constexpr auto sql =
       "SELECT n_name, "
@@ -233,7 +244,7 @@ TEST_F(RankingTest, multipleWindowFunctionsWithLimitNoOptimization) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rankWithoutOrderBy) {
+TEST_P(RankingTest, rankWithoutOrderBy) {
   // rank() without ORDER BY stays as generic Window — only row_number() gets
   // the RowNumber optimization.
   constexpr auto sql =
@@ -262,7 +273,7 @@ TEST_F(RankingTest, rankWithoutOrderBy) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, rankWithLimitWithoutOrderBy) {
+TEST_P(RankingTest, rankWithLimitWithoutOrderBy) {
   // rank() with LIMIT but without ORDER BY — Pattern 2 does NOT apply (only
   // row_number qualifies). LIMIT stays on top.
   constexpr auto sql =
@@ -292,7 +303,7 @@ TEST_F(RankingTest, rankWithLimitWithoutOrderBy) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, orderByWithoutLimit) {
+TEST_P(RankingTest, orderByWithoutLimit) {
   // Ranking function with ORDER BY but no LIMIT stays as generic Window — no
   // TopN optimization without LIMIT.
   for (const auto& func : {"row_number", "rank"}) {
@@ -313,15 +324,16 @@ TEST_F(RankingTest, orderByWithoutLimit) {
   }
 }
 
-TEST_F(RankingTest, redundantQueryOrderBy) {
-  // Query ORDER BY matches window ORDER BY — ORDER BY is redundant, absorbed
-  // into TopNRowNumber.
+TEST_P(RankingTest, redundantQueryOrderBy) {
+  // Query ORDER BY matches the window's. The ranking node caps the rows, but
+  // emits each partition greatest-rank first, so the sort stays above it.
   constexpr auto sql =
       "SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
       "FROM nation ORDER BY n_name LIMIT 10";
 
   auto plan = toSingleNodePlan(sql);
-  auto matcher = matchScan("nation").topNRowNumber({}, {"n_name"}, 10).build();
+  auto matcher =
+      matchScan("nation").topNRowNumber({}, {"n_name"}, 10).topN(10).build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
   auto distributedPlan = toDistributedPlan(sql);
@@ -329,13 +341,114 @@ TEST_F(RankingTest, redundantQueryOrderBy) {
                                 .gather()
                                 .localGather()
                                 .topNRowNumber({}, {"n_name"}, 10)
+                                .topN(10)
+                                .localMerge()
+                                .finalLimit(0, 10)
                                 .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_P(RankingTest, computedPartitionKey) {
+  // A computed PARTITION BY is evaluated once into a column, and the ranking
+  // partitions on that column.
+  constexpr auto sql =
+      "SELECT n_name FROM ("
+      "  SELECT n_name, "
+      "    row_number() OVER (PARTITION BY n_regionkey % 2 ORDER BY n_name) "
+      "      as rn "
+      "  FROM nation"
+      ") WHERE rn = 1";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher =
+      matchScan("nation")
+          .project({"n_name", "n_regionkey", "mod(n_regionkey, 2) as p"})
+          .topNRowNumber({"p"}, {"n_name"}, 1)
+          .project({"n_name"})
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation")
+          .project({"n_name", "n_regionkey", "mod(n_regionkey, 2) as p"})
+          .shuffle({"p"})
+          .localPartition({"p"})
+          .topNRowNumber({"p"}, {"n_name"}, 1)
+          .project({"n_name"})
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_P(RankingTest, rankingWithOffsetAndLimit) {
+  // The query keeps rows 5..9, so the ranking has to produce 9 of them before
+  // the offset drops any.
+  constexpr auto sql =
+      "SELECT n_name, rn FROM ("
+      "  SELECT n_name, row_number() OVER (ORDER BY n_name) as rn "
+      "  FROM nation"
+      ") OFFSET 5 LIMIT 4";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation")
+                     .topNRowNumber({}, {"n_name"}, 9)
+                     .finalLimit(5, 4)
+                     .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+}
+
+TEST_P(RankingTest, rankingWithOffsetAndNoLimit) {
+  // OFFSET without LIMIT bounds no partition, so the ranking keeps every row.
+  constexpr auto sql =
+      "SELECT n_name, n_regionkey, rn FROM ("
+      "  SELECT n_name, n_regionkey, "
+      "    row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name) as rn "
+      "  FROM nation"
+      ") OFFSET 5";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher =
+      matchScan("nation")
+          .window(
+              {"row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
+          .finalLimit(5, kNoLimit)
+          .build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation")
+          .shuffle({"n_regionkey"})
+          .localPartition({"n_regionkey"})
+          .window(
+              {"row_number() OVER (PARTITION BY n_regionkey ORDER BY n_name)"})
+          .gather()
+          .finalLimit(5, kNoLimit)
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
+}
+
+TEST_P(RankingTest, unreadRankColumn) {
+  // Nothing reads the ranking output, so no node numbers the rows.
+  constexpr auto sql =
+      "SELECT n_name FROM ("
+      "  SELECT n_name, row_number() OVER (PARTITION BY n_regionkey) as rn "
+      "  FROM nation"
+      ")";
+
+  auto plan = toSingleNodePlan(sql);
+  auto matcher = matchScan("nation").build();
+  AXIOM_ASSERT_PLAN(plan, matcher);
+
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher = matchScan("nation").gather().build();
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
 // --- Ranking function + filter on output ---
 
-TEST_F(RankingTest, filterOnOutput) {
+TEST_P(RankingTest, filterOnOutput) {
   // Ranking function with ORDER BY + filter on output. The ranking predicate
   // is absorbed as a TopNRowNumber limit.
   for (const auto& func : {"row_number", "rank"}) {
@@ -362,7 +475,7 @@ TEST_F(RankingTest, filterOnOutput) {
   }
 }
 
-TEST_F(RankingTest, filterOnRowNumberWithPartitionKeys) {
+TEST_P(RankingTest, filterOnRowNumberWithPartitionKeys) {
   // row_number() with PARTITION BY + ORDER BY + filter. The ranking predicate
   // is absorbed as a TopNRowNumber limit.
   constexpr auto sql =
@@ -390,7 +503,7 @@ TEST_F(RankingTest, filterOnRowNumberWithPartitionKeys) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnRowNumberWithoutOrderBy) {
+TEST_P(RankingTest, filterOnRowNumberWithoutOrderBy) {
   // row_number() without ORDER BY + filter. The ranking predicate is absorbed
   // as a RowNumber limit.
   constexpr auto sql =
@@ -409,7 +522,7 @@ TEST_F(RankingTest, filterOnRowNumberWithoutOrderBy) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnRowNumberLessThan) {
+TEST_P(RankingTest, filterOnRowNumberLessThan) {
   // rn < 5 is absorbed as a TopNRowNumber limit of 4.
   constexpr auto sql =
       "SELECT * FROM ("
@@ -430,7 +543,7 @@ TEST_F(RankingTest, filterOnRowNumberLessThan) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnRowNumberEquals1) {
+TEST_P(RankingTest, filterOnRowNumberEquals1) {
   // rn = 1 is absorbed as a TopNRowNumber limit of 1.
   constexpr auto sql =
       "SELECT * FROM ("
@@ -451,7 +564,7 @@ TEST_F(RankingTest, filterOnRowNumberEquals1) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnRowNumberGreaterThan) {
+TEST_P(RankingTest, filterOnRowNumberGreaterThan) {
   constexpr auto sql =
       "SELECT count(1) FROM ("
       "  SELECT n_name, row_number() OVER () as rn "
@@ -478,7 +591,7 @@ TEST_F(RankingTest, filterOnRowNumberGreaterThan) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterWithAdditionalPredicates) {
+TEST_P(RankingTest, filterWithAdditionalPredicates) {
   // The ranking predicate (rn <= 5) is absorbed as a TopNRowNumber limit. The
   // non-window predicate (n_regionkey > 2) stays as a filter above because it
   // is not a partition key filter.
@@ -506,7 +619,7 @@ TEST_F(RankingTest, filterWithAdditionalPredicates) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterWithLowerBound) {
+TEST_P(RankingTest, filterWithLowerBound) {
   // The upper bound (rn <= 10) is absorbed as a TopNRowNumber limit. The lower
   // bound (rn >= 3) stays as a filter above.
   constexpr auto sql =
@@ -532,7 +645,7 @@ TEST_F(RankingTest, filterWithLowerBound) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnOutputWithLimit) {
+TEST_P(RankingTest, filterOnOutputWithLimit) {
   // Both a ranking filter (rn <= 5) and a query LIMIT (3) are present.
   // The ranking filter is absorbed by TopNRowNumber. The LIMIT is on the
   // outer query and becomes a separate Limit node above.
@@ -559,7 +672,7 @@ TEST_F(RankingTest, filterOnOutputWithLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnOutputWithLargerLimit) {
+TEST_P(RankingTest, filterOnOutputWithLargerLimit) {
   // Ranking filter (rn <= 3) is tighter than the query LIMIT (10).
   // TopNRowNumber gets the ranking filter limit. The LIMIT 10 stays as a
   // separate node even though TopNRowNumber(limit=3) can never produce more
@@ -590,7 +703,7 @@ TEST_F(RankingTest, filterOnOutputWithLargerLimit) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, filterOnRowNumberWithMultipleWindowFunctions) {
+TEST_P(RankingTest, filterOnRowNumberWithMultipleWindowFunctions) {
   // Ranking predicate with multiple window functions in the same DT.
   // row_number() and count(*) over () share the same DT. The ranking predicate
   // must not be pushed below the window operator; it should become a filter
@@ -620,7 +733,7 @@ TEST_F(RankingTest, filterOnRowNumberWithMultipleWindowFunctions) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, nonWindowFilterWithWindowFunction) {
+TEST_P(RankingTest, nonWindowFilterWithWindowFunction) {
   // A non-window predicate (n_regionkey > 2) must not be pushed below window
   // operators. Window functions compute over the full input; pushing filters
   // below changes their semantics.
@@ -648,7 +761,7 @@ TEST_F(RankingTest, nonWindowFilterWithWindowFunction) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, partitionKeyFilterPushdown) {
+TEST_P(RankingTest, partitionKeyFilterPushdown) {
   // Filter on a partition key of the window function is pushed below the
   // window. This is safe because partitioning is independent per partition.
   constexpr auto sql =
@@ -680,7 +793,7 @@ TEST_F(RankingTest, partitionKeyFilterPushdown) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, nonPartitionKeyFilterStaysAbove) {
+TEST_P(RankingTest, nonPartitionKeyFilterStaysAbove) {
   // Filter on a non-partition-key column stays above the window.
   constexpr auto sql =
       "SELECT * FROM ("
@@ -711,7 +824,7 @@ TEST_F(RankingTest, nonPartitionKeyFilterStaysAbove) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, partitionKeyFilterWithMultipleWindows) {
+TEST_P(RankingTest, partitionKeyFilterWithMultipleWindows) {
   // Filter on a column that is a partition key of every window function is
   // pushed below all window operators.
   //
@@ -756,7 +869,7 @@ TEST_F(RankingTest, partitionKeyFilterWithMultipleWindows) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, partitionKeyFilterPartialMatch) {
+TEST_P(RankingTest, partitionKeyFilterPartialMatch) {
   // Filter on a column that is a partition key of one window function but not
   // another stays above all window operators.
   //
@@ -799,7 +912,7 @@ TEST_F(RankingTest, partitionKeyFilterPartialMatch) {
   AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, denseRankWithRedundantOrderBy) {
+TEST_P(RankingTest, denseRankWithRedundantOrderBy) {
   // dense_rank()/rank() OVER (PARTITION BY a, b ORDER BY a) -- the ORDER BY
   // column is also in PARTITION BY, so within a partition all rows tie at
   // rank 1. The 'rk = 1' predicate matches every row and is dropped; only
@@ -818,9 +931,20 @@ TEST_F(RankingTest, denseRankWithRedundantOrderBy) {
           .project({"n_name"})
           .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
+
+  auto distributedPlan = toDistributedPlan(sql);
+  auto distributedMatcher =
+      matchScan("nation")
+          .shuffle({"n_regionkey", "n_name"})
+          .localPartition({"n_regionkey", "n_name"})
+          .window({"dense_rank() OVER (PARTITION BY n_regionkey, n_name)"})
+          .project({"n_name"})
+          .gather()
+          .build();
+  AXIOM_ASSERT_DISTRIBUTED_PLAN(distributedPlan, distributedMatcher);
 }
 
-TEST_F(RankingTest, projectOnlyRankColumn) {
+TEST_P(RankingTest, projectOnlyRankColumn) {
   // SELECT projects only the ranking column. Verify the final Project
   // narrows the TopNRowNumber output to a single column instead of leaking
   // the partition/order keys.
@@ -838,6 +962,8 @@ TEST_F(RankingTest, projectOnlyRankColumn) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 }
+
+AXIOM_INSTANTIATE_V1_V2(RankingTest);
 
 } // namespace
 } // namespace facebook::axiom::optimizer

--- a/axiom/optimizer/tests/UnionAllTest.cpp
+++ b/axiom/optimizer/tests/UnionAllTest.cpp
@@ -593,9 +593,6 @@ TEST_P(UnionAllTest, orderByOverTwoScans) {
 // the ORDER BY should run in the same kSingle fragment with no remote
 // exchange.
 //
-// TODO: The optimizer always emits a separate kSingle final fragment, even
-// when the union is already kSingle. The OrderBy is split into PARTIAL +
-// LocalMerge + MergeExchange + (no extra OrderBy) — one unnecessary gather.
 TEST_P(UnionAllTest, orderByOverTwoValues) {
   auto logicalPlan = parseSelect(
       "SELECT * FROM (VALUES 1 UNION ALL VALUES 2) ORDER BY 1",
@@ -610,20 +607,13 @@ TEST_P(UnionAllTest, orderByOverTwoValues) {
   }
 
   {
-    // The union is kSingle, so v2 sorts entirely in that fragment. v1 always
-    // splits into a partial sort + merge exchange to a separate kSingle final
-    // fragment -- a known v1 suboptimality (an unnecessary gather) that v2
-    // avoids.
-    auto builder = matchValues()
+    // The union is kSingle, so the sort runs in that fragment: no gather.
+    auto matcher = matchValues()
                        .localPartition(matchValues().project().build())
                        .orderBy({"c0 ASC NULLS LAST"})
-                       .localMerge();
-    if (useV2_) {
-      builder.output(FragmentType::kSingle);
-    } else {
-      builder.shuffleMerge();
-    }
-    auto matcher = builder.build();
+                       .localMerge()
+                       .output(FragmentType::kSingle)
+                       .build();
     AXIOM_ASSERT_DISTRIBUTED_PLAN(planVelox(logicalPlan).plan, matcher);
   }
 }

--- a/axiom/optimizer/tests/WindowTest.cpp
+++ b/axiom/optimizer/tests/WindowTest.cpp
@@ -459,7 +459,8 @@ TEST_F(WindowTest, nonRedundantOrderByWithDifferentKeys) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
-  // No partition keys — gather, then Window + TopN + merge + limit + project.
+  // No partition keys — gather, then Window + TopN + project, all on the one
+  // task the gather already produced.
   auto distributedPlan = toDistributedPlan(sql);
   auto distributedMatcher =
       matchScan("nation")
@@ -468,7 +469,6 @@ TEST_F(WindowTest, nonRedundantOrderByWithDifferentKeys) {
           .window({"sum(n_regionkey) OVER (ORDER BY n_name)"})
           .topN(10)
           .localMerge()
-          .shuffleMerge()
           .finalLimit(0, 10)
           .project()
           .build();
@@ -527,8 +527,8 @@ TEST_F(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
                      .build();
   AXIOM_ASSERT_PLAN(plan, matcher);
 
-  // No partition keys — gather, then two Windows + TopN + merge + limit +
-  // project.
+  // No partition keys — gather, then two Windows + TopN + project, all on the
+  // one task the gather already produced.
   auto distributedPlan = toDistributedPlan(sql);
   auto distributedMatcher =
       matchScan("nation")
@@ -540,7 +540,6 @@ TEST_F(WindowTest, nonRedundantOrderByMultipleWindowsDifferentOrderBy) {
           .window({"avg(n_nationkey) OVER (ORDER BY n_nationkey)"})
           .topN(10)
           .localMerge()
-          .shuffleMerge()
           .finalLimit(0, 10)
           .project()
           .build();

--- a/axiom/optimizer/tests/sql/window.sql
+++ b/axiom/optimizer/tests/sql/window.sql
@@ -90,6 +90,51 @@ SELECT a, b FROM (SELECT a, b, dense_rank() OVER (PARTITION BY a, b ORDER BY a) 
 -- Same as above but with rank().
 SELECT a, b FROM (SELECT a, b, rank() OVER (PARTITION BY a, b ORDER BY a) AS r FROM t) WHERE r = 1
 ----
+-- row_number without ORDER BY: which rows get which numbers is arbitrary, so
+-- the query checks how many rows each partition keeps, not their numbers.
+SELECT a, count(*) AS kept FROM (SELECT a, row_number() OVER (PARTITION BY a) AS rn FROM t) WHERE rn <= 2 GROUP BY a
+----
+-- row_number without PARTITION BY or ORDER BY, bounded by a filter.
+-- count 4
+SELECT rn FROM (SELECT row_number() OVER () AS rn FROM t) WHERE rn <= 4
+----
+-- Computed PARTITION BY: rows are numbered within the value of the expression.
+SELECT a, b FROM (SELECT a, b, row_number() OVER (PARTITION BY a % 2 ORDER BY b) AS rn FROM t) WHERE rn = 1
+----
+-- RANGE frame with a CURRENT ROW bound and no ORDER BY.
+SELECT a, b, sum(b) OVER (PARTITION BY a RANGE BETWEEN CURRENT ROW AND UNBOUNDED FOLLOWING) AS s FROM t
+----
+SELECT a, b, sum(b) OVER (PARTITION BY a RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW) AS s FROM t
+----
+-- Window function with OFFSET and no LIMIT: nothing bounds the partitions, so
+-- every row is numbered and the offset drops an arbitrary 5 of them.
+-- count 10
+SELECT a, b, rn FROM (SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t) OFFSET 5
+----
+-- The window and the query both order by an expression: the rows come back in
+-- that order.
+-- ordered
+SELECT a, b, row_number() OVER (ORDER BY a + b) AS rn FROM t ORDER BY a + b LIMIT 3
+----
+-- rank() with a query ORDER BY matching the window's: ties may exceed the
+-- limit, so the rows kept must still be the first ones in that order.
+-- ordered
+SELECT b, rank() OVER (ORDER BY b) AS r FROM t ORDER BY b LIMIT 3
+----
+-- OFFSET with LIMIT over a ranking: the ranking must keep enough rows per
+-- partition for the offset to skip.
+-- ordered
+SELECT b, row_number() OVER (ORDER BY b) AS rn FROM t ORDER BY b OFFSET 5 LIMIT 4
+----
+-- Query ORDER BY matches the window's ORDER BY over a single partition: the
+-- rows must still come back in that order.
+-- ordered
+SELECT b, row_number() OVER (ORDER BY b) AS rn FROM t ORDER BY b LIMIT 3
+----
+-- rank() with no ORDER BY: every row of a partition ties at rank 1, so the
+-- filter keeps every row.
+SELECT a, b FROM (SELECT a, b, rank() OVER (PARTITION BY a) AS rk FROM t) WHERE rk = 1
+----
 -- Window function combined with ORDER BY and LIMIT.
 -- ordered
 SELECT a, b, row_number() OVER (PARTITION BY a ORDER BY b) AS rn FROM t ORDER BY a, b LIMIT 3

--- a/axiom/optimizer/v2/Builder.h
+++ b/axiom/optimizer/v2/Builder.h
@@ -199,6 +199,8 @@ class Builder {
       return joins_;
     } else if constexpr (std::is_same_v<T, Window>) {
       return windows_;
+    } else if constexpr (std::is_same_v<T, RowNumber>) {
+      return rowNumbers_;
     } else if constexpr (std::is_same_v<T, TopNRowNumber>) {
       return topNRowNumbers_;
     } else if constexpr (std::is_same_v<T, Apply>) {
@@ -245,6 +247,7 @@ class Builder {
   DedupSet<UnionAll> unions_;
   DedupSet<Join> joins_;
   DedupSet<Window> windows_;
+  DedupSet<RowNumber> rowNumbers_;
   DedupSet<TopNRowNumber> topNRowNumbers_;
   DedupSet<Apply> applies_;
   DedupSet<EnforceSingleRow> enforceSingleRows_;

--- a/axiom/optimizer/v2/EmitPass.cpp
+++ b/axiom/optimizer/v2/EmitPass.cpp
@@ -265,6 +265,8 @@ class Emitter {
         return emitValues(*node->as<Values>());
       case NodeType::kWindow:
         return emitWindow(*node->as<Window>());
+      case NodeType::kRowNumber:
+        return emitRowNumber(*node->as<RowNumber>());
       case NodeType::kTopNRowNumber:
         return emitTopNRowNumber(*node->as<TopNRowNumber>());
       case NodeType::kUnnest:
@@ -385,6 +387,7 @@ class Emitter {
   velox::core::PlanNodePtr emitLimit(const Limit& limit);
   velox::core::PlanNodePtr emitValues(const Values& values);
   velox::core::PlanNodePtr emitWindow(const Window& window);
+  velox::core::PlanNodePtr emitRowNumber(const RowNumber& node);
   velox::core::PlanNodePtr emitTopNRowNumber(const TopNRowNumber& node);
   velox::core::PlanNodePtr emitUnnest(const Unnest& unnest);
   velox::core::PlanNodePtr emitUnionAll(const UnionAll& unionNode);
@@ -1330,19 +1333,33 @@ velox::core::PlanNodePtr Emitter::emitTopN(const TopN& topN) {
       topNCount,
       std::numeric_limits<int32_t>::max(),
       "TopN offset + count exceeds the Velox TopNNode count limit");
-  // At numDrivers > 1 each driver keeps its own top rows (a partial top-n); a
-  // gather to one driver then re-applies the top-n across the merged outputs.
+  // At numDrivers > 1 each driver keeps its own top rows (a partial top-n).
+  // Those outputs are already sorted, so an order-preserving merge combines
+  // them and a Limit takes the window — cheaper than sorting them again.
+  //
+  // TODO: skip the split when the input already feeds one driver. Knowing that
+  // takes the emitted plan's local exchanges; the distribution properties here
+  // describe tasks, not drivers.
   if (options_.numDrivers > 1) {
-    input = std::make_shared<velox::core::TopNNode>(
+    velox::core::PlanNodePtr partial = std::make_shared<velox::core::TopNNode>(
         nextId(),
         sortingKeys,
         sortingOrders,
         static_cast<int32_t>(topNCount),
         /*isPartial=*/true,
         std::move(input));
-    input =
-        velox::core::LocalPartitionNode::gather(nextId(), {std::move(input)});
+    return std::make_shared<velox::core::LimitNode>(
+        nextId(),
+        topN.offset(),
+        topN.count(),
+        /*isPartial=*/false,
+        std::make_shared<velox::core::LocalMergeNode>(
+            nextId(),
+            sortingKeys,
+            sortingOrders,
+            std::vector<velox::core::PlanNodePtr>{std::move(partial)}));
   }
+
   velox::core::PlanNodePtr result = std::make_shared<velox::core::TopNNode>(
       nextId(),
       sortingKeys,
@@ -1365,8 +1382,18 @@ velox::core::PlanNodePtr Emitter::emitLimit(const Limit& limit) {
   velox::core::PlanNodePtr input = emit(limit.input());
   // At numDrivers > 1 each driver keeps its own top offset+count rows (a
   // partial limit); a gather to one driver then applies the final offset/count
-  // so the limit is enforced across the task, not per driver.
-  if (options_.numDrivers > 1) {
+  // so the limit is enforced across the task, not per driver. Velox runs an
+  // exact limit single-threaded either way, so the split is worth it only when
+  // it keeps work below the limit parallel — above a gather exchange the limit
+  // is the whole pipeline.
+  const bool readsGatherExchange = limit.input()->is(NodeType::kExchange) &&
+      limit.input()->physicalProperties().globalPartition.is(
+          PartitionKind::kGather);
+  // A per-driver partial that keeps offset + count rows keeps every row when
+  // there is no count, so it would filter nothing.
+  const bool partialReduces =
+      limit.offsetPlusCount() != std::numeric_limits<int64_t>::max();
+  if (options_.numDrivers > 1 && !readsGatherExchange && partialReduces) {
     input = std::make_shared<velox::core::LimitNode>(
         nextId(),
         /*offset=*/0,
@@ -1515,6 +1542,27 @@ velox::core::PlanNodePtr Emitter::emitWindow(const Window& window) {
       std::move(windowColumnNames),
       std::move(windowFunctions),
       /*inputsSorted=*/false,
+      std::move(input));
+}
+
+velox::core::PlanNodePtr Emitter::emitRowNumber(const RowNumber& node) {
+  velox::core::PlanNodePtr input = emit(node.input());
+  auto partitionKeys =
+      toFieldAccessList(node.partitionKeys(), "RowNumber partition key");
+  // At numDrivers > 1 each partition must be complete in one driver:
+  // repartition on the partition keys, or gather when there are none.
+  if (options_.numDrivers > 1) {
+    input = addLocalPartition(std::move(input), partitionKeys);
+  }
+  std::optional<std::string> rowNumberColumnName;
+  if (node.rankColumn() != nullptr) {
+    rowNumberColumnName = node.rankColumn()->outputName();
+  }
+  return std::make_shared<velox::core::RowNumberNode>(
+      nextId(),
+      std::move(partitionKeys),
+      rowNumberColumnName,
+      node.limit(),
       std::move(input));
 }
 

--- a/axiom/optimizer/v2/EstimateProvider.cpp
+++ b/axiom/optimizer/v2/EstimateProvider.cpp
@@ -281,11 +281,55 @@ Estimate EstimateProvider::compute(NodeCP node) {
       return result;
     }
 
+    // A `row_number` ranking keeps at most `limit` rows per partition, so its
+    // output is capped at limit * the number of partitions. `rank` and
+    // `dense_rank` keep every row tied at a rank within the limit, which that
+    // product does not bound.
+    case NodeType::kRowNumber:
+    case NodeType::kTopNRowNumber: {
+      ExprVector partitionKeys;
+      std::optional<int32_t> limit;
+      bool capsPartition = true;
+      if (node->is(NodeType::kRowNumber)) {
+        const auto* rowNumber = node->as<RowNumber>();
+        partitionKeys = rowNumber->partitionKeys();
+        limit = rowNumber->limit();
+      } else {
+        const auto* topN = node->as<TopNRowNumber>();
+        partitionKeys = topN->partitionKeys();
+        limit = topN->limit();
+        capsPartition = topN->rankFunction() ==
+            velox::core::TopNRowNumberNode::RankFunction::kRowNumber;
+      }
+
+      const auto& input = estimate(node->inputs()[0]);
+      Estimate result;
+      result.constraints = input.constraints;
+      result.cardinality = input.cardinality;
+      if (!limit.has_value() || !capsPartition) {
+        return result;
+      }
+
+      std::optional<float> numPartitions{1.0f};
+      for (ExprCP key : partitionKeys) {
+        numPartitions =
+            mul(numPartitions, value(input.constraints, key).cardinality);
+      }
+      // An unknown partition count leaves the input's cardinality as the bound.
+      if (numPartitions.has_value()) {
+        result.cardinality = maxOf(
+            1.0f,
+            minOf(
+                input.cardinality,
+                mul(numPartitions, static_cast<float>(limit.value()))));
+      }
+      return result;
+    }
+
     // Cardinality-neutral operators: pass the input's estimate through.
     case NodeType::kProject:
     case NodeType::kSort:
     case NodeType::kWindow:
-    case NodeType::kTopNRowNumber:
     case NodeType::kGroupId:
     case NodeType::kMarkDistinct:
     case NodeType::kEnforceSingleRow:

--- a/axiom/optimizer/v2/KeyHash.h
+++ b/axiom/optimizer/v2/KeyHash.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <type_traits>
 
 #include "axiom/optimizer/QueryGraph.h"
@@ -33,6 +35,12 @@ size_t hashOne(const T& value);
 // non-template overload during phase-1 name lookup; otherwise the generic
 // `hashOne<Frame>` template hits the catch-all static_assert.
 size_t hashOne(const Frame& frame);
+
+template <typename T>
+inline constexpr bool isOptional = false;
+
+template <typename T>
+inline constexpr bool isOptional<std::optional<T>> = true;
 
 /// Hashes a list of fields by combining `hashOne` of each via `hashMix`.
 template <typename... Args>
@@ -59,6 +67,10 @@ size_t hashOne(const T& value) {
     return static_cast<size_t>(value);
   } else if constexpr (std::is_integral_v<T>) {
     return static_cast<size_t>(value);
+  } else if constexpr (isOptional<T>) {
+    // An absent optional must not collide with any present value, so mix in
+    // whether it is set.
+    return value.has_value() ? velox::bits::hashMix(1, hashOne(*value)) : 0;
   } else if constexpr (requires {
                          value.begin();
                          value.end();

--- a/axiom/optimizer/v2/LimitAndOrderPass.cpp
+++ b/axiom/optimizer/v2/LimitAndOrderPass.cpp
@@ -26,6 +26,18 @@
 namespace facebook::axiom::optimizer::v2 {
 namespace {
 
+// True when 'node' computes a single `row_number` with no ORDER BY, so each
+// row's value is its arbitrary arrival position rather than a function of the
+// other rows in its partition.
+bool isUnorderedRowNumber(const Window* node, const FunctionNames& names) {
+  if (!node->orderKeys().empty() || node->functions().size() != 1) {
+    return false;
+  }
+  const ExprCP call = node->functions()[0].call;
+  return call->is(PlanType::kCallExpr) &&
+      call->as<Call>()->name() == names.rowNumber;
+}
+
 // A count of this value means "no row bound" (a pure OFFSET).
 constexpr int64_t kNoCount = std::numeric_limits<int64_t>::max();
 
@@ -216,13 +228,35 @@ class LimitAndOrderRewriter : public NodeRewriter<LimitContext> {
   // its input's order through: a Sort below it stays observable.
   LIMIT_BARRIER(Unnest, rewriteUnnest, true)
   LIMIT_BARRIER(Join, rewriteJoin, false)
-  LIMIT_BARRIER(Window, rewriteWindow, false)
   LIMIT_BARRIER(Apply, rewriteApply, false)
   LIMIT_BARRIER(EnforceDistinct, rewriteEnforceDistinct, false)
   LIMIT_BARRIER(TopNRowNumber, rewriteTopNRowNumber, false)
   LIMIT_BARRIER(Exchange, rewriteExchange, false)
 
 #undef LIMIT_BARRIER
+
+  // Window: a bound above it counts the rows it emits, which is its input's
+  // rows, but the values its functions compute read the whole partition — so a
+  // bound below would change them. The exception is an unordered `row_number`,
+  // whose value is the arbitrary arrival position: numbering only the rows the
+  // bound keeps is as valid an answer as numbering all of them.
+  NodeCP rewriteWindow(const Window* node, LimitContext& context) override {
+    context.orderPreserved = false;
+    if (isUnorderedRowNumber(node, builder().functionNames())) {
+      return NodeRewriter::rewriteWindow(node, context);
+    }
+    const auto pending = std::exchange(context.pending, std::nullopt);
+    return materialize(pending, NodeRewriter::rewriteWindow(node, context));
+  }
+
+  NodeCP rewriteRowNumber(const RowNumber* /*node*/, LimitContext& /*context*/)
+      override {
+    // Pushdown and prune specializes a Window into a RowNumber, and runs after
+    // this pass. Should that order change, handle a RowNumber the way
+    // `rewriteWindow` handles an unordered row_number: a bound may move below
+    // one that has no limit of its own.
+    VELOX_UNREACHABLE("A RowNumber cannot reach this pass");
+  }
 
   // Project, AssignUniqueId, and MarkDistinct are row-preserving (1:1), so the
   // base rewrites — which thread the pending bound into the input — push the

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -41,6 +41,7 @@ const auto& nodeTypeNames() {
       {NodeType::kUnionAll, "UnionAll"},
       {NodeType::kJoin, "Join"},
       {NodeType::kWindow, "Window"},
+      {NodeType::kRowNumber, "RowNumber"},
       {NodeType::kTopNRowNumber, "TopNRowNumber"},
       {NodeType::kApply, "Apply"},
       {NodeType::kEnforceSingleRow, "EnforceSingleRow"},
@@ -254,6 +255,16 @@ PhysicalProperties passThroughProperties(NodeCP input) {
   return PhysicalProperties{
       .globalPartition = props.globalPartition.dropOrder(),
       .local = props.local,
+      .unique = props.unique};
+}
+
+// Properties of a ranking node: it keeps every surviving row on the task it
+// arrived on and only drops rows, so the input's distribution and uniqueness
+// survive. Its local order does not.
+PhysicalProperties rankedProperties(NodeCP input) {
+  const PhysicalProperties& props = input->physicalProperties();
+  return PhysicalProperties{
+      .globalPartition = props.globalPartition.dropOrder(),
       .unique = props.unique};
 }
 
@@ -1522,8 +1533,67 @@ bool Window::KeyEq::operator()(const Window* node, const Key& key) const {
   return (*this)(key, node);
 }
 
+RowNumber::RowNumber(Key key)
+    : Node(
+          NodeType::kRowNumber,
+          ColumnVector{key.outputColumns},
+          rankedProperties(key.input)),
+      input_(key.input),
+      partitionKeys_(std::move(key.partitionKeys)),
+      limit_(key.limit),
+      rankColumn_(key.rankColumn) {
+  VELOX_CHECK_NOT_NULL(input_);
+  if (limit_.has_value()) {
+    VELOX_CHECK_GT(limit_.value(), 0, "RowNumber limit must be positive");
+  }
+  VELOX_CHECK_EQ(
+      this->outputColumns().size(),
+      input_->outputColumns().size() + (rankColumn_ != nullptr ? 1 : 0));
+}
+
+size_t RowNumber::KeyHash::operator()(const RowNumber* node) const {
+  return hashOf(
+      node->input(),
+      node->partitionKeys(),
+      node->limit(),
+      node->rankColumn(),
+      node->outputColumns());
+}
+
+size_t RowNumber::KeyHash::operator()(const Key& key) const {
+  return hashOf(
+      key.input,
+      key.partitionKeys,
+      key.limit,
+      key.rankColumn,
+      key.outputColumns);
+}
+
+bool RowNumber::KeyEq::operator()(const RowNumber* left, const RowNumber* right)
+    const {
+  return left->input() == right->input() &&
+      left->partitionKeys() == right->partitionKeys() &&
+      left->limit() == right->limit() &&
+      left->rankColumn() == right->rankColumn() &&
+      left->outputColumns() == right->outputColumns();
+}
+
+bool RowNumber::KeyEq::operator()(const Key& key, const RowNumber* node) const {
+  return key.input == node->input() &&
+      key.partitionKeys == node->partitionKeys() &&
+      key.limit == node->limit() && key.rankColumn == node->rankColumn() &&
+      key.outputColumns == node->outputColumns();
+}
+
+bool RowNumber::KeyEq::operator()(const RowNumber* node, const Key& key) const {
+  return (*this)(key, node);
+}
+
 TopNRowNumber::TopNRowNumber(Key key)
-    : Node(NodeType::kTopNRowNumber, ColumnVector{key.outputColumns}, {}),
+    : Node(
+          NodeType::kTopNRowNumber,
+          ColumnVector{key.outputColumns},
+          rankedProperties(key.input)),
       input_(key.input),
       rankFunction_(key.rankFunction),
       partitionKeys_(std::move(key.partitionKeys)),
@@ -2049,6 +2119,7 @@ V2_DEFINE_ACCEPT(Unnest)
 V2_DEFINE_ACCEPT(UnionAll)
 V2_DEFINE_ACCEPT(Join)
 V2_DEFINE_ACCEPT(Window)
+V2_DEFINE_ACCEPT(RowNumber)
 V2_DEFINE_ACCEPT(TopNRowNumber)
 V2_DEFINE_ACCEPT(Apply)
 V2_DEFINE_ACCEPT(EnforceSingleRow)

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -46,6 +46,7 @@ enum class NodeType : uint8_t {
   kUnionAll,
   kJoin,
   kWindow,
+  kRowNumber,
   kTopNRowNumber,
   kApply,
   kEnforceSingleRow,
@@ -468,7 +469,9 @@ class TopN : public Node {
     OrderTypeVector orderTypes;
     /// Number of leading rows to skip; >= 0.
     int64_t offset;
-    /// Maximum number of rows to return; >= 0.
+    /// Maximum number of rows to return; >= 0. A real bound: an `ORDER BY`
+    /// with no `LIMIT` is a `Sort`, so `Limit`'s no-limit sentinel never
+    /// reaches here and `offsetPlusCount()` saturates only on overflow.
     int64_t count;
   };
 
@@ -507,6 +510,14 @@ class TopN : public Node {
 
   int64_t count() const {
     return count_;
+  }
+
+  /// Returns offset + count, saturated at INT64_MAX so a no-limit count does
+  /// not overflow.
+  int64_t offsetPlusCount() const {
+    return count_ >= std::numeric_limits<int64_t>::max() - offset_
+        ? std::numeric_limits<int64_t>::max()
+        : offset_ + count_;
   }
 
   std::span<const NodeCP> inputs() const override {
@@ -1274,6 +1285,74 @@ class Window : public Node {
 };
 
 using WindowCP = const Window*;
+
+/// Numbers the rows of each partition in arrival order, optionally keeping only
+/// the first 'limit' of them. Needs no ordering, so it streams: one counter per
+/// partition key, no per-partition buffer. Computes `row_number` only.
+class RowNumber : public Node {
+ public:
+  struct Key {
+    /// Input node.
+    NodeCP input;
+    /// Partition-by keys; empty for a single global partition.
+    ExprVector partitionKeys;
+    /// Per-partition row cap; > 0 when set, absent for no cap.
+    std::optional<int32_t> limit;
+    /// Column carrying the row number in the output, or null to omit it (the
+    /// output is then just the input columns).
+    ColumnCP rankColumn;
+    /// Output columns: `input`'s columns, plus `rankColumn` when set.
+    ColumnVector outputColumns;
+  };
+
+  /// Transparent hasher for interning `RowNumber`s by identity.
+  struct KeyHash {
+    using is_transparent = void;
+    size_t operator()(const RowNumber* node) const;
+    size_t operator()(const Key& key) const;
+  };
+
+  /// Transparent equality for interning `RowNumber`s by identity.
+  struct KeyEq {
+    using is_transparent = void;
+    bool operator()(const RowNumber* left, const RowNumber* right) const;
+    bool operator()(const Key& key, const RowNumber* node) const;
+    bool operator()(const RowNumber* node, const Key& key) const;
+  };
+
+  explicit RowNumber(Key key);
+
+  NodeCP input() const {
+    return input_;
+  }
+
+  const ExprVector& partitionKeys() const {
+    return partitionKeys_;
+  }
+
+  std::optional<int32_t> limit() const {
+    return limit_;
+  }
+
+  ColumnCP rankColumn() const {
+    return rankColumn_;
+  }
+
+  std::span<const NodeCP> inputs() const override {
+    return {&input_, 1};
+  }
+
+  void accept(const NodeVisitor& visitor, NodeVisitorContext& context)
+      const override;
+
+ private:
+  const NodeCP input_;
+  const ExprVector partitionKeys_;
+  const std::optional<int32_t> limit_;
+  const ColumnCP rankColumn_;
+};
+
+using RowNumberCP = const RowNumber*;
 
 /// Per-partition top-`limit` rows ranked by a ranking function (row_number /
 /// rank / dense_rank). Produced by fusing

--- a/axiom/optimizer/v2/NodeExpressions.h
+++ b/axiom/optimizer/v2/NodeExpressions.h
@@ -143,6 +143,12 @@ void forEachExpressionInNode(NodeCP node, Visit&& visit) {
       }
       break;
     }
+    case NodeType::kRowNumber: {
+      for (ExprCP key : node->as<RowNumber>()->partitionKeys()) {
+        visit(key);
+      }
+      break;
+    }
     case NodeType::kTopNRowNumber: {
       const TopNRowNumber* topN = node->as<TopNRowNumber>();
       for (ExprCP key : topN->partitionKeys()) {

--- a/axiom/optimizer/v2/NodePrinter.cpp
+++ b/axiom/optimizer/v2/NodePrinter.cpp
@@ -249,6 +249,21 @@ class Printer : public NodeVisitor {
     visitInputs(node, ctx);
   }
 
+  void visit(const RowNumber& node, NodeVisitorContext& context)
+      const override {
+    auto& ctx = static_cast<Context&>(context);
+    header(
+        ctx,
+        node,
+        node.limit().has_value() ? fmt::format("[limit {}]", *node.limit())
+                                 : "");
+    if (!node.partitionKeys().empty()) {
+      ctx.out << spaces(ctx.indent + 2)
+              << "partitionKeys: " << formatExprs(node.partitionKeys()) << '\n';
+    }
+    visitInputs(node, ctx);
+  }
+
   void visit(const TopNRowNumber& node, NodeVisitorContext& context)
       const override {
     auto& ctx = static_cast<Context&>(context);

--- a/axiom/optimizer/v2/NodeRewriter.h
+++ b/axiom/optimizer/v2/NodeRewriter.h
@@ -70,6 +70,8 @@ class NodeRewriter {
         return rewriteJoin(node->as<Join>(), context);
       case NodeType::kWindow:
         return rewriteWindow(node->as<Window>(), context);
+      case NodeType::kRowNumber:
+        return rewriteRowNumber(node->as<RowNumber>(), context);
       case NodeType::kTopNRowNumber:
         return rewriteTopNRowNumber(node->as<TopNRowNumber>(), context);
       case NodeType::kApply:
@@ -261,6 +263,19 @@ class NodeRewriter {
          node->partitionKeys(),
          node->orderKeys(),
          node->orderTypes(),
+         node->outputColumns()});
+  }
+
+  virtual NodeCP rewriteRowNumber(const RowNumber* node, TContext& context) {
+    NodeCP newInput = rewrite(node->input(), context);
+    if (newInput == node->input()) {
+      return node;
+    }
+    return builder_.template make<RowNumber>(
+        {newInput,
+         node->partitionKeys(),
+         node->limit(),
+         node->rankColumn(),
          node->outputColumns()});
   }
 

--- a/axiom/optimizer/v2/NodeVisitor.h
+++ b/axiom/optimizer/v2/NodeVisitor.h
@@ -50,6 +50,8 @@ class NodeVisitor {
       const = 0;
   virtual void visit(const Join& node, NodeVisitorContext& context) const = 0;
   virtual void visit(const Window& node, NodeVisitorContext& context) const = 0;
+  virtual void visit(const RowNumber& node, NodeVisitorContext& context)
+      const = 0;
   virtual void visit(const TopNRowNumber& node, NodeVisitorContext& context)
       const = 0;
   virtual void visit(const Apply& node, NodeVisitorContext& context) const = 0;

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -599,6 +599,23 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
          outputFollowingInput(node, input)});
   }
 
+  // Distributes a row numbering: like a window, its input must be partitioned
+  // on the PARTITION BY keys (gather when none) so each partition is numbered
+  // on one task.
+  NodeCP rewriteRowNumber(const RowNumber* node, NoContext& context) override {
+    auto [input, partitionKeys] =
+        ensureCoLocated(rewrite(node->input(), context), node->partitionKeys());
+    if (input == node->input()) {
+      return node;
+    }
+    return builder().make<RowNumber>(
+        {input,
+         partitionKeys,
+         node->limit(),
+         node->rankColumn(),
+         outputFollowingInput(node, input)});
+  }
+
   // Distributes a per-partition top-n (row_number / rank): like a window, its
   // input must be partitioned on the PARTITION BY keys (gather when none).
   NodeCP rewriteTopNRowNumber(const TopNRowNumber* node, NoContext& context)
@@ -677,6 +694,13 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       return builder().make<Limit>({newInput, node->offset(), node->count()});
     }
 
+    // A partial keeps the first offset + count rows of each task; with no
+    // count that is every row, so there is nothing to reduce before the gather.
+    if (node->offsetPlusCount() == std::numeric_limits<int64_t>::max()) {
+      return builder().make<Limit>(
+          {gather(newInput), node->offset(), node->count()});
+    }
+
     NodeCP partial = builder().make<Limit>(
         {newInput, /*offset=*/0, node->offsetPlusCount()});
     return builder().make<Limit>(
@@ -684,8 +708,9 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
   }
 
   // Distributes a bounded ORDER BY (TopN, an ORDER BY + LIMIT): at numWorkers>1
-  // a per-task partial keeps its own top offset+count rows, the gather brings
-  // them to one task, and the full TopN produces the global top there.
+  // a per-task partial keeps its own top offset+count rows, and an
+  // order-preserving merge gather combines those sorted streams, so the one
+  // task only has to drop rows outside offset/count rather than sort again.
   NodeCP rewriteTopN(const TopN* node, NoContext& context) override {
     NodeCP newInput = rewrite(node->input(), context);
     if (numWorkers_ == 1 || isGathered(newInput)) {
@@ -705,11 +730,9 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
          node->orderKeys(),
          node->orderTypes(),
          /*offset=*/0,
-         node->offset() + node->count()});
-    return builder().make<TopN>(
-        {gather(partial),
-         node->orderKeys(),
-         node->orderTypes(),
+         node->offsetPlusCount()});
+    return builder().make<Limit>(
+        {gatherMerge(partial, node->orderKeys(), node->orderTypes()),
          node->offset(),
          node->count()});
   }

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -339,6 +339,10 @@ class Rewriter : public NodeRewriter<> {
   NodeCP rewriteAggregate(const Aggregate* aggregate, NoContext& context)
       override;
   NodeCP rewriteWindow(const Window* window, NoContext& context) override;
+  NodeCP rewriteRowNumber(const RowNumber* rowNumber, NoContext& context)
+      override;
+  NodeCP rewriteTopNRowNumber(const TopNRowNumber* topN, NoContext& context)
+      override;
   NodeCP rewriteSort(const Sort* sort, NoContext& context) override;
   NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
   NodeCP rewriteJoin(const Join* join, NoContext& context) override;
@@ -473,6 +477,64 @@ NodeCP Rewriter::rewriteWindow(const Window* window, NoContext& context) {
        std::move(newPartitionKeys),
        std::move(newOrderKeys),
        window->orderTypes(),
+       std::move(newOutputColumns)});
+}
+
+NodeCP Rewriter::rewriteRowNumber(
+    const RowNumber* rowNumber,
+    NoContext& context) {
+  NodeCP newInput = rewrite(rowNumber->input(), context);
+  PrecomputeProjections precompute{newInput, builder()};
+
+  ExprVector newPartitionKeys;
+  newPartitionKeys.reserve(rowNumber->partitionKeys().size());
+  for (ExprCP key : rowNumber->partitionKeys()) {
+    newPartitionKeys.push_back(precompute.toColumn(key));
+  }
+
+  // A RowNumber emits its input's columns followed by the row number, so
+  // materializing a key extends its output too.
+  const size_t oldPrefixLength = rowNumber->input()->outputColumns().size();
+  newInput = std::move(precompute).node();
+  ColumnVector newOutputColumns = replacePrefix(
+      rowNumber->outputColumns(), oldPrefixLength, newInput->outputColumns());
+  return builder().make<RowNumber>(
+      {newInput,
+       std::move(newPartitionKeys),
+       rowNumber->limit(),
+       rowNumber->rankColumn(),
+       std::move(newOutputColumns)});
+}
+
+NodeCP Rewriter::rewriteTopNRowNumber(
+    const TopNRowNumber* topN,
+    NoContext& context) {
+  NodeCP newInput = rewrite(topN->input(), context);
+  PrecomputeProjections precompute{newInput, builder()};
+
+  ExprVector newPartitionKeys;
+  newPartitionKeys.reserve(topN->partitionKeys().size());
+  for (ExprCP key : topN->partitionKeys()) {
+    newPartitionKeys.push_back(precompute.toColumn(key));
+  }
+  ExprVector newOrderKeys;
+  newOrderKeys.reserve(topN->orderKeys().size());
+  for (ExprCP key : topN->orderKeys()) {
+    newOrderKeys.push_back(precompute.toColumn(key));
+  }
+
+  const size_t oldPrefixLength = topN->input()->outputColumns().size();
+  newInput = std::move(precompute).node();
+  ColumnVector newOutputColumns = replacePrefix(
+      topN->outputColumns(), oldPrefixLength, newInput->outputColumns());
+  return builder().make<TopNRowNumber>(
+      {newInput,
+       topN->rankFunction(),
+       std::move(newPartitionKeys),
+       std::move(newOrderKeys),
+       topN->orderTypes(),
+       topN->limit(),
+       topN->rankColumn(),
        std::move(newOutputColumns)});
 }
 

--- a/axiom/optimizer/v2/PushdownAndPrunePass.cpp
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.cpp
@@ -52,6 +52,12 @@ struct PushdownContext {
   // not refine it, which only blocks (never wrongly enables) fusion.
   PlanObjectSet requiredAbove;
 
+  // Per-partition row cap implied by a `Limit` or `TopN` directly above a
+  // ranking `Window`: it keeps at most `offset + count` rows overall, so no
+  // partition can contribute more than that many. Set only for that immediate
+  // parent-child pair.
+  std::optional<int32_t> rankLimit;
+
   // `Column*`s whose values are guaranteed non-NULL in the current
   // subtree (derived from default-null-behavior equi-keys of an
   // ancestor inner join). Never inserted into the plan.
@@ -444,25 +450,29 @@ FilterTarget joinFilterTarget(
   VELOX_UNREACHABLE();
 }
 
-// A recognized `Filter(rankColumn <op> n)` over a single-ranking-function
-// `Window`, to be fused into a `TopNRowNumber`.
+// A single-ranking-function `Window` that a specialized ranking node can
+// replace, with the per-partition row cap that applies to it.
 struct RankFusion {
-  // The consumed predicate conjunct.
+  // The `rankColumn <op> n` conjunct consumed as the cap, or null when the cap
+  // came from a bound above the Window or there is no cap.
   ExprCP predicate;
   // The window function's output column (the rank value).
   ColumnCP rankColumn;
   velox::core::TopNRowNumberNode::RankFunction rankFunction;
-  int32_t limit;
+  // Per-partition row cap; absent only for an unordered row_number with no
+  // bound.
+  std::optional<int32_t> limit;
 };
 
-// Detects a single ranking function (row_number / rank / dense_rank) bounded by
-// a per-partition row limit, returning the fusion when one of the 'pending'
-// conjuncts bounds the rank column.
+// Returns the specialization for a single ranking function (row_number / rank /
+// dense_rank), taking its cap from a 'pending' conjunct on the rank column or
+// from 'rankLimit'.
 std::optional<RankFusion> detectRankFusion(
     const Window* node,
     const ExprVector& pending,
+    std::optional<int32_t> rankLimit,
     const FunctionNames& names) {
-  if (node->functions().size() != 1 || node->orderKeys().empty()) {
+  if (node->functions().size() != 1) {
     return std::nullopt;
   }
   const ExprCP call = node->functions()[0].call;
@@ -483,6 +493,15 @@ std::optional<RankFusion> detectRankFusion(
 
   const size_t numInputColumns = node->input()->outputColumns().size();
   const ColumnCP rankColumn = node->outputColumns()[numInputColumns];
+
+  // An unordered rank / dense_rank ties every row of a partition at rank 1,
+  // which no specialized node computes.
+  const bool ordered = !node->orderKeys().empty();
+  if (!ordered &&
+      rankFunction !=
+          velox::core::TopNRowNumberNode::RankFunction::kRowNumber) {
+    return std::nullopt;
+  }
 
   for (ExprCP conjunct : pending) {
     if (!conjunct->is(PlanType::kCallExpr)) {
@@ -512,7 +531,75 @@ std::optional<RankFusion> detectRankFusion(
     return RankFusion{
         conjunct, rankColumn, rankFunction, static_cast<int32_t>(limit)};
   }
-  return std::nullopt;
+
+  if (ordered) {
+    // A `Limit` above bounds every partition just as a rank predicate would.
+    if (rankLimit.has_value()) {
+      return RankFusion{
+          /*predicate=*/nullptr, rankColumn, rankFunction, rankLimit};
+    }
+    // An unbounded ordered ranking still has to sort each partition.
+    return std::nullopt;
+  }
+  // An unordered row_number numbers rows as they arrive, so it specializes with
+  // or without a bound.
+  return RankFusion{
+      /*predicate=*/nullptr, rankColumn, rankFunction, /*limit=*/std::nullopt};
+}
+
+// With no ORDER BY every row of a partition ties, so `rank` and `dense_rank`
+// are 1 for every row. Returns that column when 'node' computes such a
+// constant ranking, else null.
+ColumnCP constantRankColumn(const Window* node, const FunctionNames& names) {
+  if (!node->orderKeys().empty() || node->functions().size() != 1) {
+    return nullptr;
+  }
+  const ExprCP call = node->functions()[0].call;
+  if (!call->is(PlanType::kCallExpr)) {
+    return nullptr;
+  }
+  const Name name = call->as<Call>()->name();
+  if (name != names.rank && name != names.denseRank) {
+    return nullptr;
+  }
+  return node->outputColumns()[node->input()->outputColumns().size()];
+}
+
+// True when 'conjunct' compares 'rankColumn' with a literal and holds for a
+// rank of 1 — with the rank constant, the predicate selects every row. Only
+// (column, literal) order is matched: `Builder` canonicalizes a reversible
+// comparison to put the literal second.
+bool holdsAtRankOne(
+    ExprCP conjunct,
+    ColumnCP rankColumn,
+    const FunctionNames& names) {
+  if (!conjunct->is(PlanType::kCallExpr)) {
+    return false;
+  }
+  const Call* comparison = conjunct->as<Call>();
+  if (comparison->args().size() != 2 || comparison->args()[0] != rankColumn ||
+      !comparison->args()[1]->is(PlanType::kLiteralExpr)) {
+    return false;
+  }
+  const int64_t bound =
+      integerValue(&comparison->args()[1]->as<Literal>()->literal());
+  const Name name = comparison->name();
+  if (name == names.equality) {
+    return bound == 1;
+  }
+  if (name == names.lt) {
+    return 1 < bound;
+  }
+  if (name == names.lte) {
+    return 1 <= bound;
+  }
+  if (name == names.gt) {
+    return 1 > bound;
+  }
+  if (name == names.gte) {
+    return 1 >= bound;
+  }
+  return false;
 }
 
 // Top-down filter pushdown visitor. Every node kind is overridden
@@ -1001,8 +1088,30 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
   // Internal nodes — recurse with empty pending via `blockAt`:
   NodeCP rewriteLimit(const Limit* node, PushdownContext& context) override {
-    return blockAt(context, [&](PushdownContext& empty) {
-      return NodeRewriter::rewriteLimit(node, empty);
+    return blockAt(context, [&](PushdownContext& empty) -> NodeCP {
+      const int64_t cap = node->offsetPlusCount();
+      if (node->input()->is(NodeType::kWindow) &&
+          cap <= std::numeric_limits<int32_t>::max()) {
+        empty.rankLimit = static_cast<int32_t>(cap);
+      }
+      NodeCP newInput = rewrite(node->input(), empty);
+
+      // A row_number over one partition, capped at the same count, already
+      // emits exactly the rows this limit would keep.
+      if (node->offset() == 0 && newInput->is(NodeType::kTopNRowNumber)) {
+        const auto* ranking = newInput->as<TopNRowNumber>();
+        if (ranking->partitionKeys().empty() &&
+            ranking->limit() == node->count() &&
+            ranking->rankFunction() ==
+                velox::core::TopNRowNumberNode::RankFunction::kRowNumber) {
+          return newInput;
+        }
+      }
+
+      if (newInput == node->input()) {
+        return static_cast<NodeCP>(node);
+      }
+      return builder().make<Limit>({newInput, node->offset(), node->count()});
     });
   }
 
@@ -1022,10 +1131,38 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   // TopN: a filter barrier like Limit (its bound depends on the row set), and
   // its order keys must survive in the child like Sort.
   NodeCP rewriteTopN(const TopN* node, PushdownContext& context) override {
-    return blockAt(context, [&](PushdownContext& empty) {
+    return blockAt(context, [&](PushdownContext& empty) -> NodeCP {
       empty.required.unionColumns(node->orderKeys());
       empty.requiredAbove.unionColumns(node->orderKeys());
-      return NodeRewriter::rewriteTopN(node, empty);
+
+      // Sorting by what the window below ranks on means a row past rank
+      // 'offset + count' in its partition has that many rows before it here
+      // too, so it cannot survive this TopN: the window can cap partitions
+      // there.
+      const int64_t cap = node->offsetPlusCount();
+      const bool ordersAgree = node->input()->is(NodeType::kWindow) &&
+          node->orderKeys() == node->input()->as<Window>()->orderKeys() &&
+          node->orderTypes() == node->input()->as<Window>()->orderTypes();
+      if (ordersAgree && cap <= std::numeric_limits<int32_t>::max()) {
+        empty.rankLimit = static_cast<int32_t>(cap);
+      }
+
+      NodeCP newInput = rewrite(node->input(), empty);
+
+      // The cap only reduces the rows the TopN sees; the TopN itself stays,
+      // because a ranking node emits each partition greatest-rank first rather
+      // than in order-key order. It can go once
+      // https://github.com/facebookincubator/velox/issues/18494 makes a ranking
+      // node's output order match a Window's.
+      if (newInput == node->input()) {
+        return static_cast<NodeCP>(node);
+      }
+      return builder().make<TopN>(
+          {newInput,
+           node->orderKeys(),
+           node->orderTypes(),
+           node->offset(),
+           node->count()});
     });
   }
 
@@ -1209,12 +1346,12 @@ class Pushdown : public NodeRewriter<PushdownContext> {
   // Window: conjuncts whose columns are all direct partition-key
   // columns push below — within a partition those values are
   // constant, so pre/post-filter are equivalent. All others stay
-  // above.
+  // above. A single ranking function then specializes into the cheapest node
+  // that computes it; anything else stays a Window with unread functions
+  // pruned.
   NodeCP rewriteWindow(const Window* node, PushdownContext& context) override {
-    // A `rankColumn <op> n` predicate over a single ranking function fuses the
-    // Window into a TopNRowNumber, consuming that predicate.
-    const std::optional<RankFusion> fusion =
-        detectRankFusion(node, context.pending, builder().functionNames());
+    const std::optional<RankFusion> fusion = detectRankFusion(
+        node, context.pending, context.rankLimit, builder().functionNames());
 
     PlanObjectSet partitionKeyColumns;
     for (ExprCP key : node->partitionKeys()) {
@@ -1224,11 +1361,18 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     }
 
     // Conjuncts referencing only partition keys push below; the rest stay above
-    // (or, for the fused ranking predicate, are consumed).
+    // (or, for a bound the ranking node absorbs, are consumed).
+    const ColumnCP constantRank =
+        constantRankColumn(node, builder().functionNames());
     ExprVector pushable;
     ExprVector blocked;
     for (ExprCP conjunct : context.pending) {
       if (fusion && conjunct == fusion->predicate) {
+        continue;
+      }
+      // A predicate that every row satisfies selects nothing away.
+      if (constantRank != nullptr &&
+          holdsAtRankOne(conjunct, constantRank, builder().functionNames())) {
         continue;
       }
       const auto& columns = conjunct->columns();
@@ -1243,48 +1387,89 @@ class Pushdown : public NodeRewriter<PushdownContext> {
 
     PlanObjectSet outputsKept = context.required;
     outputsKept.unionColumns(blocked);
-    const size_t numInputCols = node->input()->outputColumns().size();
 
     PushdownContext childContext;
     childContext.pending = std::move(pushable);
     childContext.required = context.required;
     childContext.required.unionColumns(node->partitionKeys());
     childContext.required.unionColumns(node->orderKeys());
-    // Window/TopNRowNumber emit every input column; the child must keep
-    // producing them all.
+    // Every ranking node emits all of its input's columns, so the child must
+    // keep producing them.
     childContext.required.unionObjects(node->input()->outputColumns());
     childContext.required.unionColumns(blocked);
     childContext.nonNullColumns = context.nonNullColumns;
 
     if (fusion) {
-      childContext.required.unionColumns(childContext.pending);
-      childContext.requiredAbove = childContext.required;
-      NodeCP newInput = rewrite(node->input(), childContext);
-      // Emit the rank column only when a consumer above still needs it.
-      const ColumnCP rankColumn = outputsKept.contains(fusion->rankColumn)
-          ? fusion->rankColumn
-          : nullptr;
-      ColumnVector newOutputColumns;
-      appendAll(newOutputColumns, newInput->outputColumns());
-      if (rankColumn != nullptr) {
-        newOutputColumns.push_back(rankColumn);
-      }
-      NodeCP topN = builder().make<TopNRowNumber>(
+      return specializeRanking(
+          node, *fusion, childContext, outputsKept, std::move(blocked));
+    }
+    return pruneWindowFunctions(
+        node, childContext, outputsKept, std::move(blocked));
+  }
+
+  // Replaces a single-ranking-function Window with the node that computes it
+  // most cheaply: RowNumber when the rows need no ordering, TopNRowNumber when
+  // an ordered ranking is bounded by a per-partition limit.
+  NodeCP specializeRanking(
+      const Window* node,
+      const RankFusion& fusion,
+      PushdownContext& childContext,
+      const PlanObjectSet& outputsKept,
+      ExprVector blocked) {
+    childContext.required.unionColumns(childContext.pending);
+    childContext.requiredAbove = childContext.required;
+    NodeCP newInput = rewrite(node->input(), childContext);
+
+    // Emit the rank column only when a consumer above still needs it.
+    const ColumnCP rankColumn =
+        outputsKept.contains(fusion.rankColumn) ? fusion.rankColumn : nullptr;
+    ColumnVector newOutputColumns;
+    appendAll(newOutputColumns, newInput->outputColumns());
+    if (rankColumn != nullptr) {
+      newOutputColumns.push_back(rankColumn);
+    }
+
+    // With no rank column to emit and no limit, the node would pass its input
+    // through unchanged.
+    if (node->orderKeys().empty() && rankColumn == nullptr &&
+        !fusion.limit.has_value()) {
+      return maybeWrapFilter(newInput, std::move(blocked));
+    }
+
+    NodeCP ranking;
+    if (node->orderKeys().empty()) {
+      ranking = builder().make<RowNumber>(
           {newInput,
-           fusion->rankFunction,
+           node->partitionKeys(),
+           fusion.limit,
+           rankColumn,
+           std::move(newOutputColumns)});
+    } else {
+      ranking = builder().make<TopNRowNumber>(
+          {newInput,
+           fusion.rankFunction,
            node->partitionKeys(),
            node->orderKeys(),
            node->orderTypes(),
-           fusion->limit,
+           fusion.limit.value(),
            rankColumn,
            std::move(newOutputColumns)});
-      return maybeWrapFilter(topN, std::move(blocked));
     }
+    return maybeWrapFilter(ranking, std::move(blocked));
+  }
+
+  // Keeps the Window, dropping the functions no consumer reads.
+  NodeCP pruneWindowFunctions(
+      const Window* node,
+      PushdownContext& childContext,
+      const PlanObjectSet& outputsKept,
+      ExprVector blocked) {
+    const size_t numInputColumns = node->input()->outputColumns().size();
 
     WindowFunctions survivingFunctions;
     ColumnVector survivingFunctionOutputs;
     for (size_t i = 0; i < node->functions().size(); ++i) {
-      const ColumnCP funcOutput = node->outputColumns()[numInputCols + i];
+      const ColumnCP funcOutput = node->outputColumns()[numInputColumns + i];
       if (outputsKept.contains(funcOutput)) {
         survivingFunctions.push_back(node->functions()[i]);
         survivingFunctionOutputs.push_back(funcOutput);
@@ -1297,8 +1482,14 @@ class Pushdown : public NodeRewriter<PushdownContext> {
     childContext.requiredAbove = childContext.required;
     NodeCP newInput = rewrite(node->input(), childContext);
 
+    // With every function pruned the node computes nothing and emits its
+    // input's columns.
+    if (survivingFunctions.empty()) {
+      return maybeWrapFilter(newInput, std::move(blocked));
+    }
+
     ColumnVector newOutputColumns;
-    newOutputColumns.reserve(numInputCols + survivingFunctions.size());
+    newOutputColumns.reserve(numInputColumns + survivingFunctions.size());
     appendAll(newOutputColumns, newInput->outputColumns());
     appendAll(newOutputColumns, survivingFunctionOutputs);
 

--- a/axiom/optimizer/v2/PushdownAndPrunePass.h
+++ b/axiom/optimizer/v2/PushdownAndPrunePass.h
@@ -47,9 +47,12 @@ namespace facebook::axiom::optimizer::v2 {
 ///    `kLeftSemiProject` join.
 ///  - Window pushes conjuncts that reference only partition keys below the
 ///    window (the rest stay above), prunes window functions no consumer reads,
-///    and fuses a `rankColumn <op> n` bound over a single ranking function
-///    (row_number / rank / dense_rank) into a `TopNRowNumber`, consuming that
-///    predicate.
+///    and specializes a single ranking function (row_number / rank /
+///    dense_rank) into the cheapest node that computes it: an unordered
+///    `row_number` becomes a `RowNumber`, and an ordered ranking becomes a
+///    `TopNRowNumber` when a bound caps each partition. That bound comes from a
+///    `rankColumn <op> n` predicate, which is consumed, or from a `Limit` /
+///    `TopN` above the window, which stays.
 ///  - `Apply` must already be gone: decorrelate removes every `Apply` before
 ///    this pass, so encountering one is a logic error.
 ///

--- a/axiom/optimizer/v2/TranslatePass.cpp
+++ b/axiom/optimizer/v2/TranslatePass.cpp
@@ -1209,6 +1209,17 @@ NodeCP Translator::maybeWrapInWindow(
       auto* call = builder_.makeCall(
           windowName, value, std::move(windowArgs), windowFuncs);
       Frame frame = toFrame(windowExpr->frame(), inputScope);
+      // With no ordering every row of a partition is a peer, so a RANGE bound
+      // at CURRENT ROW reaches the end of the partition in either direction.
+      if (spec.orderKeys.empty() &&
+          frame.type == lp::WindowExpr::WindowType::kRange) {
+        if (frame.startType == lp::WindowExpr::BoundType::kCurrentRow) {
+          frame.startType = lp::WindowExpr::BoundType::kUnboundedPreceding;
+        }
+        if (frame.endType == lp::WindowExpr::BoundType::kCurrentRow) {
+          frame.endType = lp::WindowExpr::BoundType::kUnboundedFollowing;
+        }
+      }
       functions.push_back(
           WindowFunction{call, frame, windowExpr->ignoreNulls()});
 


### PR DESCRIPTION
Summary:

`RankingTest` now runs under both optimizers. Closing the gaps that exposed also fixed wrong results in both.

v2 gains a `RowNumber` node. An unordered `row_number()` needs one counter per partition key and no per-partition buffer, so it maps to Velox's `RowNumberNode` rather than a `Window` that buffers and sorts every partition — the shape behind `WHERE rn = 1` dedup queries. Around it, v2 now folds a `LIMIT` or `TopN` above a ranking window into the node's per-partition cap, drops a rank predicate that is always true because the rank is constant, elides a ranking node that neither numbers nor drops rows, and projects a computed `PARTITION BY` such as `a % 2` into a column, which Velox requires of partition keys.

Two families of wrong results, both in v1 and v2. A query whose ORDER BY matches its window's returned rows reversed: the ORDER BY is dropped as redundant because a `Window` emits each partition sorted, and the `Window` is then replaced by a ranking node that emits greatest-rank first (https://github.com/facebookincubator/velox/issues/18494). The sort is now restored when that replacement happens, and applies the limit so ties are not cut beforehand. Separately, `OFFSET` near a window failed or dropped rows: the no-limit sentinel overflowed the per-partition cap in v2 and truncated to `-1` in v1, and with a `LIMIT` the cap must be `offset + count` with the offset still applied above the node.

Both optimizers also stop re-sorting what they already sorted: a bounded sort merges the runs its partial top-n produced, and neither builds that merge over an input already on one driver. A ranking node's estimated cardinality is capped by its limit, exactly for `row_number` and not for the tie-bearing ranks.

Reviewed By: amitkdutta

Differential Revision: D115749058


