### PR TITLE
feat(parser): Support '= ANY' and '<> ALL' subqueries (#1696)

### DIFF
--- a/axiom/optimizer/tests/SqlTest.cpp
+++ b/axiom/optimizer/tests/SqlTest.cpp
@@ -484,6 +484,7 @@ int main(int argc, char** argv) {
   registerQueryFile<"nondeterministic">();
   registerQueryFile<"nullif">();
   registerQueryFile<"set">();
+  registerQueryFile<"sort">();
   registerQueryFile<"subfield">();
   registerQueryFile<"subquery">();
   registerQueryFile<"unionAll">();

--- a/axiom/optimizer/tests/sql/limit.sql
+++ b/axiom/optimizer/tests/sql/limit.sql
@@ -22,6 +22,14 @@
 -- ordered
 SELECT a, b FROM t ORDER BY b LIMIT 3
 ----
+-- ORDER BY an expression that is not in the select list, with LIMIT.
+-- ordered
+SELECT * FROM t ORDER BY b + c DESC LIMIT 3
+----
+-- Same, over an input that is already on one task.
+-- ordered
+SELECT * FROM (VALUES (1, 2), (3, 1), (2, 5)) t(a, b) ORDER BY a + b DESC LIMIT 2
+----
 -- count 0
 SELECT a, b FROM t LIMIT 0
 ----

--- a/axiom/optimizer/tests/sql/sort.sql
+++ b/axiom/optimizer/tests/sql/sort.sql
@@ -1,0 +1,30 @@
+-- setup_file: common_setup.sql
+
+-- Table t(a BIGINT, b BIGINT, c DOUBLE) with 15 rows across 3 splits:
+--   a |   b |    c
+--  ---+-----+------
+--   1 |  10 |  1.5
+--   2 |  20 |  2.5
+--   3 |  30 |  3.5
+--   1 |  40 |  4.5
+--   2 |  50 |  5.5
+--   3 |  60 |  6.5
+--   1 |  70 |  7.5
+--   2 |  80 |  8.5
+--   3 |  90 |  9.5
+--   1 | 100 | 10.5
+--   2 | 110 | 11.5
+--   3 | 120 | 12.5
+--   1 | 130 | 13.5
+--   2 | 140 | 14.5
+--   3 | 150 | 15.5
+--
+-- ORDER BY queries.
+
+-- ORDER BY an expression that is not in the select list.
+-- ordered
+SELECT * FROM t ORDER BY b + c DESC
+----
+-- ORDER BY an expression, descending on one key and ascending on another.
+-- ordered
+SELECT * FROM t ORDER BY a * -1 DESC, b + c ASC

--- a/axiom/optimizer/tests/sql/subquery.sql
+++ b/axiom/optimizer/tests/sql/subquery.sql
@@ -286,6 +286,15 @@ SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c = t.c) FROM t
 -- Correlated IN subquery with mixed equality and non-equality correlation.
 SELECT t.a IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
 ----
+-- '= ANY' means IN.
+SELECT t.a = ANY (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
+-- '= SOME' means IN.
+SELECT t.a = SOME (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
+-- '<> ALL' means NOT IN.
+SELECT t.a <> ALL (SELECT t2.a FROM t t2 WHERE t2.b = t.b) FROM t
+----
 -- Correlated NOT IN subquery with mixed equality and non-equality correlation.
 SELECT t.a NOT IN (SELECT t2.a FROM t t2 WHERE t2.b = t.b AND t2.c < t.c) FROM t
 ----

--- a/axiom/optimizer/v2/Node.cpp
+++ b/axiom/optimizer/v2/Node.cpp
@@ -1997,15 +1997,20 @@ Exchange::Exchange(Key key)
       partitioning_(std::move(key.partitioning)) {
   VELOX_CHECK_NOT_NULL(input_);
 
-  // A partition key must be a column the input produces: whoever places the
-  // shuffle materializes an expression key first, so the value is computed
-  // once and the consumer above reads that same column.
-  for (ExprCP partitionKey : partitioning_.keys) {
-    VELOX_CHECK(
-        partitionKey->is(PlanType::kColumnExpr),
-        "Exchange partitioning key must be a column: {}",
-        partitionKey->toString());
-  }
+  // A partition or merge-order key must be a column the input produces:
+  // whoever places the shuffle materializes an expression key first, so the
+  // value is computed once and the consumer above reads that same column.
+  const auto checkColumns = [](const ExprVector& keys, std::string_view role) {
+    for (ExprCP key : keys) {
+      VELOX_CHECK(
+          key->is(PlanType::kColumnExpr),
+          "Exchange {} must be a column: {}",
+          role,
+          key->toString());
+    }
+  };
+  checkColumns(partitioning_.keys, "partitioning key");
+  checkColumns(partitioning_.orderKeys, "merge order key");
 }
 
 size_t Exchange::KeyHash::operator()(const Exchange* node) const {

--- a/axiom/optimizer/v2/Node.h
+++ b/axiom/optimizer/v2/Node.h
@@ -1792,6 +1792,11 @@ using EnforceDistinctCP = const EnforceDistinct*;
 /// partitioning via a shuffle, whereas other nodes derive theirs from their
 /// input. The distributed memo places it when a consumer needs a partitioning
 /// the input lacks.
+///
+/// Invariants:
+///   - `input` is non-null.
+///   - Every key in `partitioning.keys` is a `Column`.
+///   - Every key in `partitioning.orderKeys` is a `Column`.
 class Exchange : public Node {
  public:
   struct Key {

--- a/axiom/optimizer/v2/PhysicalProperties.h
+++ b/axiom/optimizer/v2/PhysicalProperties.h
@@ -82,8 +82,12 @@ AXIOM_DECLARE_ENUM_NAME(PartitionKind);
 ///   - `orderKeys` / `orderTypes` are non-empty only for an order-preserving
 ///     `kGather` (see `globalGatherMerge`).
 ///   - `partitionType` is null for standard Velox hash partitioning.
-///   - `keys` are expressions (not just columns) to match the partition
-///     function's input.
+///   - As a requirement a consumer states, `keys` and `orderKeys` may be any
+///     expression. On the `Partitioning` an `Exchange` carries they must be
+///     columns the exchange's input produces: whoever places the shuffle
+///     materializes an expression key first, so the value is computed once
+///     below the shuffle and read as a column above it (see
+///     `Builder::materializeKeys`).
 struct Partitioning {
   PartitionKind kind{PartitionKind::kUnspecified};
 

--- a/axiom/optimizer/v2/PlanPhysicalPass.cpp
+++ b/axiom/optimizer/v2/PlanPhysicalPass.cpp
@@ -651,9 +651,11 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
       return builder().make<Sort>(
           {input, node->orderKeys(), node->orderTypes()});
     }
+    auto [sortInput, orderKeys] =
+        builder().materializeKeys(input, node->orderKeys());
     NodeCP partialSort =
-        builder().make<Sort>({input, node->orderKeys(), node->orderTypes()});
-    return gatherMerge(partialSort, node->orderKeys(), node->orderTypes());
+        builder().make<Sort>({sortInput, orderKeys, node->orderTypes()});
+    return gatherMerge(partialSort, orderKeys, node->orderTypes());
   }
 
   // Distributes an EnforceSingleRow (scalar-subquery single-row assertion): it
@@ -725,14 +727,16 @@ class PhysicalPlanRewriter : public NodeRewriter<> {
            node->count()});
     }
 
+    auto [topNInput, orderKeys] =
+        builder().materializeKeys(newInput, node->orderKeys());
     NodeCP partial = builder().make<TopN>(
-        {newInput,
-         node->orderKeys(),
+        {topNInput,
+         orderKeys,
          node->orderTypes(),
          /*offset=*/0,
          node->offsetPlusCount()});
     return builder().make<Limit>(
-        {gatherMerge(partial, node->orderKeys(), node->orderTypes()),
+        {gatherMerge(partial, orderKeys, node->orderTypes()),
          node->offset(),
          node->count()});
   }

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.cpp
@@ -74,7 +74,7 @@ ColumnVector replacePrefix(
 class PrecomputeProjections {
  public:
   // When `projectAllInputs` is true (the default, for pass-through consumers
-  // like Window/Sort/Exchange), the project preserves every input column
+  // like Window/Sort/TopN), the project preserves every input column
   // alongside the lifted ones. When false (for narrowing consumers like
   // Aggregate/Unnest/Join), the project outputs only the columns passed to
   // `toColumn` — so an input column kept solely to feed a lifted expression is
@@ -329,8 +329,8 @@ void JoinFilterRewriter::keep(ColumnCP column) {
   }
 }
 
-// Lifts compound expressions at restricted positions of Aggregate /
-// Window / Sort / Unnest into a Project below the consumer.
+// Lifts compound expressions at restricted operator positions into a Project
+// below the consumer.
 class Rewriter : public NodeRewriter<> {
  public:
   using NodeRewriter::NodeRewriter;
@@ -344,6 +344,7 @@ class Rewriter : public NodeRewriter<> {
   NodeCP rewriteTopNRowNumber(const TopNRowNumber* topN, NoContext& context)
       override;
   NodeCP rewriteSort(const Sort* sort, NoContext& context) override;
+  NodeCP rewriteTopN(const TopN* topN, NoContext& context) override;
   NodeCP rewriteUnnest(const Unnest* unnest, NoContext& context) override;
   NodeCP rewriteJoin(const Join* join, NoContext& context) override;
   NodeCP rewriteUnionAll(const UnionAll* unionAll, NoContext& context) override;
@@ -550,6 +551,22 @@ NodeCP Rewriter::rewriteSort(const Sort* sort, NoContext& context) {
       {std::move(precompute).node(),
        std::move(newOrderKeys),
        sort->orderTypes()});
+}
+
+NodeCP Rewriter::rewriteTopN(const TopN* topN, NoContext& context) {
+  NodeCP newInput = rewrite(topN->input(), context);
+  PrecomputeProjections precompute{newInput, builder()};
+  ExprVector newOrderKeys;
+  newOrderKeys.reserve(topN->orderKeys().size());
+  for (ExprCP key : topN->orderKeys()) {
+    newOrderKeys.push_back(precompute.toColumn(key));
+  }
+  return builder().make<TopN>(
+      {std::move(precompute).node(),
+       std::move(newOrderKeys),
+       topN->orderTypes(),
+       topN->offset(),
+       topN->count()});
 }
 
 NodeCP Rewriter::rewriteJoin(const Join* join, NoContext& context) {

--- a/axiom/optimizer/v2/PrecomputeProjectionsPass.h
+++ b/axiom/optimizer/v2/PrecomputeProjectionsPass.h
@@ -31,13 +31,17 @@ class PrecomputeProjectionsPass {
   /// Most positions are moved because Velox demands a `FieldAccessTypedExpr`
   /// (or, where allowed, a constant) there:
   ///   - Aggregate: grouping keys, aggregate args, FILTER mask, ORDER BY keys
-  ///   - Window:    partition keys, order keys, function args
-  ///   - Sort:      order keys
-  ///   - Unnest:    unnest expressions
-  ///   - Join:      join keys
+  ///   - Window: partition keys, order keys, function args, frame bounds
+  ///   - Sort, TopN: order keys
+  ///   - RowNumber: partition keys
+  ///   - TopNRowNumber: partition keys, order keys
+  ///   - Unnest: unnest expressions
+  ///   - Join: join keys
   ///
-  /// A join filter is the one exception: Velox accepts any expression there,
-  /// so the move is an optimization rather than a requirement.
+  /// A join filter is one exception: Velox accepts any expression there, so
+  /// the move is an optimization rather than a requirement. A `UnionAll` is
+  /// another: its legs are aligned to the union's output columns because
+  /// Velox's `LocalPartition` requires one shared output `RowType`.
   ///
   /// A join with no equi keys evaluates its filter once for every pair of
   /// input rows. A subexpression of the filter that reads only one side has

--- a/axiom/sql/presto/ExpressionPlanner.cpp
+++ b/axiom/sql/presto/ExpressionPlanner.cpp
@@ -779,6 +779,36 @@ TypePtr ExpressionPlanner::resolveType(const TypeSignaturePtr& type) {
   return veloxType;
 }
 
+namespace {
+
+// `= ANY` and `= SOME` mean IN, and `<> ALL` means NOT IN, with the same null
+// and empty-subquery semantics. Fails for the other combinations.
+bool lowersToNotIn(const QuantifiedComparisonExpression& comparison) {
+  using Operator = ComparisonExpression::Operator;
+  using Quantifier = QuantifiedComparisonExpression::Quantifier;
+
+  const auto op = comparison.op();
+  const auto quantifier = comparison.quantifier();
+
+  if (op == Operator::kEqual &&
+      (quantifier == Quantifier::kAny || quantifier == Quantifier::kSome)) {
+    return false;
+  }
+
+  if (op == Operator::kNotEqual && quantifier == Quantifier::kAll) {
+    return true;
+  }
+
+  AXIOM_PRESTO_SYNTAX_FAIL(
+      comparison.location(),
+      std::string{toSqlString(quantifier)},
+      "Quantified comparison is not supported: {} {}",
+      toSqlString(op),
+      toSqlString(quantifier));
+}
+
+} // namespace
+
 lp::ExprApi ExpressionPlanner::toExpr(
     const ExpressionPtr& node,
     ExprOptions options) {
@@ -952,6 +982,16 @@ lp::ExprApi ExpressionPlanner::toExpr(
       auto* exists = node->as<ExistsPredicate>();
       return lp::Exists(planSubquery(
           exists->subquery()->as<SubqueryExpression>(), /*scalar=*/false));
+    }
+
+    case NodeType::kQuantifiedComparisonExpression: {
+      auto* comparison = node->as<QuantifiedComparisonExpression>();
+      const bool negated = lowersToNotIn(*comparison);
+      auto in = lp::Call(
+          "in",
+          toExpr(comparison->value(), options),
+          toExpr(comparison->subquery(), options));
+      return negated ? lp::Call("not", in) : in;
     }
 
     case NodeType::kCast: {

--- a/axiom/sql/presto/ast/AstBuilder.cpp
+++ b/axiom/sql/presto/ast/AstBuilder.cpp
@@ -1869,6 +1869,13 @@ std::any AstBuilder::visitLogicalBinary(
 
 namespace {
 
+// Returns the token type of a single-terminal rule context's only child.
+size_t terminalTokenType(antlr4::tree::ParseTree* node) {
+  return dynamic_cast<antlr4::tree::TerminalNode*>(node)
+      ->getSymbol()
+      ->getType();
+}
+
 ComparisonExpression::Operator toComparisonOperator(size_t tokenType) {
   switch (tokenType) {
     case PrestoSqlParser::EQ:
@@ -1896,19 +1903,49 @@ std::any AstBuilder::visitComparison(PrestoSqlParser::ComparisonContext* ctx) {
   auto leftExpr = visitExpression(ctx->value);
   auto rightExpr = visitExpression(ctx->right);
 
-  auto operatorToken = ctx->comparisonOperator()->children[0];
-  auto terminalNode = dynamic_cast<antlr4::tree::TerminalNode*>(operatorToken);
-  auto op = toComparisonOperator(terminalNode->getSymbol()->getType());
+  auto op = toComparisonOperator(
+      terminalTokenType(ctx->comparisonOperator()->children[0]));
 
   return std::static_pointer_cast<Expression>(
       std::make_shared<ComparisonExpression>(
           getLocation(ctx), op, leftExpr, rightExpr));
 }
 
+namespace {
+
+QuantifiedComparisonExpression::Quantifier toQuantifier(size_t tokenType) {
+  switch (tokenType) {
+    case PrestoSqlParser::ALL:
+      return QuantifiedComparisonExpression::Quantifier::kAll;
+    case PrestoSqlParser::ANY:
+      return QuantifiedComparisonExpression::Quantifier::kAny;
+    case PrestoSqlParser::SOME:
+      return QuantifiedComparisonExpression::Quantifier::kSome;
+    default:
+      VELOX_UNREACHABLE(
+          "Unexpected comparison quantifier token: {}", tokenType);
+  }
+}
+
+} // namespace
+
 std::any AstBuilder::visitQuantifiedComparison(
     PrestoSqlParser::QuantifiedComparisonContext* ctx) {
   trace("visitQuantifiedComparison");
-  return visitChildren("visitQuantifiedComparison", ctx);
+
+  auto op = toComparisonOperator(
+      terminalTokenType(ctx->comparisonOperator()->children[0]));
+  auto quantifier =
+      toQuantifier(terminalTokenType(ctx->comparisonQuantifier()->children[0]));
+
+  return std::static_pointer_cast<Expression>(
+      std::make_shared<QuantifiedComparisonExpression>(
+          getLocation(ctx),
+          op,
+          quantifier,
+          visitExpression(ctx->value),
+          std::make_shared<SubqueryExpression>(
+              getLocation(ctx), visitTyped<Statement>(ctx->query()))));
 }
 
 namespace {

--- a/axiom/sql/presto/ast/AstExpressions.h
+++ b/axiom/sql/presto/ast/AstExpressions.h
@@ -356,6 +356,9 @@ class ComparisonExpression : public Expression {
   ExpressionPtr right_;
 };
 
+/// Returns the SQL spelling of 'op', e.g. "<=".
+std::string_view toSqlString(ComparisonExpression::Operator op);
+
 class BetweenPredicate : public Expression {
  public:
   BetweenPredicate(
@@ -638,6 +641,10 @@ class QuantifiedComparisonExpression : public Expression {
   ExpressionPtr value_;
   ExpressionPtr subquery_;
 };
+
+/// Returns the SQL spelling of 'quantifier', e.g. "ANY".
+std::string_view toSqlString(
+    QuantifiedComparisonExpression::Quantifier quantifier);
 
 // Logical Expressions
 

--- a/axiom/sql/presto/ast/AstNodesAll.cpp
+++ b/axiom/sql/presto/ast/AstNodesAll.cpp
@@ -248,6 +248,39 @@ const auto& nodeTypeNames() {
 
 AXIOM_DEFINE_ENUM_NAME(NodeType, nodeTypeNames);
 
+std::string_view toSqlString(ComparisonExpression::Operator op) {
+  switch (op) {
+    case ComparisonExpression::Operator::kEqual:
+      return "=";
+    case ComparisonExpression::Operator::kNotEqual:
+      return "!=";
+    case ComparisonExpression::Operator::kLessThan:
+      return "<";
+    case ComparisonExpression::Operator::kLessThanOrEqual:
+      return "<=";
+    case ComparisonExpression::Operator::kGreaterThan:
+      return ">";
+    case ComparisonExpression::Operator::kGreaterThanOrEqual:
+      return ">=";
+    case ComparisonExpression::Operator::kIsDistinctFrom:
+      return "IS DISTINCT FROM";
+  }
+  VELOX_UNREACHABLE("Unsupported comparison operator");
+}
+
+std::string_view toSqlString(
+    QuantifiedComparisonExpression::Quantifier quantifier) {
+  switch (quantifier) {
+    case QuantifiedComparisonExpression::Quantifier::kAll:
+      return "ALL";
+    case QuantifiedComparisonExpression::Quantifier::kAny:
+      return "ANY";
+    case QuantifiedComparisonExpression::Quantifier::kSome:
+      return "SOME";
+  }
+  VELOX_UNREACHABLE("Unsupported comparison quantifier");
+}
+
 // Literal implementations
 void BooleanLiteral::accept(AstVisitor* visitor) {
   visitor->visitBooleanLiteral(this);

--- a/axiom/sql/presto/ast/AstPrinter.cpp
+++ b/axiom/sql/presto/ast/AstPrinter.cpp
@@ -98,27 +98,6 @@ std::string toString(ArithmeticBinaryExpression::Operator op) {
   VELOX_FAIL("Unsupported arithmetic operator");
 }
 
-std::string toString(ComparisonExpression::Operator op) {
-  switch (op) {
-    case ComparisonExpression::Operator::kEqual:
-      return "=";
-    case ComparisonExpression::Operator::kNotEqual:
-      return "!=";
-    case ComparisonExpression::Operator::kLessThan:
-      return "<";
-    case ComparisonExpression::Operator::kLessThanOrEqual:
-      return "<=";
-    case ComparisonExpression::Operator::kGreaterThan:
-      return ">";
-    case ComparisonExpression::Operator::kGreaterThanOrEqual:
-      return ">=";
-    case ComparisonExpression::Operator::kIsDistinctFrom:
-      return "IS DISTINCT FROM";
-    default:
-      VELOX_FAIL("Unsupported comparison operator");
-  }
-}
-
 std::string toString(SortItem::Ordering ordering) {
   switch (ordering) {
     case SortItem::Ordering::kAscending:
@@ -414,7 +393,7 @@ void AstPrinter::visitJoinOn(JoinOn* node) {
 
 void AstPrinter::visitComparisonExpression(ComparisonExpression* node) {
   printHeader("Comparison", node, [&](std::ostream& out) {
-    out << toString(node->op());
+    out << toSqlString(node->op());
   });
 
   indent_++;
@@ -595,7 +574,9 @@ void AstPrinter::visitExistsPredicate(ExistsPredicate* node) {
 
 void AstPrinter::visitQuantifiedComparisonExpression(
     QuantifiedComparisonExpression* node) {
-  printHeader("QuantifiedComparison", node);
+  printHeader("QuantifiedComparison", node, [&](std::ostream& out) {
+    out << toSqlString(node->op()) << " " << toSqlString(node->quantifier());
+  });
 
   indent_++;
   printChild("Value", node->value());

--- a/axiom/sql/presto/tests/ExprMatcher.cpp
+++ b/axiom/sql/presto/tests/ExprMatcher.cpp
@@ -33,20 +33,12 @@ namespace {
     return false;                              \
   }
 
-bool isWildcard(const velox::core::ExprPtr& expr) {
+bool isWildcard(const velox::core::ExprPtr& expr, std::string_view name) {
   if (!expr->is(velox::core::IExpr::Kind::kCall)) {
     return false;
   }
   const auto* call = expr->as<velox::core::CallExpr>();
-  return call->name() == ExprMatcher::kWildcard && call->inputs().empty();
-}
-
-bool isExistsWildcard(const velox::core::ExprPtr& expr) {
-  if (!expr->is(velox::core::IExpr::Kind::kCall)) {
-    return false;
-  }
-  const auto* call = expr->as<velox::core::CallExpr>();
-  return call->name() == ExprMatcher::kExistsWildcard && call->inputs().empty();
+  return call->name() == name && call->inputs().empty();
 }
 
 // Forward declaration for mutual recursion.
@@ -407,11 +399,11 @@ bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
   VELOX_CHECK_NOT_NULL(actual);
   VELOX_CHECK_NOT_NULL(expected);
 
-  if (isWildcard(expected)) {
+  if (isWildcard(expected, ExprMatcher::kWildcard)) {
     return true;
   }
 
-  if (isExistsWildcard(expected)) {
+  if (isWildcard(expected, ExprMatcher::kExistsWildcard)) {
     if (actual->kind() != ExprKind::kSpecialForm) {
       ADD_FAILURE() << "Expected EXISTS (any_exists() wildcard), got "
                     << actual->kindName() << ".";
@@ -421,6 +413,15 @@ bool matchImpl(const ExprPtr& actual, const velox::core::ExprPtr& expected) {
     if (form != SpecialForm::kExists) {
       ADD_FAILURE() << "Expected EXISTS special form, got "
                     << SpecialFormName::toName(form) << ".";
+      return false;
+    }
+    return true;
+  }
+
+  if (isWildcard(expected, ExprMatcher::kSubqueryWildcard)) {
+    if (actual->kind() != ExprKind::kSubquery) {
+      ADD_FAILURE() << "Expected a subquery (any_subquery() wildcard), got "
+                    << actual->kindName() << ".";
       return false;
     }
     return true;

--- a/axiom/sql/presto/tests/ExprMatcher.h
+++ b/axiom/sql/presto/tests/ExprMatcher.h
@@ -36,6 +36,11 @@ class ExprMatcher {
   /// cannot be spelled in expected strings.
   static constexpr std::string_view kExistsWildcard = "any_exists";
 
+  /// Matches any actual subquery, for the same reason as `kExistsWildcard`.
+  /// Lets an expected string spell the shape around one, e.g.
+  /// `"in"(x, any_subquery())`.
+  static constexpr std::string_view kSubqueryWildcard = "any_subquery";
+
   /// Returns true if the trees match. On mismatch, sets gtest failures
   /// with SCOPED_TRACE context showing the path through the tree.
   static bool match(

--- a/axiom/sql/presto/tests/ExprMatcherTest.cpp
+++ b/axiom/sql/presto/tests/ExprMatcherTest.cpp
@@ -73,13 +73,23 @@ velox::core::ExprPtr existsWildcard() {
       std::nullopt);
 }
 
-ExprPtr exists() {
+velox::core::ExprPtr subqueryWildcard() {
+  return std::make_shared<velox::core::CallExpr>(
+      std::string{ExprMatcher::kSubqueryWildcard},
+      std::vector<velox::core::ExprPtr>{},
+      std::nullopt);
+}
+
+ExprPtr subquery() {
   auto subqueryPlan = std::make_shared<ValuesNode>(
       "values_0",
       ROW({"x"}, {BIGINT()}),
       ValuesNode::Variants{Variant::row({42LL})});
-  auto subquery = std::make_shared<SubqueryExpr>(subqueryPlan);
-  return specialForm(BOOLEAN(), SpecialForm::kExists, {subquery});
+  return std::make_shared<SubqueryExpr>(subqueryPlan);
+}
+
+ExprPtr exists() {
+  return specialForm(BOOLEAN(), SpecialForm::kExists, {subquery()});
 }
 
 class ExprMatcherTest : public testing::Test {
@@ -365,6 +375,27 @@ TEST_F(ExprMatcherTest, existsWildcardRejectsNonExists) {
   EXPECT_NONFATAL_FAILURE(
       ExprMatcher::match(coalesce, existsWildcard()),
       "Expected EXISTS special form, got COALESCE.");
+}
+
+TEST_F(ExprMatcherTest, subqueryWildcardMatchesSubquery) {
+  ExprMatcher::match(subquery(), subqueryWildcard());
+}
+
+TEST_F(ExprMatcherTest, subqueryWildcardMatchesNestedSubquery) {
+  auto in = specialForm(
+      BOOLEAN(), SpecialForm::kIn, {field(BIGINT(), "a"), subquery()});
+  ExprMatcher::match(
+      in,
+      std::make_shared<velox::core::CallExpr>(
+          "in",
+          std::vector<velox::core::ExprPtr>{parseExpr("a"), subqueryWildcard()},
+          std::nullopt));
+}
+
+TEST_F(ExprMatcherTest, subqueryWildcardRejectsNonSubquery) {
+  EXPECT_NONFATAL_FAILURE(
+      ExprMatcher::match(field(BOOLEAN(), "a"), subqueryWildcard()),
+      "Expected a subquery (any_subquery() wildcard)");
 }
 
 } // namespace

--- a/axiom/sql/presto/tests/ExpressionParserTest.cpp
+++ b/axiom/sql/presto/tests/ExpressionParserTest.cpp
@@ -712,36 +712,45 @@ TEST_F(ExpressionParserTest, in) {
       "n_nationkey in (1, 2, 3)",
       "IN(n_nationkey, CAST(1 AS BIGINT), CAST(2 AS BIGINT), CAST(3 AS BIGINT))");
 
-  auto assertInSubquery = [](const lp::ExprPtr& expr) {
-    ASSERT_EQ(lp::ExprKind::kSpecialForm, expr->kind());
-    auto& in = *expr->as<lp::SpecialFormExpr>();
-    ASSERT_EQ(in.form(), lp::SpecialForm::kIn);
-    ASSERT_EQ(in.inputs().size(), 2);
-    ASSERT_EQ(lp::ExprKind::kInputReference, in.inputAt(0)->kind());
-    ASSERT_EQ(lp::ExprKind::kSubquery, in.inputAt(1)->kind());
-  };
-
   // Subquery IN in WHERE clause produces a filter with IN(column, subquery).
   testSelect(
       "SELECT * FROM nation WHERE n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name like 'A%')",
-      matchScan()
-          .filter([&](const auto& node) {
-            auto filter = std::dynamic_pointer_cast<const lp::FilterNode>(node);
-            assertInSubquery(filter->predicate());
-          })
-          .output());
+      matchScan().filter(R"("in"(n_regionkey, any_subquery()))").output());
 
   // Subquery IN in SELECT clause produces a project with IN(column, subquery).
   testSelect(
       "SELECT n_regionkey IN (SELECT r_regionkey FROM region WHERE r_name like 'A%') FROM nation",
-      matchScan()
-          .project([&](const auto& node) {
-            auto project =
-                std::dynamic_pointer_cast<const lp::ProjectNode>(node);
-            ASSERT_EQ(project->expressions().size(), 1);
-            assertInSubquery(project->expressionAt(0));
-          })
-          .output());
+      matchScan().project({R"("in"(n_regionkey, any_subquery()))"}).output());
+}
+
+TEST_F(ExpressionParserTest, quantifiedComparison) {
+  // '= ANY' and '= SOME' mean IN; '<> ALL' means NOT IN.
+  testSelect(
+      "SELECT * FROM nation WHERE n_regionkey = ANY (SELECT r_regionkey FROM region)",
+      matchScan().filter(R"("in"(n_regionkey, any_subquery()))").output());
+  testSelect(
+      "SELECT * FROM nation WHERE n_regionkey = SOME (SELECT r_regionkey FROM region)",
+      matchScan().filter(R"("in"(n_regionkey, any_subquery()))").output());
+  testSelect(
+      "SELECT * FROM nation WHERE n_regionkey <> ALL (SELECT r_regionkey FROM region)",
+      matchScan().filter(R"(not("in"(n_regionkey, any_subquery())))").output());
+
+  // The remaining operator and quantifier combinations have no lowering.
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(
+          "SELECT * FROM nation "
+          "WHERE n_regionkey > ALL (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is not supported: > ALL");
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(
+          "SELECT * FROM nation "
+          "WHERE n_regionkey <= ANY (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is not supported: <= ANY");
+  AXIOM_EXPECT_PRESTO_SYNTAX_ERROR(
+      parseSelect(
+          "SELECT * FROM nation "
+          "WHERE n_regionkey = ALL (SELECT r_regionkey FROM region)"),
+      "Quantified comparison is not supported: = ALL");
 }
 
 TEST_F(ExpressionParserTest, notLike) {

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.cpp
@@ -215,9 +215,6 @@ class JoinMatcher : public LogicalPlanMatcherImpl<JoinNode> {
   const std::vector<std::string> outputAliases_;
 };
 
-// Matches a FilterNode with the specified expression. The expected expression
-// is parsed with DuckDB and printed in a format compatible with
-// lp::ExprPrinter, then compared against the filter expression's toString().
 class FilterMatcher : public LogicalPlanMatcherImpl<FilterNode> {
  public:
   FilterMatcher(
@@ -323,7 +320,6 @@ class LimitMatcher : public LogicalPlanMatcherImpl<LimitNode> {
 // - String constructor: parses with DuckDB, corrects window frame defaults.
 // - ExprApi constructor: uses the expression directly, applies SQL standard
 //   default frame when none is specified.
-// Both paths compare against expressionAt(i)->toString().
 class ProjectMatcher : public LogicalPlanMatcherImpl<ProjectNode> {
  public:
   ProjectMatcher(

--- a/axiom/sql/presto/tests/LogicalPlanMatcher.h
+++ b/axiom/sql/presto/tests/LogicalPlanMatcher.h
@@ -138,16 +138,17 @@ class LogicalPlanMatcherBuilder {
   LogicalPlanMatcherBuilder& filter(OnMatchCallback onMatch = nullptr);
 
   /// Matches a FilterNode with the specified expression. The expected
-  /// expression is parsed with DuckDB and compared against the filter
-  /// expression's toString(). Supports symbol rewriting.
+  /// expression is parsed with DuckDB and matched structurally against the
+  /// filter expression, so `ExprMatcher` wildcards apply. Supports symbol
+  /// rewriting.
   LogicalPlanMatcherBuilder& filter(const std::string& expression);
 
   /// Matches a ProjectNode.
   LogicalPlanMatcherBuilder& project(OnMatchCallback onMatch = nullptr);
 
   /// Matches a ProjectNode with the specified expressions. Each expected
-  /// expression is parsed with DuckDB and printed in a format compatible with
-  /// lp::ExprPrinter, then compared against expressionAt(i)->toString().
+  /// expression is parsed with DuckDB and matched structurally against
+  /// expressionAt(i), so `ExprMatcher` wildcards apply.
   LogicalPlanMatcherBuilder& project(
       const std::vector<std::string>& expressions);
 


### PR DESCRIPTION
Summary:

A quantified comparison against a subquery failed with an internal error:

    SELECT * FROM nation WHERE n_regionkey = ANY (SELECT r_regionkey FROM region)

reported `visitChildren called with more than one child: 5 (visitQuantifiedComparison)`, because the parser's handler for these was a stub that fell through to a helper valid only for single-child grammar rules.

`= ANY` and `= SOME` mean IN, and `<> ALL` means NOT IN, agreeing with IN on nulls and on an empty subquery. The parser now builds the `QuantifiedComparisonExpression` the AST already defined but nothing produced, and the planner lowers it to the existing `in` and `not(in)` — no optimizer change.

The other operator and quantifier combinations compare against the subquery's extremes. They have no lowering and now report `Quantified comparison is not supported: > ALL` as a user error rather than an internal one.

Reviewed By: amitkdutta

Differential Revision: D115809730
