### PR TITLE
fix(optimizer): Allow ORDER BY an expression in v2 (#1694)

### DIFF
--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -484,6 +484,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"nondeterministic">();
   registerQueryFile<"nullif">();
   registerQueryFile<"set">();
+  registerQueryFile<"sort">();
   registerQueryFile<"subfield">();
   registerQueryFile<"subquery">();
   registerQueryFile<"unionAll">();

--- a/axiom/optimizer/tests/sql/limit.sql
+++ b/axiom/optimizer/tests/sql/limit.sql
@@ -22,6 +22,14 @@
 -- ordered
 SELECT a, b FROM t ORDER BY b LIMIT 3
 ----
+-- ORDER BY an expression that is not in the select list, with LIMIT.
+-- ordered
+SELECT * FROM t ORDER BY b + c DESC LIMIT 3
+----
+-- Same, over an input that is already on one task.
+-- ordered
+SELECT * FROM (VALUES (1, 2), (3, 1), (2, 5)) t(a, b) ORDER BY a + b DESC LIMIT 2
+----
 -- count 0
 SELECT a, b FROM t LIMIT 0
 ----

--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -1,0 +1,30 @@
+-- setup_file: common_setup.sql
+
+-- Table t(a BIGINT, b BIGINT, c DOUBLE) with 15 rows across 3 splits:
+--   a |   b |    c
+--  ---+-----+------
+--   1 |  10 |  1.5
+--   2 |  20 |  2.5
+--   3 |  30 |  3.5
+--   1 |  40 |  4.5
+--   2 |  50 |  5.5
+--   3 |  60 |  6.5
+--   1 |  70 |  7.5
+--   2 |  80 |  8.5
+--   3 |  90 |  9.5
+--   1 | 100 | 10.5
+--   2 | 110 | 11.5
+--   3 | 120 | 12.5
+--   1 | 130 | 13.5
+--   2 | 140 | 14.5
+--   3 | 150 | 15.5
+--
+-- ORDER BY queries.
+
+-- ORDER BY an expression that is not in the select list.
+-- ordered
+SELECT * FROM t ORDER BY b + c DESC
+----
+-- ORDER BY an expression, descending on one key and ascending on another.
+-- ordered
+SELECT * FROM t ORDER BY a * -1 DESC, b + c ASC

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1997,15 +1997,20 @@ Exchange::Exchange(Key key)
       partitioning_(std::move(key.partitioning)) {
   VELOX_CHECK_NOT_NULL(input_);
 
-  // A partition key must be a column the input produces: whoever places the
-  // shuffle materializes an expression key first, so the value is computed
-  // once and the consumer above reads that same column.
-  for (ExprCP partitionKey : partitioning_.keys) {
-    VELOX_CHECK(
-        partitionKey->is(PlanType::kColumnExpr),
-        "Exchange partitioning key must be a column: {}",
-        partitionKey->toString());
-  }
+  // A partition or merge-order key must be a column the input produces:
+  // whoever places the shuffle materializes an expression key first, so the
+  // value is computed once and the consumer above reads that same column.
+  const auto checkColumns = [](const ExprVector& keys, std::string_view role) {
+    for (ExprCP key : keys) {
+      VELOX_CHECK(
+          key->is(PlanType::kColumnExpr),
+          "Exchange {} must be a column: {}",
+          role,
+          key->toString());
+    }
+  };
+  checkColumns(partitioning_.keys, "partitioning key");
+  checkColumns(partitioning_.orderKeys, "merge order key");
 }
 
 size_t Exchange::KeyHash::operator()(const Exchange* node) const {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1792,6 +1792,11 @@ using EnforceDistinctCP = const EnforceDistinct*;
 /// partitioning via a shuffle, whereas other nodes derive theirs from their
 /// input. The distributed memo places it when a consumer needs a partitioning
 /// the input lacks.
+///
+/// Invariants:
+///   - `input` is non-null.
+///   - Every key in `partitioning.keys` is a `Column`.
+///   - Every key in `partitioning.orderKeys` is a `Column`.
 class Exchange : public Node {
  public:
   struct Key {

--- a/axiom/optimizer/v2/PhysicalProperties.h
+++ b/axiom/optimizer/v2/PhysicalProperties.h
@@ -82,8 +82,12 @@ AXIOM_DECLARE_ENUM_NAME(PartitionKind);
 ///   - `orderKeys` / `orderTypes` are non-empty only for an order-preserving
 ///     `kGather` (see `globalGatherMerge`).
 ///   - `partitionType` is null for standard Velox hash partitioning.
-///   - `keys` are expressions (not just columns) to match the partition
-///     function's input.
+///   - As a requirement a consumer states, `keys` and `orderKeys` may be any
+///     expression. On the `Partitioning` an `Exchange` carries they must be
+///     columns the exchange's input produces: whoever places the shuffle
+///     materializes an expression key first, so the value is computed once
+///     below the shuffle and read as a column above it (see
+///     `Builder::materializeKeys`).
 struct Partitioning {
   PartitionKind kind{PartitionKind::kUnspecified};
 

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -651,9 +651,11 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       return builder().make<Sort>(
           {input, node->orderKeys(), node->orderTypes()});
     }
+    auto [sortInput, orderKeys] =
+        builder().materializeKeys(input, node->orderKeys());
     NodeCP partialSort =
-        builder().make<Sort>({input, node->orderKeys(), node->orderTypes()});
-    return gatherMerge(partialSort, node->orderKeys(), node->orderTypes());
+        builder().make<Sort>({sortInput, orderKeys, node->orderTypes()});
+    return gatherMerge(partialSort, orderKeys, node->orderTypes());
   }
 
   // Distributes an EnforceSingleRow (scalar-subquery single-row assertion): it
@@ -725,14 +727,16 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
            node->count()});
     }
 
+    auto [topNInput, orderKeys] =
+        builder().materializeKeys(newInput, node->orderKeys());
     NodeCP partial = builder().make<TopN>(
-        {newInput,
-         node->orderKeys(),
+        {topNInput,
+         orderKeys,
          node->orderTypes(),
          /*offset=*/0,
          node->offsetPlusCount()});
     return builder().make<Limit>(
-        {gatherMerge(partial, node->orderKeys(), node->orderTypes()),
+        {gatherMerge(partial, orderKeys, node->orderTypes()),
          node->offset(),
          node->count()});
   }

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -74,7 +74,7 @@ ColumnVector replacePrefix(
 class PrecomputeProjections {
  public:
   // When `projectAllInputs` is true (the default, for pass-through consumers
-  // like Window/Sort/Exchange), the project preserves every input column
+  // like Window/Sort/TopN), the project preserves every input column
   // alongside the lifted ones. When false (for narrowing consumers like
   // Aggregate/Unnest/Join), the project outputs only the columns passed to
   // `toColumn` — so an input column kept solely to feed a lifted expression is
@@ -329,8 +329,8 @@ void JoinFilterRewriter::keep(ColumnCP column) {
   }
 }
 
-// Lifts compound expressions at restricted positions of Aggregate /
-// Window / Sort / Unnest into a Project below the consumer.
+// Lifts compound expressions at restricted operator positions into a Project
+// below the consumer.
 class Rewriter : public NodeRewriter<> {
  public:
   using NodeRewriter::NodeRewriter;
@@ -344,6 +344,7 @@ class Rewriter : public NodeRewriter<> {
   NodeCP rewriteTopNRowNumber(const TopNRowNumber* topN, NoContext& context)
       override;
   NodeCP rewriteSort(const Sort* sort, NoContext& context) override;
+  NodeCP rewriteTopN(const TopN* topN, NoContext& context) override;
   NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
   NodeCP rewriteJoin(const Join* join, NoContext& context) override;
   NodeCP rewriteUnionAll(const UnionAll* unionAll, NoContext& context) override;
@@ -550,6 +551,22 @@ NodeCP Rewriter::rewriteSort(const Sort* sort, NoContext& context) {
       {std::move(precompute).node(),
        std::move(newOrderKeys),
        sort->orderTypes()});
+}
+
+NodeCP Rewriter::rewriteTopN(const TopN* topN, NoContext& context) {
+  NodeCP newInput = rewrite(topN->input(), context);
+  PrecomputeProjections precompute{newInput, builder()};
+  ExprVector newOrderKeys;
+  newOrderKeys.reserve(topN->orderKeys().size());
+  for (ExprCP key : topN->orderKeys()) {
+    newOrderKeys.push_back(precompute.toColumn(key));
+  }
+  return builder().make<TopN>(
+      {std::move(precompute).node(),
+       std::move(newOrderKeys),
+       topN->orderTypes(),
+       topN->offset(),
+       topN->count()});
 }
 
 NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.h
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.h
@@ -31,13 +31,17 @@ class PrecomputeProjectionsPass {
   /// Most positions are moved because Velox demands a `FieldAccessTypedExpr`
   /// (or, where allowed, a constant) there:
   ///   - Aggregate: grouping keys, aggregate args, FILTER mask, ORDER BY keys
-  ///   - Window:    partition keys, order keys, function args
-  ///   - Sort:      order keys
-  ///   - Unnest:    unnest expressions
-  ///   - Join:      join keys
+  ///   - Window: partition keys, order keys, function args, frame bounds
+  ///   - Sort, TopN: order keys
+  ///   - RowNumber: partition keys
+  ///   - TopNRowNumber: partition keys, order keys
+  ///   - Unnest: unnest expressions
+  ///   - Join: join keys
   ///
-  /// A join filter is the one exception: Velox accepts any expression there,
-  /// so the move is an optimization rather than a requirement.
+  /// A join filter is one exception: Velox accepts any expression there, so
+  /// the move is an optimization rather than a requirement. A `UnionAll` is
+  /// another: its legs are aligned to the union's output columns because
+  /// Velox's `LocalPartition` requires one shared output `RowType`.
   ///
   /// A join with no equi keys evaluates its filter once for every pair of
   /// input rows. A subexpression of the filter that reads only one side has


### PR DESCRIPTION
Summary:

A query that sorts on an expression it does not select failed under the v2 optimizer:

    SELECT * FROM t ORDER BY b + c DESC LIMIT 3

fails with `TopN key must be a column reference`, or with `Merge exchange key must be a column reference` when the input is spread over more than one worker. Without `LIMIT` only the second failure applies. The Presto parser projects the sort key when the select list is explicit, so only `SELECT *` reaches the optimizer with an expression key.

Velox requires a column reference wherever it sorts. `PrecomputeProjectionsPass` lifts an expression key into a `Project` below its consumer, but had no case for `TopN` — the node `LimitAndOrderPass` forms from a `Sort` and a `Limit`. It handles `TopN` now.

A gather that merges sorted streams took its order keys from the `Sort` or `TopN` below it, before that lift ran, so the expression reached the exchange. The two sites that place such a gather now call `Builder::materializeKeys` first, the same rule the sites that place a hash shuffle already follow, and `Exchange` checks merge keys the way it already checks partition keys.

Reviewed By: amitkdutta

Differential Revision: D115805147
